### PR TITLE
Add OpenVoiceUI to Voice AI Agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ A curated collection of **Awesome LLM apps built with RAG, AI Agents, Multi-agen
 *   [📞 Customer Support Voice Agent](voice_ai_agents/customer_support_voice_agent/)
 *   [🔊 Voice RAG Agent (OpenAI SDK)](voice_ai_agents/voice_rag_openaisdk/)
 *   [🎙️ OpenSource Voice Dictation Agent (like Wispr Flow](https://github.com/akshayaggarwal99/jarvis-ai-assistant)
+*   [🎤 OpenVoiceUI — Voice AI Assistant Platform](https://github.com/MCERQUA/OpenVoiceUI) - Connect any LLM, TTS, and STT with a live web canvas, music generation, and agent orchestration. Install with `npx openvoiceui setup`.
 
 ### <img src="https://cdn.simpleicons.org/modelcontextprotocol"  alt="mcp logo" width="25" height="20"> MCP AI Agents 
 


### PR DESCRIPTION
## Summary

Adds [OpenVoiceUI](https://github.com/MCERQUA/OpenVoiceUI) to the **Voice AI Agents** section.

**OpenVoiceUI** is an open-source (MIT) voice-powered AI assistant platform that lets you connect any LLM, any TTS engine, and any STT provider through a unified interface. It includes a live web canvas for visual content, music generation via Suno, and multi-agent orchestration.

- **GitHub:** https://github.com/MCERQUA/OpenVoiceUI
- **npm:** https://www.npmjs.com/package/openvoiceui
- **Install:** `npx openvoiceui setup`
- **License:** MIT

It fits naturally alongside the existing voice agent projects in this section, as it provides a full platform for building voice-first AI experiences.