### PR TITLE
Add AI Interview Coach for Engineering Leaders

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@
 # 🌟 Awesome LLM Apps
 
 A curated collection of **Awesome LLM apps built with RAG, AI Agents, Multi-agent Teams, MCP, Voice Agents, and more.** This repository features LLM apps that use models from <img src="https://cdn.jsdelivr.net/npm/simple-icons@15/icons/openai.svg"  alt="openai logo" width="25" height="15">**OpenAI** , <img src="https://cdn.simpleicons.org/anthropic"  alt="anthropic logo" width="25" height="15">**Anthropic**, <img src="https://cdn.simpleicons.org/googlegemini"  alt="google logo" width="25" height="18">**Google**, <img src="https://cdn.simpleicons.org/x"  alt="X logo" width="25" height="15">**xAI** and open-source models like <img src="https://cdn.simpleicons.org/alibabacloud"  alt="alibaba logo" width="25" height="15">**Qwen** or  <img src="https://cdn.simpleicons.org/meta"  alt="meta logo" width="25" height="15">**Llama** that you can run locally on your computer.
+- [AI Interview Coach](https://em-tools.io/interview-prep) - Voice-based AI behavioral interview practice for engineering managers and software engineers. 130+ role-specific questions, STAR-format scoring, and 3 interviewer personas.
 
 <p align="center">
   <a href="https://trendshift.io/repositories/9876" target="_blank">


### PR DESCRIPTION
## Add AI Interview Coach for Engineering Leaders

[AI Interview Coach](https://em-tools.io/interview-prep) - Voice-based AI behavioral interview practice built for software engineers and engineering managers. 130+ role-specific questions, STAR-format scoring across 6 dimensions, probing follow-ups, and 3 interviewer personas (Startup CTO, Big Tech VP, Scale-up Director). Free first question.