### PR TITLE
Add VeritasGraph link to RAG section in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ A curated collection of **Awesome LLM apps built with RAG, AI Agents, Multi-agen
 *   [🌍 AI Travel Planner MCP Agent](mcp_ai_agents/ai_travel_planner_mcp_agent_team)
 
 ### 📀 RAG (Retrieval Augmented Generation)
+*   [🕸️ [VeritasGraph](https://github.com/bibinprathap/VeritasGraph) - A Knowledge Graph-based RAG framework for verifiable and accurate LLM responses.
 *   [🔥 Agentic RAG with Embedding Gemma](rag_tutorials/agentic_rag_embedding_gemma)
 *   [🧐 Agentic RAG with Reasoning](rag_tutorials/agentic_rag_with_reasoning/)
 *   [📰 AI Blog Search (RAG)](rag_tutorials/ai_blog_search/)


### PR DESCRIPTION
Added a link to VeritasGraph, a knowledge graph-based RAG framework.