### PR TITLE
docs: Add Agent Governance tutorials to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ A curated collection of **Awesome LLM apps built with RAG, AI Agents, Multi-agen
 *   [🧬 AI Self-Evolving Agent](advanced_ai_agents/multi_agent_apps/ai_Self-Evolving_agent/)
 *   [👨🏻‍💼 AI Sales Intelligence Agent Team](advanced_ai_agents/multi_agent_apps/agent_teams/ai_sales_intelligence_agent_team)
 *   [🎧 AI Social Media News and Podcast Agent](advanced_ai_agents/multi_agent_apps/ai_news_and_podcast_agents/)
+*   [🛡️ AI Agent Governance - Policy Sandboxing](advanced_ai_agents/single_agent_apps/ai_agent_governance/)
 *   [🌐 Openwork - Open Browser Automation Agent](https://github.com/accomplish-ai/openwork)
 
 ### 🎮 Autonomous Game Playing Agents
@@ -146,6 +147,7 @@ A curated collection of **Awesome LLM apps built with RAG, AI Agents, Multi-agen
 *   [💻 Multimodal Coding Agent Team](advanced_ai_agents/multi_agent_apps/agent_teams/multimodal_coding_agent_team/)
 *   [✨ Multimodal Design Agent Team](advanced_ai_agents/multi_agent_apps/agent_teams/multimodal_design_agent_team/)
 *   [🎨 🍌 Multimodal UI/UX Feedback Agent Team with Nano Banana](advanced_ai_agents/multi_agent_apps/agent_teams/multimodal_uiux_feedback_agent_team/)
+*   [🔐 Multi-Agent Trust Layer](advanced_ai_agents/multi_agent_apps/multi_agent_trust_layer/)
 *   [🌏 AI Travel Planner Agent Team](/advanced_ai_agents/multi_agent_apps/agent_teams/ai_travel_planner_agent_team/)
 
 ### 🗣️ Voice AI Agents


### PR DESCRIPTION
This PR adds the missing README links for the tutorials that were merged in #467.

### Added Links
- **🛡️ AI Agent Governance - Policy Sandboxing** — Tutorial on building deterministic policy enforcement for single AI agents (filesystem access control, network policy, rate limiting, audit logging)
- **🔐 Multi-Agent Trust Layer** — Tutorial on building secure agent-to-agent communication (cryptographic identity, trust scoring, delegation chains, policy enforcement)

Both tutorials are already in the repo (merged via #467) but were not linked from the README, making them hard to discover.

cc @Shubhamsaboo
