### PR TITLE
Add OpenAgents Multi-Agent Research Team Demo

### DIFF
--- a/advanced_ai_agents/multi_agent_apps/agent_teams/openagents_research_team/README.md
+++ b/advanced_ai_agents/multi_agent_apps/agent_teams/openagents_research_team/README.md
@@ -1,0 +1,204 @@
+<div align="center">
+
+# 🧠 OpenAgents Multi-Agent Research Team
+
+🚀 A production-ready multi-agent collaboration demo built with OpenAgents  
+📦 Designed for Awesome-LLM-Apps showcase  
+⚡ Uses default `openagents init` network (no custom YAML required)
+
+</div>
+
+---
+
+## ✨ Overview
+
+This project demonstrates a fully automated **multi-agent research workflow** using the OpenAgents framework.
+
+It models a collaborative research team composed of:
+
+- 📋 **Planner** – Breaks down user requests into structured plans  
+- 🔎 **Researcher** – Generates detailed research notes  
+- 🧠 **Critic** – Reviews and improves the output  
+- ✍️ **Writer** – Produces the final Markdown report  
+
+Agents communicate via OpenAgents workspace channels using the official `workspace()` API.
+
+No custom YAML.  
+No low-level event hacks.  
+Only recommended framework interfaces.
+
+---
+
+## 🏗 Architecture
+
+### Agent Pipeline
+
+```
+User (#general)
+      ↓
+Planner (#ideas)
+      ↓
+Researcher (#discussion)
+      ↓
+Critic (#pitch-room)
+      ↓
+Writer (writes file + posts result)
+```
+
+### Channel Flow
+
+```
+general → ideas → discussion → pitch-room → discussion
+```
+
+---
+
+## 🚀 Quick Start
+
+### 1️⃣ Install
+
+```bash
+pip install openagents
+```
+
+### 2️⃣ Initialize Network
+
+```bash
+openagents init my_first_network
+cd my_first_network
+```
+
+> Do NOT modify `network.yaml`.
+
+---
+
+### 3️⃣ Set OpenAI API Key
+
+**Windows (PowerShell)**
+
+```powershell
+$env:OPENAI_API_KEY="your_key_here"
+```
+
+**macOS / Linux**
+
+```bash
+export OPENAI_API_KEY="your_key_here"
+```
+
+---
+
+### 4️⃣ Start Network
+
+```bash
+openagents network start
+```
+
+---
+
+### 5️⃣ Start Agents (Recommended: gRPC)
+
+Open four separate terminals:
+
+```bash
+python planner_agent.py --url grpc://localhost:8600
+python researcher_agent.py --url grpc://localhost:8600
+python critic_agent.py --url grpc://localhost:8600
+python writer_agent.py --url grpc://localhost:8600
+```
+
+---
+
+## 💬 Usage
+
+1. Open the OpenAgents UI  
+2. Navigate to **#general**  
+3. Send a message, for example:
+
+```
+Explain the difference between multi-agent and single-agent systems.
+```
+
+The agents will automatically collaborate and generate a structured research report.
+
+---
+
+## 📄 Output
+
+The final report:
+
+- Appears in **#discussion**
+- Is saved locally as:
+
+```
+report_<run_id>.md
+```
+
+Example:
+
+```
+report_aba50bd9.md
+```
+
+---
+
+## 🔥 Why This Demo Matters
+
+This project demonstrates:
+
+- Multi-agent orchestration using a production-ready framework
+- Clean separation of agent responsibilities
+- Structured channel-based collaboration
+- End-to-end automated content generation
+- Official workspace API usage (no internal event hacks)
+
+It serves as a minimal and reproducible template for building multi-agent systems with OpenAgents.
+
+---
+
+## 🧪 Optional: Mock Mode
+
+Run without OpenAI API calls:
+
+```bash
+export OPENAGENTS_MOCK=1
+```
+
+---
+
+## ⚠️ Troubleshooting
+
+### Agents not responding?
+
+- Ensure you send messages in `#general`
+- Verify all agents are running
+- Use `grpc://localhost:8600`
+- Confirm API key is set in each terminal
+
+### "Agent already registered"?
+
+Stop old processes or restart the network.
+
+---
+
+## 🧩 Built With
+
+- OpenAgents Official Website: https://openagents.org  
+- OpenAgents GitHub: https://github.com/openagents-org/openagents  
+
+---
+
+## 📦 Project Structure
+
+```
+openagents_research_team/
+│
+├── planner_agent.py
+├── researcher_agent.py
+├── critic_agent.py
+├── writer_agent.py
+├── requirements.txt
+└── README.md
+```
+
+---

