### PR TITLE
Add `nest_asyncio` to requirements.txt

### DIFF
--- a/rag_tutorials/autonomous_rag/requirements.txt
+++ b/rag_tutorials/autonomous_rag/requirements.txt
@@ -7,3 +7,4 @@ requests
 sqlalchemy
 pypdf
 duckduckgo-search
+nest_asyncio


### PR DESCRIPTION
This PR adds `nest_asyncio` to the requirements.txt file to resolve the `ModuleNotFoundError: No module named 'nest_asyncio'` error.