### PR TITLE
Fix: Correct environment variable name for ElevenLabs API

### DIFF
--- a/starter_ai_agents/ai_blog_to_podcast_agent/blog_to_podcast_agent.py
+++ b/starter_ai_agents/ai_blog_to_podcast_agent/blog_to_podcast_agent.py
@@ -38,7 +38,7 @@ if generate_button:
     else:
         # Set API keys as environment variables for Agno and Tools
         os.environ["OPENAI_API_KEY"] = openai_api_key
-        os.environ["ELEVENLABS_API_KEY"] = elevenlabs_api_key
+        os.environ["ELEVEN_LABS_API_KEY"] = elevenlabs_api_key
         os.environ["FIRECRAWL_API_KEY"] = firecrawl_api_key
 
         with st.spinner("Processing... Scraping blog, summarizing and generating podcast 🎶"):


### PR DESCRIPTION
I corrected the environment variable name from:

`os.environ["ELEVENLABS_API_KEY"]`

to:

`os.environ["ELEVEN_LABS_API_KEY"]`

The previous name was incorrect and caused a 401 Unauthorized error when calling the ElevenLabs API. The correct variable name follows ElevenLabs' documentation and ensures proper authentication.

Additionally: 
If you'd like to make the code more robust, you could replace the direct os.environ access with this:

```
api_key = os.getenv("ELEVEN_LABS_API_KEY")
if not api_key:
    raise ValueError("Missing ELEVEN_LABS_API_KEY in environment variables")
```
This makes the code safer by:

1. Catching missing or unset environment variables early

2. Providing a clear error message to the developer

3. Preventing hard-to-debug authentication errors later in the flow

Happy to help!