--- a/advanced_ai_agents/multi_agent_apps/agent_teams/openagents_research_team/critic_agent.py
+++ b/advanced_ai_agents/multi_agent_apps/agent_teams/openagents_research_team/critic_agent.py
@@ -1,0 +1,194 @@
+#!/usr/bin/env python3
+"""
+Critic Agent (stable workspace API)
+- Listens:  #discussion
+- Sends:    #pitch-room
+Reviews research notes and provides constructive critique.
+"""
+
+import asyncio
+import os
+from collections import deque
+from typing import Optional
+
+from openagents.agents.worker_agent import WorkerAgent, EventContext, ChannelMessageContext
+from openagents.models.agent_config import AgentConfig
+
+
+def _safe_bool_env(name: str, default: bool = False) -> bool:
+    v = os.getenv(name, "")
+    if not v:
+        return default
+    return v.strip().lower() in ("1", "true", "yes", "y", "on")
+
+
+class _Dedupe:
+    def __init__(self, max_items: int = 512):
+        self.max_items = max_items
+        self._q = deque()
+        self._s = set()
+
+    def seen(self, key: str) -> bool:
+        if key in self._s:
+            return True
+        self._s.add(key)
+        self._q.append(key)
+        while len(self._q) > self.max_items:
+            old = self._q.popleft()
+            self._s.discard(old)
+        return False
+
+
+def _get_text_from_channel_event(context: ChannelMessageContext) -> str:
+    payload = getattr(context.incoming_event, "payload", None) or {}
+    if isinstance(payload, dict):
+        content = payload.get("content")
+        if isinstance(content, dict) and isinstance(content.get("text"), str):
+            return content["text"]
+        if isinstance(payload.get("text"), str):
+            return payload["text"]
+    return ""
+
+
+def _event_id_or_hash(context: EventContext, text: str) -> str:
+    ev = getattr(context, "incoming_event", None)
+    ev_id = getattr(ev, "id", None) or getattr(ev, "event_id", None)
+    if ev_id:
+        return str(ev_id)
+    return f"hash:{hash(text)}"
+
+
+def _extract_llm_response(trajectory) -> Optional[str]:
+    for action in getattr(trajectory, "actions", []) or []:
+        payload = getattr(action, "payload", None) or {}
+        if not isinstance(payload, dict):
+            continue
+        for k in ("response", "text", "content", "output"):
+            v = payload.get(k)
+            if isinstance(v, str) and v.strip():
+                return v
+            if isinstance(v, dict) and isinstance(v.get("text"), str) and v.get("text").strip():
+                return v["text"]
+    return None
+
+
+def _parse_run_id(text: str) -> Optional[str]:
+    first = (text.splitlines() or [""])[0].strip()
+    if first.lower().startswith("run_id:"):
+        return first.split(":", 1)[1].strip() or None
+    return None
+
+
+class CriticAgent(WorkerAgent):
+    default_agent_id = "critic"
+
+    def __init__(self, **kwargs):
+        self.api_key = os.getenv("OPENAI_API_KEY")
+        self.force_mock = _safe_bool_env("OPENAGENTS_MOCK", default=False)
+        self.mock_mode = self.force_mock or (not bool(self.api_key))
+        self._dedupe = _Dedupe(max_items=512)
+
+        agent_config = AgentConfig(
+            instruction=(
+                "You are the Critic agent.\n"
+                "Given QUESTION/PLAN/NOTES, critique the notes:\n"
+                "- identify gaps\n- suggest improvements\n- propose a better outline\n"
+                "Be constructive and specific."
+            ),
+            model_name=os.getenv("OPENAI_MODEL", "gpt-4o-mini"),
+            provider=os.getenv("OPENAI_PROVIDER", "openai"),
+            api_key=self.api_key,
+        )
+        super().__init__(agent_config=agent_config, **kwargs)
+
+    async def on_startup(self):
+        print(f"✅ CriticAgent online | listens: #discussion → sends: #pitch-room | Mock: {self.mock_mode}")
+
+    async def on_channel_post(self, context: ChannelMessageContext):
+        if context.channel != "discussion":
+            return
+        if getattr(context, "source_id", None) == self.agent_id:
+            return
+
+        incoming = _get_text_from_channel_event(context).strip()
+        if not incoming:
+            return
+
+        key = f"{context.channel}:{_event_id_or_hash(context, incoming)}"
+        if self._dedupe.seen(key):
+            return
+
+        run_id = _parse_run_id(incoming) or "unknown"
+        print(f"🔎 Critic processing (run_id={run_id})")
+
+        if self.mock_mode:
+            critique = (
+                "## Gaps / missing points\n"
+                "- Add a short section on evaluation/observability (logs, traces, metrics).\n"
+                "- Mention coordination failure modes (conflicts, loops).\n"
+                "- Clarify when single-agent is sufficient.\n\n"
+                "## Suggested improvements\n"
+                "- Add a simple workflow diagram / message flow.\n"
+                "- Use concrete examples with inputs/outputs.\n\n"
+                "## Proposed final outline\n"
+                "1) Overview\n"
+                "2) Definitions\n"
+                "3) Key Differences\n"
+                "4) Benefits\n"
+                "5) Limitations & Failure Modes\n"
+                "6) When to Use Which\n"
+                "7) Conclusion\n"
+            )
+        else:
+            try:
+                trajectory = await self.run_agent(
+                    context=context,
+                    instruction=(
+                        "Review the input and produce:\n"
+                        "1) Gaps / missing points\n"
+                        "2) Suggested improvements\n"
+                        "3) Proposed final outline\n"
+                        "Return ONLY the critique.\n\n"
+                        f"Input:\n{incoming}"
+                    ),
+                )
+                critique = _extract_llm_response(trajectory) or "(No critique generated)"
+            except Exception as e:
+                print(f"⚠️ Critic LLM error: {e}")
+                critique = "(Error generating critique, using fallback)"
+
+        msg = f"RUN_ID: {run_id}\n{incoming}\n\nCRITIQUE:\n{critique}"
+
+        ws = self.workspace()
+        await ws.channel("pitch-room").post(msg)
+        print(f"✅ Critic → #pitch-room (run_id={run_id})")
+
+
+async def main():
+    import argparse
+    parser = argparse.ArgumentParser(description="Critic Agent (workspace API stable)")
+    parser.add_argument("--host", default="localhost")
+    parser.add_argument("--port", type=int, default=8700, help="HTTP port for connection (default: 8700)")
+    parser.add_argument("--url", default=None, help="Direct connection URL (recommended: grpc://localhost:8600)")
+    args = parser.parse_args()
+
+    agent = CriticAgent()
+    try:
+        if args.url:
+            print(f"🚀 Starting Critic with URL: {args.url}")
+            await agent.async_start(url=args.url)
+        else:
+            print(f"🚀 Starting Critic on http://{args.host}:{args.port}")
+            await agent.async_start(network_host=args.host, network_port=args.port)
+
+        while True:
+            await asyncio.sleep(1)
+
+    except KeyboardInterrupt:
+        print("\n👋 Critic shutting down...")
+    finally:
+        await agent.async_stop()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/advanced_ai_agents/multi_agent_apps/agent_teams/openagents_research_team/planner_agent.py
+++ b/advanced_ai_agents/multi_agent_apps/agent_teams/openagents_research_team/planner_agent.py
@@ -1,0 +1,183 @@
+#!/usr/bin/env python3
+"""
+Planner Agent (stable workspace API)
+- Listens:  #general
+- Sends:    #ideas
+Creates a structured plan from user questions.
+"""
+
+import asyncio
+import os
+import uuid
+from collections import deque
+from typing import Optional
+
+from openagents.agents.worker_agent import WorkerAgent, EventContext, ChannelMessageContext
+from openagents.models.agent_config import AgentConfig
+
+
+def _safe_bool_env(name: str, default: bool = False) -> bool:
+    v = os.getenv(name, "")
+    if not v:
+        return default
+    return v.strip().lower() in ("1", "true", "yes", "y", "on")
+
+
+class _Dedupe:
+    """Simple in-memory dedupe (OpenAgents can deliver at-least-once)."""
+    def __init__(self, max_items: int = 512):
+        self.max_items = max_items
+        self._q = deque()
+        self._s = set()
+
+    def seen(self, key: str) -> bool:
+        if key in self._s:
+            return True
+        self._s.add(key)
+        self._q.append(key)
+        while len(self._q) > self.max_items:
+            old = self._q.popleft()
+            self._s.discard(old)
+        return False
+
+
+def _get_text_from_channel_event(context: ChannelMessageContext) -> str:
+    payload = getattr(context.incoming_event, "payload", None) or {}
+    if isinstance(payload, dict):
+        content = payload.get("content")
+        if isinstance(content, dict) and isinstance(content.get("text"), str):
+            return content["text"]
+        if isinstance(payload.get("text"), str):
+            return payload["text"]
+    return ""
+
+
+def _event_id_or_hash(context: EventContext, text: str) -> str:
+    ev = getattr(context, "incoming_event", None)
+    ev_id = getattr(ev, "id", None) or getattr(ev, "event_id", None)
+    if ev_id:
+        return str(ev_id)
+    return f"hash:{hash(text)}"
+
+
+def _extract_llm_response(trajectory) -> Optional[str]:
+    """Be defensive about payload shapes across versions/providers."""
+    for action in getattr(trajectory, "actions", []) or []:
+        payload = getattr(action, "payload", None) or {}
+        if not isinstance(payload, dict):
+            continue
+        for k in ("response", "text", "content", "output"):
+            v = payload.get(k)
+            if isinstance(v, str) and v.strip():
+                return v
+            if isinstance(v, dict) and isinstance(v.get("text"), str) and v.get("text").strip():
+                return v["text"]
+    return None
+
+
+class PlannerAgent(WorkerAgent):
+    default_agent_id = "planner"
+
+    def __init__(self, **kwargs):
+        self.api_key = os.getenv("OPENAI_API_KEY")
+        self.force_mock = _safe_bool_env("OPENAGENTS_MOCK", default=False)
+        self.mock_mode = self.force_mock or (not bool(self.api_key))
+        self._dedupe = _Dedupe(max_items=512)
+
+        agent_config = AgentConfig(
+            instruction=(
+                "You are the Planner agent in a multi-agent research pipeline.\n"
+                "When you receive a user question, produce a short, structured plan.\n"
+                "Output MUST be concise and actionable."
+            ),
+            model_name=os.getenv("OPENAI_MODEL", "gpt-4o-mini"),
+            provider=os.getenv("OPENAI_PROVIDER", "openai"),
+            api_key=self.api_key,
+        )
+        super().__init__(agent_config=agent_config, **kwargs)
+
+    async def on_startup(self):
+        print(f"✅ PlannerAgent online | listens: #general → sends: #ideas | Mock: {self.mock_mode}")
+        # Optional hello
+        # ws = self.workspace()
+        # await ws.channel("general").post("Planner online ✅")
+
+    async def on_channel_post(self, context: ChannelMessageContext):
+        # Only handle #general
+        if context.channel != "general":
+            return
+
+        # Ignore own messages
+        if getattr(context, "source_id", None) == self.agent_id:
+            return
+
+        question = _get_text_from_channel_event(context).strip()
+        if not question:
+            return
+
+        # Deduplicate
+        key = f"{context.channel}:{_event_id_or_hash(context, question)}"
+        if self._dedupe.seen(key):
+            return
+
+        run_id = uuid.uuid4().hex[:8]
+        print(f"📋 Planner processing (run_id={run_id}): {question[:80]}")
+
+        if self.mock_mode:
+            plan = (
+                "- Define key terms and scope\n"
+                "- Identify 3–5 core points to cover\n"
+                "- Gather examples / evidence\n"
+                "- Draft structure with headings\n"
+                "- Review & refine for clarity"
+            )
+        else:
+            try:
+                trajectory = await self.run_agent(
+                    context=context,
+                    instruction=(
+                        "Create a step-by-step plan for researching and writing a report.\n"
+                        "Return ONLY the plan as bullet points.\n\n"
+                        f"User question: {question}"
+                    ),
+                )
+                plan = _extract_llm_response(trajectory) or "- (No plan generated)"
+            except Exception as e:
+                print(f"⚠️ Planner LLM error: {e}")
+                plan = "- (Error generating plan, using fallback)"
+
+        msg = f"RUN_ID: {run_id}\nQUESTION:\n{question}\n\nPLAN:\n{plan}"
+
+        ws = self.workspace()
+        await ws.channel("ideas").post(msg)
+        print(f"✅ Planner → #ideas (run_id={run_id})")
+
+
+async def main():
+    import argparse
+    parser = argparse.ArgumentParser(description="Planner Agent (workspace API stable)")
+    parser.add_argument("--host", default="localhost")
+    parser.add_argument("--port", type=int, default=8700, help="HTTP port for connection (default: 8700)")
+    parser.add_argument("--url", default=None, help="Direct connection URL (recommended: grpc://localhost:8600)")
+    args = parser.parse_args()
+
+    agent = PlannerAgent()
+    try:
+        if args.url:
+            print(f"🚀 Starting Planner with URL: {args.url}")
+            await agent.async_start(url=args.url)
+        else:
+            print(f"🚀 Starting Planner on http://{args.host}:{args.port}")
+            await agent.async_start(network_host=args.host, network_port=args.port)
+
+        while True:
+            await asyncio.sleep(1)
+
+    except KeyboardInterrupt:
+        print("\n👋 Planner shutting down...")
+    finally:
+        await agent.async_stop()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/advanced_ai_agents/multi_agent_apps/agent_teams/openagents_research_team/requirements.txt
+++ b/advanced_ai_agents/multi_agent_apps/agent_teams/openagents_research_team/requirements.txt
@@ -1,0 +1,1 @@
+openagents>=0.8.5

