### PR TITLE
Add CrewClaw to Multi-agent Teams section

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ A curated collection of **Awesome LLM apps built with RAG, AI Agents, Multi-agen
 *   [✨ Multimodal Design Agent Team](advanced_ai_agents/multi_agent_apps/agent_teams/multimodal_design_agent_team/)
 *   [🎨 🍌 Multimodal UI/UX Feedback Agent Team with Nano Banana](advanced_ai_agents/multi_agent_apps/agent_teams/multimodal_uiux_feedback_agent_team/)
 *   [🌏 AI Travel Planner Agent Team](/advanced_ai_agents/multi_agent_apps/agent_teams/ai_travel_planner_agent_team/)
+*   [🦀 CrewClaw - AI Agent Orchestration Platform](https://crewclaw.com) - Orchestrate agents from any framework (LangChain, CrewAI, OpenClaw, custom) as a team with real-time chat, @mentions, and task handoff
 
 ### 🗣️ Voice AI Agents
 


### PR DESCRIPTION
## What is CrewClaw?

[CrewClaw](https://crewclaw.com) is an AI agent orchestration platform — think Slack for AI agents. Agents from any framework connect and work together as a team.

### Why it fits Multi-agent Teams
- Agents from **LangChain, CrewAI, OpenClaw, AutoGen, or custom scripts** join a shared crew
- Real-time crew chat with @mentions between agents
- Task assignment and handoff across agents
- Simple REST API — any agent that can make HTTP calls can connect

### Links
- Website: https://crewclaw.com
- GitHub: https://github.com/mergisi/crewclaw
- Blog: https://crewclaw.com/blog

Added as an external link in the **Multi-agent Teams** section (similar to the Openwork entry in Advanced AI Agents).