### PR TITLE
Add OpenPaw — turns Claude Code into a personal assistant with 38 skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ A curated collection of **Awesome LLM apps built with RAG, AI Agents, Multi-agen
 *   [👨🏻‍💼 AI Sales Intelligence Agent Team](advanced_ai_agents/multi_agent_apps/agent_teams/ai_sales_intelligence_agent_team)
 *   [🎧 AI Social Media News and Podcast Agent](advanced_ai_agents/multi_agent_apps/ai_news_and_podcast_agents/)
 *   [🌐 Openwork - Open Browser Automation Agent](https://github.com/accomplish-ai/openwork)
+*   [🐾 OpenPaw - Turn Claude Code into a Personal Assistant](https://github.com/daxaur/openpaw)
 
 ### 🎮 Autonomous Game Playing Agents
 


### PR DESCRIPTION
Hey! Wanted to share OpenPaw with this list.

**OpenPaw** is an open-source CLI tool (`npx pawmode`) that turns Claude Code into a full personal assistant. It ships with 38 ready-to-use skills covering email, calendar, Spotify, smart home, Slack, GitHub, Obsidian, and more — all from the terminal.

- No daemon, no cloud, just Claude Code + skills
- MIT licensed
- One command to get started: `npx pawmode`

Repo: https://github.com/daxaur/openpaw
npm: https://www.npmjs.com/package/pawmode

I added it to the Advanced AI Agents section since it's a pretty full-featured agent system. Happy to move it elsewhere if there's a better fit. Thanks for maintaining this list!