--- a/advanced_ai_agents/multi_agent_apps/agent_teams/openagents_research_team/researcher_agent.py
+++ b/advanced_ai_agents/multi_agent_apps/agent_teams/openagents_research_team/researcher_agent.py
@@ -1,0 +1,192 @@
+#!/usr/bin/env python3
+"""
+Researcher Agent (stable workspace API)
+- Listens:  #ideas
+- Sends:    #discussion
+Produces structured research notes from plans.
+"""
+
+import asyncio
+import os
+from collections import deque
+from typing import Optional
+
+from openagents.agents.worker_agent import WorkerAgent, EventContext, ChannelMessageContext
+from openagents.models.agent_config import AgentConfig
+
+
+def _safe_bool_env(name: str, default: bool = False) -> bool:
+    v = os.getenv(name, "")
+    if not v:
+        return default
+    return v.strip().lower() in ("1", "true", "yes", "y", "on")
+
+
+class _Dedupe:
+    def __init__(self, max_items: int = 512):
+        self.max_items = max_items
+        self._q = deque()
+        self._s = set()
+
+    def seen(self, key: str) -> bool:
+        if key in self._s:
+            return True
+        self._s.add(key)
+        self._q.append(key)
+        while len(self._q) > self.max_items:
+            old = self._q.popleft()
+            self._s.discard(old)
+        return False
+
+
+def _get_text_from_channel_event(context: ChannelMessageContext) -> str:
+    payload = getattr(context.incoming_event, "payload", None) or {}
+    if isinstance(payload, dict):
+        content = payload.get("content")
+        if isinstance(content, dict) and isinstance(content.get("text"), str):
+            return content["text"]
+        if isinstance(payload.get("text"), str):
+            return payload["text"]
+    return ""
+
+
+def _event_id_or_hash(context: EventContext, text: str) -> str:
+    ev = getattr(context, "incoming_event", None)
+    ev_id = getattr(ev, "id", None) or getattr(ev, "event_id", None)
+    if ev_id:
+        return str(ev_id)
+    return f"hash:{hash(text)}"
+
+
+def _extract_llm_response(trajectory) -> Optional[str]:
+    for action in getattr(trajectory, "actions", []) or []:
+        payload = getattr(action, "payload", None) or {}
+        if not isinstance(payload, dict):
+            continue
+        for k in ("response", "text", "content", "output"):
+            v = payload.get(k)
+            if isinstance(v, str) and v.strip():
+                return v
+            if isinstance(v, dict) and isinstance(v.get("text"), str) and v.get("text").strip():
+                return v["text"]
+    return None
+
+
+def _parse_run_id(text: str) -> Optional[str]:
+    first = (text.splitlines() or [""])[0].strip()
+    if first.lower().startswith("run_id:"):
+        return first.split(":", 1)[1].strip() or None
+    return None
+
+
+class ResearcherAgent(WorkerAgent):
+    default_agent_id = "researcher"
+
+    def __init__(self, **kwargs):
+        self.api_key = os.getenv("OPENAI_API_KEY")
+        self.force_mock = _safe_bool_env("OPENAGENTS_MOCK", default=False)
+        self.mock_mode = self.force_mock or (not bool(self.api_key))
+        self._dedupe = _Dedupe(max_items=512)
+
+        agent_config = AgentConfig(
+            instruction=(
+                "You are the Researcher agent.\n"
+                "Given a QUESTION and a PLAN, produce structured research notes.\n"
+                "Notes should be factual, organized, and suitable for a final report."
+            ),
+            model_name=os.getenv("OPENAI_MODEL", "gpt-4o-mini"),
+            provider=os.getenv("OPENAI_PROVIDER", "openai"),
+            api_key=self.api_key,
+        )
+        super().__init__(agent_config=agent_config, **kwargs)
+
+    async def on_startup(self):
+        print(f"✅ ResearcherAgent online | listens: #ideas → sends: #discussion | Mock: {self.mock_mode}")
+
+    async def on_channel_post(self, context: ChannelMessageContext):
+        if context.channel != "ideas":
+            return
+        if getattr(context, "source_id", None) == self.agent_id:
+            return
+
+        incoming = _get_text_from_channel_event(context).strip()
+        if not incoming:
+            return
+
+        key = f"{context.channel}:{_event_id_or_hash(context, incoming)}"
+        if self._dedupe.seen(key):
+            return
+
+        run_id = _parse_run_id(incoming) or "unknown"
+        print(f"🔍 Researcher processing (run_id={run_id})")
+
+        if self.mock_mode:
+            notes = (
+                "## Definitions\n"
+                "- **Single-agent pipeline**: one LLM call chain (prompt → response), optionally with tools/RAG.\n"
+                "- **Multi-agent system**: multiple specialized agents collaborate via messages and roles.\n\n"
+                "## Key differences\n"
+                "- **Control flow**: linear chain vs role-based message passing.\n"
+                "- **Specialization**: one generalist vs multiple specialists.\n"
+                "- **Quality control**: limited vs critique/refinement loops.\n\n"
+                "## Benefits\n"
+                "- Better task decomposition\n"
+                "- Higher quality via review and iteration\n\n"
+                "## Limitations\n"
+                "- More latency/cost\n"
+                "- Coordination complexity\n\n"
+                "## Practical examples\n"
+                "- Research pipeline (planner/researcher/critic/writer)\n"
+                "- Code review team (dev/reviewer/tester)\n"
+            )
+        else:
+            try:
+                trajectory = await self.run_agent(
+                    context=context,
+                    instruction=(
+                        "From the input, produce research notes with headings:\n"
+                        "1) Definitions\n2) Key differences\n3) Benefits\n4) Limitations\n5) Practical examples\n\n"
+                        "Return ONLY the notes.\n\n"
+                        f"Input:\n{incoming}"
+                    ),
+                )
+                notes = _extract_llm_response(trajectory) or "(No notes generated)"
+            except Exception as e:
+                print(f"⚠️ Researcher LLM error: {e}")
+                notes = "(Error generating notes, using fallback)"
+
+        msg = f"RUN_ID: {run_id}\n{incoming}\n\nNOTES:\n{notes}"
+
+        ws = self.workspace()
+        await ws.channel("discussion").post(msg)
+        print(f"✅ Researcher → #discussion (run_id={run_id})")
+
+
+async def main():
+    import argparse
+    parser = argparse.ArgumentParser(description="Researcher Agent (workspace API stable)")
+    parser.add_argument("--host", default="localhost")
+    parser.add_argument("--port", type=int, default=8700, help="HTTP port for connection (default: 8700)")
+    parser.add_argument("--url", default=None, help="Direct connection URL (recommended: grpc://localhost:8600)")
+    args = parser.parse_args()
+
+    agent = ResearcherAgent()
+    try:
+        if args.url:
+            print(f"🚀 Starting Researcher with URL: {args.url}")
+            await agent.async_start(url=args.url)
+        else:
+            print(f"🚀 Starting Researcher on http://{args.host}:{args.port}")
+            await agent.async_start(network_host=args.host, network_port=args.port)
+
+        while True:
+            await asyncio.sleep(1)
+
+    except KeyboardInterrupt:
+        print("\n👋 Researcher shutting down...")
+    finally:
+        await agent.async_stop()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/advanced_ai_agents/multi_agent_apps/agent_teams/openagents_research_team/writer_agent.py
+++ b/advanced_ai_agents/multi_agent_apps/agent_teams/openagents_research_team/writer_agent.py
@@ -1,0 +1,218 @@
+#!/usr/bin/env python3
+"""
+Writer Agent (stable workspace API)
+- Listens:  #pitch-room
+- Sends:    #discussion
+Writes final Markdown reports and saves them to disk.
+"""
+
+import asyncio
+import os
+from pathlib import Path
+from collections import deque
+from typing import Optional
+
+from openagents.agents.worker_agent import WorkerAgent, EventContext, ChannelMessageContext
+from openagents.models.agent_config import AgentConfig
+
+
+def _safe_bool_env(name: str, default: bool = False) -> bool:
+    v = os.getenv(name, "")
+    if not v:
+        return default
+    return v.strip().lower() in ("1", "true", "yes", "y", "on")
+
+
+class _Dedupe:
+    def __init__(self, max_items: int = 512):
+        self.max_items = max_items
+        self._q = deque()
+        self._s = set()
+
+    def seen(self, key: str) -> bool:
+        if key in self._s:
+            return True
+        self._s.add(key)
+        self._q.append(key)
+        while len(self._q) > self.max_items:
+            old = self._q.popleft()
+            self._s.discard(old)
+        return False
+
+
+def _get_text_from_channel_event(context: ChannelMessageContext) -> str:
+    payload = getattr(context.incoming_event, "payload", None) or {}
+    if isinstance(payload, dict):
+        content = payload.get("content")
+        if isinstance(content, dict) and isinstance(content.get("text"), str):
+            return content["text"]
+        if isinstance(payload.get("text"), str):
+            return payload["text"]
+    return ""
+
+
+def _event_id_or_hash(context: EventContext, text: str) -> str:
+    ev = getattr(context, "incoming_event", None)
+    ev_id = getattr(ev, "id", None) or getattr(ev, "event_id", None)
+    if ev_id:
+        return str(ev_id)
+    return f"hash:{hash(text)}"
+
+
+def _extract_llm_response(trajectory) -> Optional[str]:
+    for action in getattr(trajectory, "actions", []) or []:
+        payload = getattr(action, "payload", None) or {}
+        if not isinstance(payload, dict):
+            continue
+        for k in ("response", "text", "content", "output"):
+            v = payload.get(k)
+            if isinstance(v, str) and v.strip():
+                return v
+            if isinstance(v, dict) and isinstance(v.get("text"), str) and v.get("text").strip():
+                return v["text"]
+    return None
+
+
+def _parse_run_id(text: str) -> Optional[str]:
+    first = (text.splitlines() or [""])[0].strip()
+    if first.lower().startswith("run_id:"):
+        return first.split(":", 1)[1].strip() or None
+    return None
+
+
+class WriterAgent(WorkerAgent):
+    default_agent_id = "writer"
+
+    def __init__(self, **kwargs):
+        self.api_key = os.getenv("OPENAI_API_KEY")
+        self.force_mock = _safe_bool_env("OPENAGENTS_MOCK", default=False)
+        self.mock_mode = self.force_mock or (not bool(self.api_key))
+        self._dedupe = _Dedupe(max_items=512)
+
+        agent_config = AgentConfig(
+            instruction=(
+                "You are the Writer agent.\n"
+                "Given QUESTION/PLAN/NOTES/CRITIQUE, write a final Markdown report.\n"
+                "Use clear headings and concise explanations.\n"
+                "Return ONLY the Markdown report."
+            ),
+            model_name=os.getenv("OPENAI_MODEL", "gpt-4o-mini"),
+            provider=os.getenv("OPENAI_PROVIDER", "openai"),
+            api_key=self.api_key,
+        )
+        super().__init__(agent_config=agent_config, **kwargs)
+
+    async def on_startup(self):
+        print(f"✅ WriterAgent online | listens: #pitch-room → sends: #discussion | Mock: {self.mock_mode}")
+
+    def _mock_report(self) -> str:
+        return (
+            "# Multi-Agent Systems vs Single-Agent LLM Pipelines\n\n"
+            "## Overview\n"
+            "Single-agent pipelines are typically linear prompt/tool chains, while multi-agent systems split work across roles that communicate via messages.\n\n"
+            "## Key Differences\n"
+            "- **Control flow**: linear chain vs role-based coordination\n"
+            "- **Specialization**: one generalist vs multiple specialists\n"
+            "- **Quality control**: limited vs critique/refinement loops\n\n"
+            "## Benefits\n"
+            "- Better task decomposition and parallelism\n"
+            "- More robust outputs via review cycles\n\n"
+            "## Limitations & Failure Modes\n"
+            "- Higher latency and cost\n"
+            "- Coordination issues (loops, conflicts)\n"
+            "- Harder observability/debugging\n\n"
+            "## When to Use Which\n"
+            "- Single-agent: small, well-scoped tasks\n"
+            "- Multi-agent: complex tasks needing planning + review + structured output\n\n"
+            "## Conclusion\n"
+            "Multi-agent designs trade simplicity for controllability and output quality on complex workflows.\n"
+        )
+
+    async def _run_llm_report(self, context: ChannelMessageContext, text: str) -> str:
+        if self.mock_mode:
+            return self._mock_report()
+
+        try:
+            trajectory = await self.run_agent(
+                context=context,
+                instruction=(
+                    "IMPORTANT: Do NOT call any tools. Do NOT use tool/function calls. "
+                    "Return plain text only.\n\n"
+                    "Write a final Markdown report based on the input.\n"
+                    "Include sections: Overview, Key Differences, Benefits, Limitations & Failure Modes, When to Use Which, Conclusion.\n"
+                    "Return ONLY the Markdown.\n\n"
+                    f"Input:\n{text}"
+                ),
+            )
+            return _extract_llm_response(trajectory) or "# Report\n\n(No report generated)"
+        except Exception as e:
+            print(f"⚠️ Writer LLM error: {e}, using fallback")
+            return self._mock_report()
+
+    async def on_channel_post(self, context: ChannelMessageContext):
+        if context.channel != "pitch-room":
+            return
+        if getattr(context, "source_id", None) == self.agent_id:
+            return
+
+        incoming = _get_text_from_channel_event(context).strip()
+        if not incoming:
+            return
+
+        key = f"{context.channel}:{_event_id_or_hash(context, incoming)}"
+        if self._dedupe.seen(key):
+            return
+
+        run_id = _parse_run_id(incoming) or "unknown"
+        print(f"✍️ Writer processing (run_id={run_id})")
+
+        report = await self._run_llm_report(context, incoming)
+
+        # Output location (default: current working directory)
+        out_dir = os.getenv("OPENAGENTS_OUTPUT_DIR", "").strip()
+        base = Path(out_dir) if out_dir else Path.cwd()
+        base.mkdir(parents=True, exist_ok=True)
+
+        out_path = base / f"report_{run_id}.md"
+        out_path.write_text(report, encoding="utf-8")
+
+        ws = self.workspace()
+        await ws.channel("discussion").post(
+            "✅ "
+            f"RUN_ID: {run_id}\n"
+            f"✅ Report written to: {out_path}\n\n"
+            f"(Preview)\n{report[:900]}\n\n"
+            "Tip: open the full file for the complete report."
+        )
+
+        print(f"✅ Writer → #discussion (saved {out_path})")
+
+
+async def main():
+    import argparse
+    parser = argparse.ArgumentParser(description="Writer Agent (workspace API stable)")
+    parser.add_argument("--host", default="localhost")
+    parser.add_argument("--port", type=int, default=8700, help="HTTP port for connection (default: 8700)")
+    parser.add_argument("--url", default=None, help="Direct connection URL (recommended: grpc://localhost:8600)")
+    args = parser.parse_args()
+
+    agent = WriterAgent()
+    try:
+        if args.url:
+            print(f"🚀 Starting Writer with URL: {args.url}")
+            await agent.async_start(url=args.url)
+        else:
+            print(f"🚀 Starting Writer on http://{args.host}:{args.port}")
+            await agent.async_start(network_host=args.host, network_port=args.port)
+
+        while True:
+            await asyncio.sleep(1)
+
+    except KeyboardInterrupt:
+        print("\n👋 Writer shutting down...")
+    finally:
+        await agent.async_stop()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
## Summary
This PR adds a complete multi-agent research team demo built with OpenAgents.

It follows the maintainer’s suggestion in #523  by providing a self-contained tutorial and working example instead of just listing the framework.

## Features
- Planner / Researcher / Critic / Writer agents
- Channel-based orchestration
- Default network.yaml (no modifications)
- Markdown report output

## Motivation
Provide a minimal reproducible multi-agent orchestration example aligned with the repo’s focus on working tutorials.