### PR TITLE
Add Taskade MCP Server

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ A curated collection of **Awesome LLM apps built with RAG, AI Agents, Multi-agen
 *   [🐙 GitHub MCP Agent](mcp_ai_agents/github_mcp_agent/)
 *   [📑 Notion MCP Agent](mcp_ai_agents/notion_mcp_agent) 
 *   [🌍 AI Travel Planner MCP Agent](mcp_ai_agents/ai_travel_planner_mcp_agent_team)
+*   [🚀 Taskade MCP Server](https://github.com/taskade/mcp) - Connect Taskade to any AI assistant via MCP — 50+ tools for workspaces, projects, tasks, AI agents, knowledge bases, templates, and media.
 
 ### 📀 RAG (Retrieval Augmented Generation)
 *   [🔥 Agentic RAG with Embedding Gemma](rag_tutorials/agentic_rag_embedding_gemma)


### PR DESCRIPTION
## What's added

Added **[Taskade MCP Server](https://github.com/taskade/mcp)** to the MCP AI Agents section.

Taskade MCP Server connects Taskade to any AI assistant via the Model Context Protocol (MCP) — providing 50+ tools for workspaces, projects, tasks, AI agents, knowledge bases, templates, and media.

- **Repo:** https://github.com/taskade/mcp
- **npm:** `@taskade/mcp-server`
- **Tools:** 50+ MCP tools covering projects, tasks, agents, knowledge, templates, media, and more

## Why this belongs here

Taskade MCP Server is a production MCP integration used by teams for productivity and AI agent workflows — a natural fit alongside the existing Browser, GitHub, Notion, and Travel Planner MCP agents.