### PR TITLE
chore: Update outdated GitHub Actions version

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -25,7 +25,7 @@ jobs:
       id-token: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
 


### PR DESCRIPTION
This PR updates an outdated GitHub Action version.

- Updated `actions/checkout` from `v4` to `v6` in `.github/workflows/claude.yml`
