### PR TITLE
fix: resolve google_search tool and artifact loading issues in home renovation agent

### DIFF
--- a/advanced_ai_agents/multi_agent_apps/ai_home_renovation_agent/agent.py
+++ b/advanced_ai_agents/multi_agent_apps/ai_home_renovation_agent/agent.py
@@ -10,7 +10,7 @@ Pattern Reference: https://google.github.io/adk-docs/agents/multi-agents/#coordi
 """
 
 from google.adk.agents import LlmAgent, SequentialAgent
-from google.adk.tools import google_search
+from google.adk.tools import GoogleSearchTool
 from google.adk.tools.agent_tool import AgentTool
 from .tools import (
     generate_renovation_rendering,
@@ -21,15 +21,20 @@ from .tools import (
 
 
 # ============================================================================
-# Helper Tool Agent (wraps google_search)
+# Helper Tool Agent (wraps GoogleSearchTool)
 # ============================================================================
+
+# Use bypass_multi_tools_limit=True to allow GoogleSearchTool in nested agent setups
+google_search_tool = GoogleSearchTool(bypass_multi_tools_limit=True)
 
 search_agent = LlmAgent(
     name="SearchAgent",
     model="gemini-3-flash-preview",
     description="Searches for renovation costs, contractors, materials, and design trends",
-    instruction="Use google_search to find current renovation information, costs, materials, and trends. Be concise and cite sources.",
-    tools=[google_search],
+    instruction="""You are a search specialist. When asked to find information about renovation costs, 
+contractors, materials, or design trends, the search capability is automatically enabled. 
+Simply respond with the information you find. Be concise and cite sources when available.""",
+    tools=[google_search_tool],
 )
 
 


### PR DESCRIPTION
## Summary
Fixes #409

## Problem
The AI Home Renovation Agent was experiencing two issues:

1. **`google_search` tool not found error**: The LLM was trying to call `google_search` as a callable function, but it's actually a Gemini built-in capability that works automatically.

2. **Artifact not found error**: When editing renderings, the LLM sometimes hallucinated incorrect filenames (e.g., `office_gaming_hybrid_renovation_v0.png` instead of `_v1.png`), causing the edit to fail.

## Solution

### agent.py
- Replace singleton `google_search` with explicit `GoogleSearchTool(bypass_multi_tools_limit=True)` for compatibility with nested agent setups (per [ADK documentation](https://google.github.io/adk-docs/tools/limitations/))
- Updated SearchAgent instruction to clarify that search is automatic, not a callable function

### tools.py
- Added validation for common LLM hallucination patterns (version 0 detection)
- Added robust fallback logic for artifact loading:
  1. Auto-correct `_v0` to `_v1` (first version is always v1)
  2. Look up known artifact versions from session state
  3. Fall back to last generated rendering
- Improved error messages to show available artifacts when loading fails

## Testing
- Syntax validated with `python -m py_compile`
- Logic reviewed to ensure fallbacks work correctly

## Notes
The `bypass_multi_tools_limit=True` parameter is the official ADK workaround for using GoogleSearchTool in nested agent configurations (available in ADK Python v1.16.0+).