### PR TITLE
Add missing requirements of local RAG

### DIFF
--- a/rag_tutorials/local_rag_agent/requirements.txt
+++ b/rag_tutorials/local_rag_agent/requirements.txt
@@ -3,3 +3,5 @@ qdrant-client
 ollama
 pypdf 
 openai
+fastapi
+uvicorn


### PR DESCRIPTION
The current list of requirements is missing two packages. 
This causes issues when the installation happens in a fresh environment (venv).

Added: 
 - fastapi
 - uvicorn