### PR TITLE
Add Manifest to LLM Optimization Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,7 @@ A curated collection of **Awesome LLM apps built with RAG, AI Agents, Multi-agen
 
 *   [🎯 Toonify Token Optimization](advanced_llm_apps/llm_optimization_tools/toonify_token_optimization/) - Reduce LLM API costs by 30-60% using TOON format
 *   [🧠 Headroom Context Optimization](advanced_llm_apps/llm_optimization_tools/headroom_context_optimization/) - Reduce LLM API costs by 50-90% through intelligent context compression for AI agents (includes persistent memory & MCP support)
+*   [📡 Manifest](https://github.com/mnfst/manifest) - Open-source real-time cost observability for AI agents — tracks tokens, costs, messages, and model usage. Self-hostable, privacy-focused, and OTLP-native
 
 ### 🔧 LLM Fine-tuning Tutorials
 


### PR DESCRIPTION
## Summary

- Adds [Manifest](https://github.com/mnfst/manifest) to the **LLM Optimization Tools** section
- Manifest is an open-source, real-time cost observability tool for AI agents that tracks tokens, costs, messages, and model usage
- MIT-licensed, self-hostable, privacy-focused, and OTLP-native
- Website: https://manifest.build

## Changes

- `README.md`: Added one entry to the LLM Optimization Tools section