### PR TITLE
Add AI Agent Discovery Agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ A curated collection of **Awesome LLM apps built with RAG, AI Agents, Multi-agen
 *   [📊 xAI Finance Agent](starter_ai_agents/xai_finance_agent/)
 *   [🔍 OpenAI Research Agent](starter_ai_agents/opeani_research_agent/)
 *   [🕸️ Web Scraping AI Agent (Local & Cloud SDK)](starter_ai_agents/web_scrapping_ai_agent/)
+*   [🔍 AI Agent Discovery (Local & Cloud)](starter_ai_agents/ai_agent_discovery_agent/)
 
 ### 🚀 Advanced AI Agents
 *   [🏚️ 🍌 AI Home Renovation Agent with Nano Banana Pro](advanced_ai_agents/multi_agent_apps/ai_home_renovation_agent)

--- a/starter_ai_agents/ai_agent_discovery_agent/README.MD
+++ b/starter_ai_agents/ai_agent_discovery_agent/README.MD
@@ -1,0 +1,66 @@
+## 🔍 AI Agent Discovery
+
+This Streamlit app is an AI-powered agent discovery tool that helps you find and compare AI agents across multiple registries. It uses the Registry Broker API to search NANDA, MCP, Virtuals, A2A, and ERC-8004 agents in one place.
+
+### Features
+- Search AI agents across 5+ registries with a single query
+- Get AI-powered recommendations using GPT-4o or local Llama
+- View detailed agent information including capabilities and endpoints
+- Browse available categories and registries
+- Works with both cloud (OpenAI) and local (Ollama) LLMs
+
+### Supported Registries
+- **NANDA** - MIT's Network for AI Networked Digital Agents
+- **MCP** - Model Context Protocol servers
+- **Virtuals** - Virtuals Protocol on-chain agents
+- **A2A** - Google's Agent-to-Agent protocol
+- **ERC-8004** - Ethereum standard for on-chain agents
+
+### How to get Started?
+
+1. Clone the GitHub repository
+
+```bash
+git clone https://github.com/Shubhamsaboo/awesome-llm-apps.git
+cd awesome-llm-apps/starter_ai_agents/ai_agent_discovery_agent
+```
+
+2. Install the required dependencies:
+
+```bash
+pip install -r requirements.txt
+```
+
+3. Get your OpenAI API Key (for cloud version)
+
+- Sign up for an [OpenAI account](https://platform.openai.com/) and obtain your API key.
+
+4. Run the Streamlit App
+
+```bash
+streamlit run agent_discovery.py
+```
+
+For local LLM usage (with Ollama):
+```bash
+ollama pull llama3.2
+streamlit run local_agent_discovery.py
+```
+
+### How it Works?
+
+The AI Agent Discovery app has two main components:
+- **Registry Search:** Queries the Registry Broker API to find agents matching your search across multiple registries (NANDA, MCP, Virtuals, A2A, ERC-8004).
+- **AI Analysis:** Uses GPT-4o (cloud) or Llama (local) to analyze the search results and provide intelligent recommendations based on your use case.
+
+### Local vs Cloud Version
+
+- **agent_discovery.py**: Uses OpenAI's GPT-4o for high-quality agent recommendations (requires OpenAI API key)
+- **local_agent_discovery.py**: Uses Ollama for local LLM inference without sending data to external APIs (requires Ollama to be installed and running)
+
+### API Reference
+
+This app uses the [Registry Broker API](https://hol.org/registry/docs):
+- `GET /api/v1/search` - Search agents across all registries
+- `GET /api/v1/agents/{uaid}` - Get agent details
+- `GET /api/v1/search/facets` - Get available categories and registries

--- a/starter_ai_agents/ai_agent_discovery_agent/agent_discovery.py
+++ b/starter_ai_agents/ai_agent_discovery_agent/agent_discovery.py
@@ -1,0 +1,179 @@
+"""
+AI Agent Discovery - Find and compare AI agents across multiple registries.
+Uses Streamlit UI with OpenAI GPT-4o for intelligent agent recommendations.
+"""
+
+import os
+import streamlit as st
+import httpx
+from openai import OpenAI
+
+REGISTRY_BROKER_BASE = "https://hol.org/registry/api/v1"
+
+
+def search_agents(query: str, limit: int = 20) -> dict:
+    """Search for AI agents across multiple registries."""
+    with httpx.Client(timeout=30.0) as client:
+        response = client.get(
+            f"{REGISTRY_BROKER_BASE}/search", params={"q": query, "limit": limit}
+        )
+        response.raise_for_status()
+        return response.json()
+
+
+def get_agent_details(uaid: str) -> dict:
+    """Get detailed information about a specific agent."""
+    with httpx.Client(timeout=30.0) as client:
+        response = client.get(f"{REGISTRY_BROKER_BASE}/agents/{uaid}")
+        response.raise_for_status()
+        return response.json()
+
+
+def get_search_facets() -> dict:
+    """Get available search facets (categories, registries)."""
+    with httpx.Client(timeout=30.0) as client:
+        response = client.get(f"{REGISTRY_BROKER_BASE}/search/facets")
+        response.raise_for_status()
+        return response.json()
+
+
+def analyze_agents_with_llm(client: OpenAI, query: str, agents: list) -> str:
+    """Use GPT-4o to analyze and recommend agents based on user query."""
+    if not agents:
+        return "No agents found matching your query."
+
+    agents_info = []
+    for agent in agents[:10]:
+        info = f"- {agent.get('name', 'Unknown')} ({agent.get('registry', 'Unknown')}): {agent.get('description', 'No description')[:200]}"
+        agents_info.append(info)
+
+    agents_text = "\n".join(agents_info)
+
+    response = client.chat.completions.create(
+        model="gpt-4o",
+        messages=[
+            {
+                "role": "system",
+                "content": """You are an AI agent discovery assistant. Analyze the available agents and provide recommendations based on the user's needs. Be concise and helpful. Explain which agents would be best for the user's use case and why.""",
+            },
+            {
+                "role": "user",
+                "content": f"User query: {query}\n\nAvailable agents:\n{agents_text}\n\nProvide recommendations for the best agents to use based on this query.",
+            },
+        ],
+        temperature=0.7,
+        max_tokens=1000,
+    )
+
+    return response.choices[0].message.content
+
+
+def main():
+    st.set_page_config(page_title="AI Agent Discovery", page_icon="🔍", layout="wide")
+
+    st.title("🔍 AI Agent Discovery")
+    st.markdown(
+        "Find and compare AI agents across **NANDA**, **MCP**, **Virtuals**, **A2A**, and **ERC-8004** registries."
+    )
+
+    # Sidebar for API key
+    with st.sidebar:
+        st.header("Configuration")
+        openai_api_key = st.text_input("OpenAI API Key", type="password")
+        st.markdown("Get your API key from [OpenAI](https://platform.openai.com/)")
+
+        st.divider()
+        st.markdown("### About")
+        st.markdown("""
+        This app searches the [Registry Broker](https://hol.org/registry/docs) - 
+        a universal index of AI agents across multiple registries:
+        
+        - **NANDA** - MIT's agent network
+        - **MCP** - Model Context Protocol servers
+        - **Virtuals** - On-chain AI agents
+        - **A2A** - Agent-to-Agent protocol
+        - **ERC-8004** - Ethereum agent standard
+        """)
+
+    # Main search interface
+    col1, col2 = st.columns([3, 1])
+
+    with col1:
+        search_query = st.text_input(
+            "Search for AI agents",
+            placeholder="e.g., code review, data analysis, trading bot, database...",
+        )
+
+    with col2:
+        num_results = st.selectbox("Results", [10, 20, 50], index=1)
+
+    if st.button("🔍 Search Agents", type="primary"):
+        if not search_query:
+            st.warning("Please enter a search query.")
+            return
+
+        with st.spinner("Searching across registries..."):
+            try:
+                results = search_agents(search_query, limit=num_results)
+                agents = results.get("agents", [])
+
+                if not agents:
+                    st.info("No agents found. Try a different search term.")
+                    return
+
+                st.success(f"Found {len(agents)} agents matching '{search_query}'")
+
+                # Display results in tabs
+                tab1, tab2 = st.tabs(["📋 Agent List", "🤖 AI Recommendations"])
+
+                with tab1:
+                    for agent in agents:
+                        with st.expander(
+                            f"**{agent.get('name', 'Unknown')}** - {agent.get('registry', 'Unknown')}"
+                        ):
+                            st.markdown(
+                                f"**Description:** {agent.get('description', 'No description')}"
+                            )
+                            st.markdown(f"**UAID:** `{agent.get('uaid', 'N/A')}`")
+                            if agent.get("capabilities"):
+                                st.markdown(
+                                    f"**Capabilities:** {', '.join(agent['capabilities'][:5])}"
+                                )
+                            if agent.get("url"):
+                                st.markdown(f"[View Agent]({agent['url']})")
+
+                with tab2:
+                    if openai_api_key:
+                        with st.spinner("Analyzing agents with GPT-4o..."):
+                            client = OpenAI(api_key=openai_api_key)
+                            analysis = analyze_agents_with_llm(
+                                client, search_query, agents
+                            )
+                            st.markdown(analysis)
+                    else:
+                        st.warning(
+                            "Enter your OpenAI API key in the sidebar to get AI-powered recommendations."
+                        )
+
+            except Exception as e:
+                st.error(f"Error searching agents: {str(e)}")
+
+    # Show available categories
+    with st.expander("📂 Browse Categories"):
+        try:
+            facets = get_search_facets()
+            if facets.get("registries"):
+                st.markdown("**Available Registries:**")
+                for registry in facets["registries"]:
+                    st.markdown(f"- {registry}")
+            if facets.get("categories"):
+                st.markdown("**Categories:**")
+                cols = st.columns(3)
+                for i, category in enumerate(facets["categories"][:15]):
+                    cols[i % 3].markdown(f"• {category}")
+        except Exception:
+            st.info("Could not load categories. Try searching directly.")
+
+
+if __name__ == "__main__":
+    main()

--- a/starter_ai_agents/ai_agent_discovery_agent/local_agent_discovery.py
+++ b/starter_ai_agents/ai_agent_discovery_agent/local_agent_discovery.py
@@ -1,0 +1,181 @@
+"""
+AI Agent Discovery (Local) - Find and compare AI agents using local Ollama LLM.
+No external API calls for LLM - all AI processing happens locally.
+"""
+
+import os
+import streamlit as st
+import httpx
+import ollama
+
+REGISTRY_BROKER_BASE = "https://hol.org/registry/api/v1"
+
+
+def search_agents(query: str, limit: int = 20) -> dict:
+    """Search for AI agents across multiple registries."""
+    with httpx.Client(timeout=30.0) as client:
+        response = client.get(
+            f"{REGISTRY_BROKER_BASE}/search", params={"q": query, "limit": limit}
+        )
+        response.raise_for_status()
+        return response.json()
+
+
+def get_agent_details(uaid: str) -> dict:
+    """Get detailed information about a specific agent."""
+    with httpx.Client(timeout=30.0) as client:
+        response = client.get(f"{REGISTRY_BROKER_BASE}/agents/{uaid}")
+        response.raise_for_status()
+        return response.json()
+
+
+def get_search_facets() -> dict:
+    """Get available search facets (categories, registries)."""
+    with httpx.Client(timeout=30.0) as client:
+        response = client.get(f"{REGISTRY_BROKER_BASE}/search/facets")
+        response.raise_for_status()
+        return response.json()
+
+
+def analyze_agents_with_local_llm(query: str, agents: list) -> str:
+    """Use local Ollama model to analyze and recommend agents."""
+    if not agents:
+        return "No agents found matching your query."
+
+    agents_info = []
+    for agent in agents[:10]:
+        info = f"- {agent.get('name', 'Unknown')} ({agent.get('registry', 'Unknown')}): {agent.get('description', 'No description')[:200]}"
+        agents_info.append(info)
+
+    agents_text = "\n".join(agents_info)
+
+    prompt = f"""You are an AI agent discovery assistant. Analyze the available agents and provide recommendations based on the user's needs.
+
+User query: {query}
+
+Available agents:
+{agents_text}
+
+Provide concise recommendations for the best agents to use based on this query. Explain why each recommended agent would be helpful."""
+
+    response = ollama.chat(
+        model="llama3.2", messages=[{"role": "user", "content": prompt}]
+    )
+
+    return response["message"]["content"]
+
+
+def main():
+    st.set_page_config(
+        page_title="AI Agent Discovery (Local)", page_icon="🔍", layout="wide"
+    )
+
+    st.title("🔍 AI Agent Discovery (Local)")
+    st.markdown(
+        "Find and compare AI agents using **local Ollama LLM** - no external API keys required!"
+    )
+
+    # Sidebar
+    with st.sidebar:
+        st.header("About")
+        st.markdown("""
+        This app searches the [Registry Broker](https://hol.org/registry/docs) - 
+        a universal index of AI agents across multiple registries:
+        
+        - **NANDA** - MIT's agent network
+        - **MCP** - Model Context Protocol servers
+        - **Virtuals** - On-chain AI agents
+        - **A2A** - Agent-to-Agent protocol
+        - **ERC-8004** - Ethereum agent standard
+        
+        ---
+        
+        **Requirements:**
+        - Ollama installed and running
+        - llama3.2 model pulled
+        
+        ```bash
+        ollama pull llama3.2
+        ```
+        """)
+
+    # Main search interface
+    col1, col2 = st.columns([3, 1])
+
+    with col1:
+        search_query = st.text_input(
+            "Search for AI agents",
+            placeholder="e.g., code review, data analysis, trading bot, database...",
+        )
+
+    with col2:
+        num_results = st.selectbox("Results", [10, 20, 50], index=1)
+
+    if st.button("🔍 Search Agents", type="primary"):
+        if not search_query:
+            st.warning("Please enter a search query.")
+            return
+
+        with st.spinner("Searching across registries..."):
+            try:
+                results = search_agents(search_query, limit=num_results)
+                agents = results.get("agents", [])
+
+                if not agents:
+                    st.info("No agents found. Try a different search term.")
+                    return
+
+                st.success(f"Found {len(agents)} agents matching '{search_query}'")
+
+                # Display results in tabs
+                tab1, tab2 = st.tabs(["📋 Agent List", "🤖 Local AI Recommendations"])
+
+                with tab1:
+                    for agent in agents:
+                        with st.expander(
+                            f"**{agent.get('name', 'Unknown')}** - {agent.get('registry', 'Unknown')}"
+                        ):
+                            st.markdown(
+                                f"**Description:** {agent.get('description', 'No description')}"
+                            )
+                            st.markdown(f"**UAID:** `{agent.get('uaid', 'N/A')}`")
+                            if agent.get("capabilities"):
+                                st.markdown(
+                                    f"**Capabilities:** {', '.join(agent['capabilities'][:5])}"
+                                )
+                            if agent.get("url"):
+                                st.markdown(f"[View Agent]({agent['url']})")
+
+                with tab2:
+                    with st.spinner("Analyzing agents with local Llama model..."):
+                        try:
+                            analysis = analyze_agents_with_local_llm(
+                                search_query, agents
+                            )
+                            st.markdown(analysis)
+                        except Exception as e:
+                            st.error(f"Error with Ollama: {str(e)}")
+                            st.info("Make sure Ollama is running: `ollama serve`")
+
+            except Exception as e:
+                st.error(f"Error searching agents: {str(e)}")
+
+    # Show available categories
+    with st.expander("📂 Browse Categories"):
+        try:
+            facets = get_search_facets()
+            if facets.get("registries"):
+                st.markdown("**Available Registries:**")
+                for registry in facets["registries"]:
+                    st.markdown(f"- {registry}")
+            if facets.get("categories"):
+                st.markdown("**Categories:**")
+                cols = st.columns(3)
+                for i, category in enumerate(facets["categories"][:15]):
+                    cols[i % 3].markdown(f"• {category}")
+        except Exception:
+            st.info("Could not load categories. Try searching directly.")
+
+
+if __name__ == "__main__":
+    main()

--- a/starter_ai_agents/ai_agent_discovery_agent/requirements.txt
+++ b/starter_ai_agents/ai_agent_discovery_agent/requirements.txt
@@ -1,0 +1,4 @@
+streamlit
+httpx
+openai
+ollama


### PR DESCRIPTION
## Summary

Adds a new **AI Agent Discovery Agent** to starter_ai_agents that helps users find and compare AI agents across multiple registries using the Registry Broker API.

## Features

- Search AI agents across 5+ registries (NANDA, MCP, Virtuals, A2A, ERC-8004)
- AI-powered recommendations using GPT-4o or local Llama
- Streamlit UI for easy interaction
- View agent details, capabilities, and browse categories

## Files Added

- `starter_ai_agents/ai_agent_discovery_agent/agent_discovery.py` - Cloud version (OpenAI)
- `starter_ai_agents/ai_agent_discovery_agent/local_agent_discovery.py` - Local version (Ollama)
- `starter_ai_agents/ai_agent_discovery_agent/README.MD` - Documentation
- `starter_ai_agents/ai_agent_discovery_agent/requirements.txt` - Dependencies

## API Used

[Registry Broker API](https://hol.org/registry/docs) - Universal AI Agent Index