### PR TITLE
Add ClawdTalk - Voice-enabled LLM app for phone-based AI interaction

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,7 @@ A curated collection of **Awesome LLM apps built with RAG, AI Agents, Multi-agen
 *   [📞 Customer Support Voice Agent](voice_ai_agents/customer_support_voice_agent/)
 *   [🔊 Voice RAG Agent (OpenAI SDK)](voice_ai_agents/voice_rag_openaisdk/)
 *   [🎙️ OpenSource Voice Dictation Agent (like Wispr Flow](https://github.com/akshayaggarwal99/jarvis-ai-assistant)
+*   [📞 ClawdTalk - Voice-enabled LLM app for phone-based AI interaction](https://github.com/team-telnyx/clawdtalk-client)
 
 ### <img src="https://cdn.simpleicons.org/modelcontextprotocol"  alt="mcp logo" width="25" height="20"> MCP AI Agents 
 


### PR DESCRIPTION
This PR adds ClawdTalk to the Voice AI Agents section.

ClawdTalk is a voice-enabled LLM application for phone-based AI agent interaction. It enables calling your AI agent from any phone with deep tool integration for calendar, Jira, web search, and more. Powered by Telnyx.