### PR TITLE
fix(client): add env config and fix undefined BASE_URL error Fixes #410

### DIFF
--- a/advanced_ai_agents/multi_agent_apps/agent_teams/ai_travel_planner_agent_team/client/.env.example
+++ b/advanced_ai_agents/multi_agent_apps/agent_teams/ai_travel_planner_agent_team/client/.env.example
@@ -1,0 +1,2 @@
+NEXT_PUBLIC_BASE_URL=http://localhost:3000
+DATABASE_URL=postgresql://postgres:postgres@localhost:5432/tripcraft_ai

--- a/advanced_ai_agents/multi_agent_apps/agent_teams/ai_travel_planner_agent_team/client/.gitignore
+++ b/advanced_ai_agents/multi_agent_apps/agent_teams/ai_travel_planner_agent_team/client/.gitignore
@@ -1,0 +1,11 @@
+node_modules
+.next
+.env*.local
+lib/generated/
+*.log
+.DS_Store
+*.pem
+.vscode
+.idea
+.vercel
+*.tsbuildinfo

--- a/advanced_ai_agents/multi_agent_apps/agent_teams/ai_travel_planner_agent_team/client/README.md
+++ b/advanced_ai_agents/multi_agent_apps/agent_teams/ai_travel_planner_agent_team/client/README.md
@@ -1,5 +1,25 @@
 This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-app`](https://nextjs.org/docs/app/api-reference/cli/create-next-app).
 
+## Setup
+
+1. **Install dependencies:**
+   ```bash
+   pnpm install
+   ```
+
+2. **Configure environment:**
+   ```bash
+   cp .env.example .env.local
+   ```
+   
+   Update `.env.local` with your database credentials if needed.
+
+3. **Setup database:**
+   ```bash
+   pnpm prisma generate
+   pnpm prisma db push
+   ```
+
 ## Getting Started
 
 First, run the development server:

--- a/advanced_ai_agents/multi_agent_apps/agent_teams/ai_travel_planner_agent_team/client/middleware.ts
+++ b/advanced_ai_agents/multi_agent_apps/agent_teams/ai_travel_planner_agent_team/client/middleware.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 
-const BASE_URL = process.env.NEXT_PUBLIC_BASE_URL
+const BASE_URL = process.env.NEXT_PUBLIC_BASE_URL || "http://localhost:3000"
 
 export async function middleware(request: NextRequest) {
 


### PR DESCRIPTION
Fixes #410 - TypeError: Failed to parse URL from undefined/api/auth/get-session

- Add .gitignore to exclude .env.local
- Add .env.example template
- Add fallback for NEXT_PUBLIC_BASE_URL in middleware
- Add setup instructions to README