### PR TITLE
fix starter_ai_agents/ai_data_analysis_agent some issues

### DIFF
--- a/starter_ai_agents/ai_data_analysis_agent/ai_data_analyst.py
+++ b/starter_ai_agents/ai_data_analysis_agent/ai_data_analyst.py
@@ -3,9 +3,9 @@ import tempfile
 import csv
 import streamlit as st
 import pandas as pd
-from agno.models.openai import OpenAIChat
+from phi.model.openai import OpenAIChat
 from phi.agent.duckdb import DuckDbAgent
-from agno.tools.pandas import PandasTools
+from phi.tools.pandas import PandasTools
 import re
 
 # Function to preprocess and save the uploaded file
@@ -87,7 +87,7 @@ if uploaded_file is not None and "openai_key" in st.session_state:
         
         # Initialize the DuckDbAgent for SQL query generation
         duckdb_agent = DuckDbAgent(
-            model=OpenAIChat(model="gpt-4", api_key=st.session_state.openai_key),
+            model=OpenAIChat(id="gpt-4o-mini", api_key=st.session_state.openai_key),
             semantic_model=json.dumps(semantic_model),
             tools=[PandasTools()],
             markdown=True,


### PR DESCRIPTION
1. OpenAIChat 和 PandasTools使用agno 框架会和phi.agent.duckdb import DuckDbAgent 的类不兼容，DuckDbAgent 继承pydantic下的 BaseModel，OpenAIChat 和 PandasTools并没有，运行会出现报错
2. OpenAIChat下没有 model 参数，model是使用 id 参数代替的