### PR TITLE
Add Fazm - voice-controlled macOS AI agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,8 +157,9 @@ A curated collection of **Awesome LLM apps built with RAG, AI Agents, Multi-agen
 *   [📞 Customer Support Voice Agent](voice_ai_agents/customer_support_voice_agent/)
 *   [🔊 Voice RAG Agent (OpenAI SDK)](voice_ai_agents/voice_rag_openaisdk/)
 *   [🎙️ OpenSource Voice Dictation Agent (like Wispr Flow](https://github.com/akshayaggarwal99/jarvis-ai-assistant)
+*   [🖥️ Fazm - Voice-Controlled macOS AI Agent](https://github.com/m13v/fazm)
 
-### <img src="https://cdn.simpleicons.org/modelcontextprotocol"  alt="mcp logo" width="25" height="20"> MCP AI Agents 
+### <img src="https://cdn.simpleicons.org/modelcontextprotocol"  alt="mcp logo" width="25" height="20"> MCP AI Agents
 
 *   [♾️ Browser MCP Agent](mcp_ai_agents/browser_mcp_agent/)
 *   [🐙 GitHub MCP Agent](mcp_ai_agents/github_mcp_agent/)


### PR DESCRIPTION
Added [Fazm](https://github.com/m13v/fazm) to the Voice AI Agents section.

Fazm is an open-source (MIT) voice-controlled AI agent for macOS built in Swift/SwiftUI. It uses WhisperKit for on-device voice transcription and LLMs to understand and execute desktop tasks through natural language.

Website: https://fazm.ai