### PR TITLE
Add Become CEO - 7-agent AI executive team on Discord

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ A curated collection of **Awesome LLM apps built with RAG, AI Agents, Multi-agen
 *   [🏠 AI Real Estate Agent Team](advanced_ai_agents/multi_agent_apps/agent_teams/ai_real_estate_agent_team)
 *   [👨‍💼 AI Services Agency (CrewAI)](advanced_ai_agents/multi_agent_apps/agent_teams/ai_services_agency/)
 *   [👨‍🏫 AI Teaching Agent Team](advanced_ai_agents/multi_agent_apps/agent_teams/ai_teaching_agent_team/)
+*   [💼 Become CEO](https://github.com/wanikua/become-ceo) — 7-agent AI executive team on Discord — Engineering, Finance, Marketing, DevOps, Legal, Management, Chief of Staff. Each agent is an independent bot with its own Claude model. One-click setup, MIT licensed.
 *   [💻 Multimodal Coding Agent Team](advanced_ai_agents/multi_agent_apps/agent_teams/multimodal_coding_agent_team/)
 *   [✨ Multimodal Design Agent Team](advanced_ai_agents/multi_agent_apps/agent_teams/multimodal_design_agent_team/)
 *   [🎨 🍌 Multimodal UI/UX Feedback Agent Team with Nano Banana](advanced_ai_agents/multi_agent_apps/agent_teams/multimodal_uiux_feedback_agent_team/)


### PR DESCRIPTION
## Summary

Adds [Become CEO](https://github.com/wanikua/become-ceo) to the Multi-agent Teams section.

- 7-agent AI executive team running on Discord (Engineering, Finance, Marketing, DevOps, Legal, Management, Chief of Staff)
- Each agent is an independent Discord bot powered by its own Claude model
- One-click setup, MIT licensed
- Uses Anthropic Claude via the Claude Code SDK

## Placement

Inserted alphabetically under **Multi-agent Teams** — after all "AI ..." entries and before "Multimodal..." entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)