### PR TITLE
Update llama3.1_local_rag.py

### DIFF
--- a/rag_tutorials/llama3.1_local_rag/requirements.txt
+++ b/rag_tutorials/llama3.1_local_rag/requirements.txt
@@ -2,3 +2,4 @@ streamlit
 ollama 
 langchain 
 langchain_community
+langchain_ollama


### PR DESCRIPTION
Fixes The class `OllamaEmbeddings` was deprecated in LangChain 0.3.1 and will be removed in 1.0.0. An updated version of the class exists in the :class:`~langchain-ollama package and should be used instead.