### PR TITLE
fix: rename loop variable to avoid shadowing Memory object

### DIFF
--- a/advanced_llm_apps/llm_apps_with_memory_tutorials/ai_travel_agent_memory/travel_agent_memory.py
+++ b/advanced_llm_apps/llm_apps_with_memory_tutorials/ai_travel_agent_memory/travel_agent_memory.py
@@ -70,9 +70,9 @@ if openai_api_key:
         relevant_memories = memory.search(query=prompt, user_id=user_id)
         context = "Relevant past information:\n"
         if relevant_memories and "results" in relevant_memories:
-            for memory in relevant_memories["results"]:
-                if "memory" in memory:
-                    context += f"- {memory['memory']}\n"
+            for mem in relevant_memories["results"]:
+                if "memory" in mem:
+                    context += f"- {mem['memory']}\n"
 
         # Prepare the full prompt
         full_prompt = f"{context}\nHuman: {prompt}\nAI:"

--- a/advanced_llm_apps/llm_apps_with_memory_tutorials/multi_llm_memory/multi_llm_memory.py
+++ b/advanced_llm_apps/llm_apps_with_memory_tutorials/multi_llm_memory/multi_llm_memory.py
@@ -51,9 +51,9 @@ if openai_api_key and anthropic_api_key:
             relevant_memories = memory.search(query=prompt, user_id=user_id)
             context = "Relevant past information:\n"
             if relevant_memories and "results" in relevant_memories:
-                for memory in relevant_memories["results"]:
-                    if "memory" in memory:
-                        context += f"- {memory['memory']}\n"
+                for mem in relevant_memories["results"]:
+                    if "memory" in mem:
+                        context += f"- {mem['memory']}\n"
                 
             full_prompt = f"{context}\nHuman: {prompt}\nAI:"
 


### PR DESCRIPTION
## Summary
Fixes #449

## Problem
The loop variable `memory` used to iterate over memory results was shadowing the `Memory` object from the mem0 library. This caused an `AttributeError: 'dict' object has no attribute 'add'` when `memory.add()` was called later in the code.

```python
# Bug: 'memory' loop variable overwrites the Memory object
for memory in relevant_memories["results"]:
    if "memory" in memory:
        context += f"- {memory['memory']}\n"

# Later fails because 'memory' is now a dict, not Memory
memory.add(prompt, user_id=user_id)  # AttributeError!
```

## Solution
Renamed the loop variable from `memory` to `mem`, which matches the pattern already used elsewhere in the codebase (e.g., in the "View My Memory" sections).

## Files Changed
- `advanced_llm_apps/llm_apps_with_memory_tutorials/ai_travel_agent_memory/travel_agent_memory.py`
- `advanced_llm_apps/llm_apps_with_memory_tutorials/multi_llm_memory/multi_llm_memory.py`

## Testing
- Verified syntax with `python -m py_compile`
- Tested logic flow to confirm `memory.add()` works after the loop

Thanks to @Veeksha-c for reporting this issue!