### PR TITLE
ArxivToolkit needs pypdf

### DIFF
--- a/chat_with_arxiv/requirements.txt
+++ b/chat_with_arxiv/requirements.txt
@@ -2,3 +2,4 @@ streamlit
 phidata
 arxiv
 openai
+pypdf


### PR DESCRIPTION
ImportError: `pypdf` not installed. Please install using `pip install pypdf`

The traceback:

```
Traceback:

File "/tmp/awesome-llm-apps/chat_with_arxiv/aaaa/lib/python3.12/site-packages/streamlit/runtime/scriptrunner/script_runner.py", line 600, in _run_script
    exec(code, module.__dict__)
File "/tmp/awesome-llm-apps/chat_with_arxiv/chat_arxiv.py", line 5, in <module>
    from phi.tools.arxiv_toolkit import ArxivToolkit
File "/tmp/awesome-llm-apps/chat_with_arxiv/aaaa/lib/python3.12/site-packages/phi/tools/arxiv_toolkit.py", line 16, in <module>
    raise ImportError("`pypdf` not installed. Please install using `pip install pypdf`")
```

