### PR TITLE
Fix typo in design agent team README

### DIFF
--- a/advanced_ai_agents/multi_agent_apps/agent_teams/multimodal_design_agent_team/README.md
+++ b/advanced_ai_agents/multi_agent_apps/agent_teams/multimodal_design_agent_team/README.md
@@ -9,7 +9,7 @@ This application leverages multiple specialized AI agents to provide comprehensi
 
 ## Features
 
-- **Specialized Legal AI Agent Team**
+- **Specialized Design AI Agent Team**
 
    - 🎨 **Visual Design Agent**: Evaluates design elements, patterns, color schemes, typography, and visual hierarchy
    - 🔄 **UX Analysis Agent**: Assesses user flows, interaction patterns, usability, and accessibility


### PR DESCRIPTION
Updated the README to replace 'Legal AI Agent Team' with 'Design AI Agent Team'.