### PR TITLE
add missing frameworks

### DIFF
--- a/ai_agent_tutorials/ai_legal_agent_team/requirements.txt
+++ b/ai_agent_tutorials/ai_legal_agent_team/requirements.txt
@@ -1,5 +1,6 @@
 phidata==2.5.33       
 streamlit==1.40.2     
 qdrant-client==1.12.1         
-openai                 
-               
+openai
+pypdf
+duckduckgo-search


### PR DESCRIPTION
- it automatically throws the error for `duckduckgo-search` that it's not installed
- but when it comes to `pypdf` it's not showing a related error: only showing an error while processing documents