### PR TITLE
Add Jarvis AI Assistant - Free Open Source Voice Dictation App

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ A curated collection of **Awesome LLM apps built with RAG, AI Agents, Multi-agen
 *   [🗣️ AI Audio Tour Agent](voice_ai_agents/ai_audio_tour_agent/)
 *   [📞 Customer Support Voice Agent](voice_ai_agents/customer_support_voice_agent/)
 *   [🔊 Voice RAG Agent (OpenAI SDK)](voice_ai_agents/voice_rag_openaisdk/)
-*   [🎙️ OpenSource Voice Dictation App (like Wispr Flow](https://github.com/akshayaggarwal99/jarvis-ai-assistant)
+*   [🎙️ OpenSource Voice Dictation Agent (like Wispr Flow](https://github.com/akshayaggarwal99/jarvis-ai-assistant)
 
 ### <img src="https://cdn.simpleicons.org/modelcontextprotocol"  alt="mcp logo" width="25" height="20"> MCP AI Agents 
 


### PR DESCRIPTION
## What is Jarvis?

Jarvis is a **free, open-source voice dictation app** for Mac that serves as a local and privacy-focused alternative to subscription-based apps like Wispr Flow ($10-24/month), SuperWhisper, and others.

### Key Features:
- 🆓 **100% Free Forever** - No subscriptions, no paywalls
- 🔇 **Fully Offline** - Local Whisper transcription (tiny/base/small models)
- 🦙 **Local LLM Support** - Works with Ollama for complete privacy
- ☁️ **Optional Cloud Mode** - Deepgram + Gemini for speed (free tiers available)
- 🔓 **MIT Licensed** - Fully open source
- 📡 **Zero Telemetry** - No tracking, no data collection

### Why this matters:
While competitors have raised $80M+ in VC funding to build paid voice dictation tools, Jarvis proves that a single developer can build a powerful, privacy-respecting alternative and give it away for free.

**Tech Stack:** Electron, TypeScript, React, Local Whisper, Ollama

**Repo:** https://github.com/akshayaggarwal99/jarvis-ai-assistant
**Website:** https://jarvis.ceo