### PR TITLE
Add Wolfcha - AI-powered Werewolf game with multi-LLM competition

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ A curated collection of **Awesome LLM apps built with RAG, AI Agents, Multi-agen
 *   [🎮 AI 3D Pygame Agent](advanced_ai_agents/autonomous_game_playing_agent_apps/ai_3dpygame_r1/)
 *   [♜ AI Chess Agent](advanced_ai_agents/autonomous_game_playing_agent_apps/ai_chess_agent/)
 *   [🎲 AI Tic-Tac-Toe Agent](advanced_ai_agents/autonomous_game_playing_agent_apps/ai_tic_tac_toe_agent/)
+*   [🐺 Wolfcha - AI Werewolf Game](https://github.com/oil-oil/wolfcha) - AI-powered Werewolf social deduction game where multiple top LLMs (DeepSeek, Qwen, Gemini) compete in logical deduction and verbal sparring.
 
 ### 🤝 Multi-agent Teams
 


### PR DESCRIPTION
[Wolfcha](https://github.com/oil-oil/wolfcha) is an open-source AI-powered Werewolf (Mafia) social deduction game where multiple top LLMs compete in the same game session. Built with Next.js, TypeScript, and ZenMux for unified LLM integration.

## Features
- 8 game roles with complex game mechanics
- Multiple AI models compete: DeepSeek V3.2, Qwen3, Kimi K2, Gemini 3 Flash
- Dual-layer AI roleplay system
- Bilingual support (EN/CN)
- Voice TTS and game analysis

Live: https://wolf-cha.com