### PR TITLE
Fix typo in instructions for xAI Finance Agent

### DIFF
--- a/starter_ai_agents/xai_finance_agent/xai_finance_agent.py
+++ b/starter_ai_agents/xai_finance_agent/xai_finance_agent.py
@@ -10,7 +10,7 @@ agent = Agent(
     name="xAI Finance Agent",
     model = xAI(id="grok-4-1-fast"),
     tools=[DuckDuckGoTools(), YFinanceTools()],
-    instructions = ["Always use tables to display financial/numerical data. For text data use bullet points and small paragrpahs."],
+    instructions = ["Always use tables to display financial/numerical data. For text data use bullet points and small paragraphs."],
     debug_mode = True,
     markdown = True,
     )


### PR DESCRIPTION
Update agent instructions to say "paragraphs" instead of "paragrpahs".