### PR TITLE
Add ShipSite Deploy Agent to MCP AI Agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,8 @@ A curated collection of **Awesome LLM apps built with RAG, AI Agents, Multi-agen
 
 *   [♾️ Browser MCP Agent](mcp_ai_agents/browser_mcp_agent/)
 *   [🐙 GitHub MCP Agent](mcp_ai_agents/github_mcp_agent/)
-*   [📑 Notion MCP Agent](mcp_ai_agents/notion_mcp_agent) 
+*   [📑 Notion MCP Agent](mcp_ai_agents/notion_mcp_agent)
+*   [🚀 ShipSite Deploy Agent](mcp_ai_agents/shipsite_deploy_agent/)
 *   [🌍 AI Travel Planner MCP Agent](mcp_ai_agents/ai_travel_planner_mcp_agent_team)
 
 ### 📀 RAG (Retrieval Augmented Generation)

--- a/mcp_ai_agents/shipsite_deploy_agent/README.md
+++ b/mcp_ai_agents/shipsite_deploy_agent/README.md
@@ -1,0 +1,89 @@
+# 🚀 ShipSite Deploy Agent
+
+A Streamlit application that lets you describe a website in natural language and have an AI agent build and deploy it live — using [ShipSite](https://shipsite.sh) through the Model Context Protocol (MCP).
+
+## Features
+
+- **Natural Language to Live Site**: Describe what you want and get a deployed URL
+- **One-Step Deploy**: The agent generates HTML/CSS/JS and deploys in a single flow
+- **MCP Integration**: Uses the `@shipsite/mcp` server to deploy static sites via API
+- **Site Management**: List, update, and delete your deployed sites through conversation
+- **Instant Results**: Sites go live on a global CDN in under a second
+
+## How It Works
+
+[ShipSite](https://shipsite.sh) is a static site hosting API built for LLM agents. Instead of git repos, build steps, and dashboards, your agent POSTs files as JSON and gets back a live URL. The MCP server exposes this as tools (`deploy_site`, `list_sites`, `delete_site`, etc.) that any MCP-compatible agent can call natively.
+
+## Setup
+
+### Requirements
+
+- Python 3.8+
+- Node.js and npm (for the ShipSite MCP server)
+  - Download and install from [nodejs.org](https://nodejs.org/)
+- OpenAI API Key
+- ShipSite API Key (get one at [shipsite.sh](https://shipsite.sh))
+
+### Getting a ShipSite API Key
+
+1. Your agent can create an account by calling `POST https://api.shipsite.sh/v1/accounts` with your email
+2. You'll get back an API key and a Stripe checkout link
+3. Open the checkout link to activate your account ($0.05/site/day, usage-based)
+4. Your API key is now active
+
+### Installation
+
+1. Clone this repository:
+   ```bash
+   git clone https://github.com/Shubhamsaboo/awesome-llm-apps.git
+   cd mcp_ai_agents/shipsite_deploy_agent
+   ```
+
+2. Install the required Python packages:
+   ```bash
+   pip install -r requirements.txt
+   ```
+
+3. Verify Node.js and npm are installed:
+   ```bash
+   node --version
+   npm --version
+   ```
+
+### Running the App
+
+1. Start the Streamlit app:
+   ```bash
+   streamlit run shipsite_agent.py
+   ```
+
+2. In the app interface:
+   - Enter your OpenAI API key
+   - Enter your ShipSite API key
+   - Describe the site you want to build
+   - Click "Deploy"
+
+### Example Prompts
+
+#### Simple Sites
+- "Create a personal portfolio page with a dark theme, my name is Alex Chen, and I'm a software engineer"
+- "Build a countdown timer page for New Year's Eve 2027"
+- "Make a simple landing page for my dog walking business called PawSteps"
+
+#### More Complex
+- "Build a recipe page for chocolate chip cookies with ingredients, steps, and a photo placeholder"
+- "Create a team directory page with 4 cards showing name, role, and a short bio"
+- "Deploy a changelog page for my app with 3 release entries"
+
+#### Site Management
+- "List all my deployed sites"
+- "Delete the site with ID site_abc123"
+
+## Architecture
+
+The application uses:
+- **Streamlit** for the user interface
+- **MCP** (Model Context Protocol) to connect the LLM with ShipSite's deploy tools
+- **@shipsite/mcp** as the MCP server (runs via npx)
+- **OpenAI** to interpret prompts and generate site code
+- **ShipSite API** to host and serve the deployed sites on a global edge CDN

--- a/mcp_ai_agents/shipsite_deploy_agent/requirements.txt
+++ b/mcp_ai_agents/shipsite_deploy_agent/requirements.txt
@@ -1,0 +1,4 @@
+streamlit>=1.28.0
+agno>=2.2.10
+mcp>=0.1.0
+openai>=1.0.0

--- a/mcp_ai_agents/shipsite_deploy_agent/shipsite_agent.py
+++ b/mcp_ai_agents/shipsite_deploy_agent/shipsite_agent.py
@@ -1,0 +1,148 @@
+import asyncio
+import os
+import streamlit as st
+from textwrap import dedent
+from agno.agent import Agent
+from agno.run.agent import RunOutput
+from agno.tools.mcp import MCPTools
+from mcp import StdioServerParameters
+
+st.set_page_config(page_title="🚀 ShipSite Deploy Agent", page_icon="🚀", layout="wide")
+
+st.markdown("<h1>🚀 ShipSite Deploy Agent</h1>", unsafe_allow_html=True)
+st.markdown("Describe a website in natural language and deploy it live instantly")
+
+with st.sidebar:
+    st.header("🔑 Authentication")
+
+    openai_key = st.text_input(
+        "OpenAI API Key",
+        type="password",
+        help="Required for the AI agent to generate site code",
+    )
+    if openai_key:
+        os.environ["OPENAI_API_KEY"] = openai_key
+
+    shipsite_key = st.text_input(
+        "ShipSite API Key",
+        type="password",
+        help="Get one at shipsite.sh — your agent can also create an account for you",
+    )
+
+    st.markdown("---")
+    st.markdown("### Example Prompts")
+
+    st.markdown("**Simple Sites**")
+    st.markdown("- Build a portfolio page for a designer named Alex")
+    st.markdown("- Create a countdown to New Year's Eve")
+    st.markdown("- Make a landing page for a coffee shop")
+
+    st.markdown("**More Complex**")
+    st.markdown("- Build a recipe page with ingredients and steps")
+    st.markdown("- Create a team directory with photo placeholders")
+
+    st.markdown("**Management**")
+    st.markdown("- List all my deployed sites")
+    st.markdown("- Delete site_abc123")
+
+    st.markdown("---")
+    st.caption("Sites cost $0.05/day and auto-expire after 24h unless pinned.")
+
+
+prompt = st.text_area(
+    "Describe Your Site",
+    placeholder="e.g. Build a minimal landing page for my SaaS product called Acme Analytics with a hero section, feature grid, and pricing card",
+    height=120,
+)
+
+
+async def run_deploy_agent(message: str, api_key: str) -> str:
+    if not os.getenv("OPENAI_API_KEY"):
+        return "Error: OpenAI API key not provided"
+
+    if not api_key:
+        return "Error: ShipSite API key not provided"
+
+    try:
+        server_params = StdioServerParameters(
+            command="npx",
+            args=["@shipsite/mcp"],
+            env={**os.environ, "SHIPSITE_API_KEY": api_key},
+        )
+
+        async with MCPTools(server_params=server_params) as mcp_tools:
+            agent = Agent(
+                tools=[mcp_tools],
+                instructions=dedent("""\
+                    You are a web developer agent that builds and deploys static websites.
+
+                    When the user describes a site they want:
+                    1. Generate clean, modern HTML/CSS (and JS if needed) for the site
+                    2. Deploy it using the deploy_site tool
+                    3. Return the live URL to the user
+
+                    Guidelines for generated sites:
+                    - Use modern CSS (flexbox/grid, custom properties, system fonts)
+                    - Make sites responsive and mobile-friendly
+                    - Keep designs clean and professional
+                    - Include all code inline (styles in <style>, scripts in <script>)
+                    - Do not use external CDNs or dependencies
+
+                    When deploying:
+                    - Put the main page in index.html
+                    - Add a style.css file if styles are substantial
+                    - Use descriptive names when the user provides one
+
+                    For management requests (list, delete, etc.), use the appropriate tools.
+
+                    Always show the deployed URL prominently in your response.
+                """),
+                markdown=True,
+            )
+
+            response: RunOutput = await asyncio.wait_for(
+                agent.arun(message), timeout=120.0
+            )
+            return response.content
+
+    except asyncio.TimeoutError:
+        return "Error: Request timed out after 120 seconds"
+    except Exception as e:
+        return f"Error: {str(e)}"
+
+
+if st.button("🚀 Deploy", type="primary", use_container_width=True):
+    if not openai_key:
+        st.error("Please enter your OpenAI API key in the sidebar")
+    elif not shipsite_key:
+        st.error("Please enter your ShipSite API key in the sidebar")
+    elif not prompt:
+        st.error("Please describe the site you want to build")
+    else:
+        with st.spinner("Building and deploying your site..."):
+            result = asyncio.run(run_deploy_agent(prompt, shipsite_key))
+
+        st.markdown("### Result")
+        st.markdown(result)
+
+if "result" not in locals():
+    st.markdown(
+        """<div style='padding: 1.5rem; border: 1px solid #333; border-radius: 8px; margin-top: 1rem;'>
+        <h4>How to use this app:</h4>
+        <ol>
+            <li>Enter your <strong>OpenAI API key</strong> in the sidebar</li>
+            <li>Enter your <strong>ShipSite API key</strong> in the sidebar
+                (<a href="https://shipsite.sh" target="_blank">get one here</a>)</li>
+            <li>Describe the website you want to create</li>
+            <li>Click <strong>Deploy</strong> — your site goes live in seconds</li>
+        </ol>
+        <p><strong>How it works:</strong></p>
+        <ul>
+            <li>The AI agent generates HTML, CSS, and JavaScript based on your description</li>
+            <li>It calls ShipSite's MCP tools to deploy the files as a live website</li>
+            <li>Your site is served on a global CDN with HTTPS — no build steps needed</li>
+            <li>Sites auto-expire after 24 hours unless pinned</li>
+        </ul>
+        </div>""",
+        unsafe_allow_html=True,
+    )


### PR DESCRIPTION
Adds a Streamlit-based MCP agent that lets users describe a website in natural language and have it built and deployed live via ShipSite (shipsite.sh) — a static site hosting API designed for LLM agents.