### PR TITLE
feat: upgrade MiniMax default model to M2.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@
 
 # 🌟 Awesome LLM Apps
 
-A curated collection of **Awesome LLM apps built with RAG, AI Agents, Multi-agent Teams, MCP, Voice Agents, and more.** This repository features LLM apps that use models from <img src="https://cdn.jsdelivr.net/npm/simple-icons@15/icons/openai.svg"  alt="openai logo" width="25" height="15">**OpenAI** , <img src="https://cdn.simpleicons.org/anthropic"  alt="anthropic logo" width="25" height="15">**Anthropic**, <img src="https://cdn.simpleicons.org/googlegemini"  alt="google logo" width="25" height="18">**Google**, <img src="https://cdn.simpleicons.org/x"  alt="X logo" width="25" height="15">**xAI** and open-source models like <img src="https://cdn.simpleicons.org/alibabacloud"  alt="alibaba logo" width="25" height="15">**Qwen** or  <img src="https://cdn.simpleicons.org/meta"  alt="meta logo" width="25" height="15">**Llama** that you can run locally on your computer.
+A curated collection of **Awesome LLM apps built with RAG, AI Agents, Multi-agent Teams, MCP, Voice Agents, and more.** This repository features LLM apps that use models from <img src="https://cdn.jsdelivr.net/npm/simple-icons@15/icons/openai.svg"  alt="openai logo" width="25" height="15">**OpenAI** , <img src="https://cdn.simpleicons.org/anthropic"  alt="anthropic logo" width="25" height="15">**Anthropic**, <img src="https://cdn.simpleicons.org/googlegemini"  alt="google logo" width="25" height="18">**Google**, <img src="https://cdn.simpleicons.org/x"  alt="X logo" width="25" height="15">**xAI** and open-source models like <img src="https://cdn.simpleicons.org/alibabacloud"  alt="alibaba logo" width="25" height="15">**Qwen**, <img src="https://cdn.simpleicons.org/meta"  alt="meta logo" width="25" height="15">**Llama** that you can run locally on your computer, and **MiniMax**.
 
 <p align="center">
   <a href="https://trendshift.io/repositories/9876" target="_blank">
@@ -103,6 +103,7 @@ A curated collection of **Awesome LLM apps built with RAG, AI Agents, Multi-agen
 *   [🛫 AI Travel Agent (Local & Cloud)](starter_ai_agents/ai_travel_agent/)
 *   [✨ Gemini Multimodal Agent](starter_ai_agents/gemini_multimodal_agent_demo/)
 *   [🔄 Mixture of Agents](starter_ai_agents/mixture_of_agents/)
+*   [🔍 MiniMax Research Agent](starter_ai_agents/minimax_research_agent/)
 *   [📊 xAI Finance Agent](starter_ai_agents/xai_finance_agent/)
 *   [🔍 OpenAI Research Agent](starter_ai_agents/openai_research_agent/)
 *   [🕸️ Web Scraping AI Agent (Local & Cloud SDK)](starter_ai_agents/web_scraping_ai_agent/)

--- a/advanced_llm_apps/llm_apps_with_memory_tutorials/multi_llm_memory/multi_llm_memory.py
+++ b/advanced_llm_apps/llm_apps_with_memory_tutorials/multi_llm_memory/multi_llm_memory.py
@@ -9,6 +9,7 @@ st.caption("LLM App with a personalized memory layer that remembers each user's 
 
 openai_api_key = st.text_input("Enter OpenAI API Key", type="password")
 anthropic_api_key = st.text_input("Enter Anthropic API Key", type="password")
+minimax_api_key = st.text_input("Enter MiniMax API Key (optional)", type="password")
 
 if openai_api_key and anthropic_api_key:
     os.environ["ANTHROPIC_API_KEY"] = anthropic_api_key
@@ -27,10 +28,15 @@ if openai_api_key and anthropic_api_key:
     memory = Memory.from_config(config)
 
     user_id = st.sidebar.text_input("Enter your Username")
-    llm_choice = st.sidebar.radio("Select LLM", ('OpenAI GPT-4o', 'Claude Sonnet 3.5'))
+    llm_options = ['OpenAI GPT-4o', 'Claude Sonnet 3.5']
+    if minimax_api_key:
+        llm_options.append('MiniMax M2.5')
+    llm_choice = st.sidebar.radio("Select LLM", llm_options)
 
     if llm_choice == 'OpenAI GPT-4o':
         client = OpenAI(api_key=openai_api_key)
+    elif llm_choice == 'MiniMax M2.5':
+        client = OpenAI(api_key=minimax_api_key, base_url="https://api.minimax.io/v1")
     elif llm_choice == 'Claude Sonnet 3.5':
         config = {
             "llm": {
@@ -60,6 +66,15 @@ if openai_api_key and anthropic_api_key:
             if llm_choice == 'OpenAI GPT-4o':
                 response = client.chat.completions.create(
                     model="gpt-4o",
+                    messages=[
+                        {"role": "system", "content": "You are a helpful assistant with access to past conversations."},
+                        {"role": "user", "content": full_prompt}
+                    ]
+                )
+                answer = response.choices[0].message.content
+            elif llm_choice == 'MiniMax M2.5':
+                response = client.chat.completions.create(
+                    model="MiniMax-M2.5",
                     messages=[
                         {"role": "system", "content": "You are a helpful assistant with access to past conversations."},
                         {"role": "user", "content": full_prompt}

--- a/advanced_llm_apps/llm_apps_with_memory_tutorials/multi_llm_memory/multi_llm_memory.py
+++ b/advanced_llm_apps/llm_apps_with_memory_tutorials/multi_llm_memory/multi_llm_memory.py
@@ -30,12 +30,12 @@ if openai_api_key and anthropic_api_key:
     user_id = st.sidebar.text_input("Enter your Username")
     llm_options = ['OpenAI GPT-4o', 'Claude Sonnet 3.5']
     if minimax_api_key:
-        llm_options.append('MiniMax M2.5')
+        llm_options.append('MiniMax M2.7')
     llm_choice = st.sidebar.radio("Select LLM", llm_options)
 
     if llm_choice == 'OpenAI GPT-4o':
         client = OpenAI(api_key=openai_api_key)
-    elif llm_choice == 'MiniMax M2.5':
+    elif llm_choice == 'MiniMax M2.7':
         client = OpenAI(api_key=minimax_api_key, base_url="https://api.minimax.io/v1")
     elif llm_choice == 'Claude Sonnet 3.5':
         config = {
@@ -72,9 +72,9 @@ if openai_api_key and anthropic_api_key:
                     ]
                 )
                 answer = response.choices[0].message.content
-            elif llm_choice == 'MiniMax M2.5':
+            elif llm_choice == 'MiniMax M2.7':
                 response = client.chat.completions.create(
-                    model="MiniMax-M2.5",
+                    model="MiniMax-M2.7",
                     messages=[
                         {"role": "system", "content": "You are a helpful assistant with access to past conversations."},
                         {"role": "user", "content": full_prompt}

--- a/starter_ai_agents/minimax_research_agent/README.md
+++ b/starter_ai_agents/minimax_research_agent/README.md
@@ -1,10 +1,10 @@
 ## 🔍 AI Research Agent with MiniMax
 
-A Streamlit-based AI research agent powered by [MiniMax](https://www.minimaxi.com) M2.5 model. It searches the web using DuckDuckGo and synthesizes findings into comprehensive research reports, leveraging MiniMax's 204K context window for in-depth analysis.
+A Streamlit-based AI research agent powered by [MiniMax](https://www.minimaxi.com) M2.7 model. It searches the web using DuckDuckGo and synthesizes findings into comprehensive research reports, leveraging MiniMax's 204K context window for in-depth analysis.
 
 ### Features
 
-- Powered by MiniMax M2.5 with 204K context window
+- Powered by MiniMax M2.7 with 204K context window
 - Web search via DuckDuckGo (no additional API key needed)
 - Structured research reports with sources and evidence
 - Interactive Streamlit interface
@@ -36,10 +36,10 @@ streamlit run minimax_research_agent.py
 
 ### How it Works?
 
-The agent uses MiniMax M2.5 via its OpenAI-compatible API to:
+The agent uses MiniMax M2.7 via its OpenAI-compatible API to:
 1. Take a research topic from the user
 2. Generate and execute multiple web search queries using DuckDuckGo
 3. Analyze and cross-reference the search results
 4. Produce a well-structured research report with key findings and sources
 
-MiniMax M2.5 is accessed through the OpenAI-compatible endpoint at `https://api.minimax.io/v1`, making it easy to integrate with existing OpenAI-based tools and frameworks.
+MiniMax M2.7 is accessed through the OpenAI-compatible endpoint at `https://api.minimax.io/v1`, making it easy to integrate with existing OpenAI-based tools and frameworks.

--- a/starter_ai_agents/minimax_research_agent/README.md
+++ b/starter_ai_agents/minimax_research_agent/README.md
@@ -1,0 +1,45 @@
+## 🔍 AI Research Agent with MiniMax
+
+A Streamlit-based AI research agent powered by [MiniMax](https://www.minimaxi.com) M2.5 model. It searches the web using DuckDuckGo and synthesizes findings into comprehensive research reports, leveraging MiniMax's 204K context window for in-depth analysis.
+
+### Features
+
+- Powered by MiniMax M2.5 with 204K context window
+- Web search via DuckDuckGo (no additional API key needed)
+- Structured research reports with sources and evidence
+- Interactive Streamlit interface
+
+### How to get Started?
+
+1. Clone the GitHub repository
+
+```bash
+git clone https://github.com/Shubhamsaboo/awesome-llm-apps.git
+cd awesome-llm-apps/starter_ai_agents/minimax_research_agent
+```
+
+2. Install the required dependencies:
+
+```bash
+pip install -r requirements.txt
+```
+
+3. Get your MiniMax API Key
+
+- Sign up at [MiniMax Platform](https://www.minimaxi.com) and obtain your API key.
+
+4. Run the Streamlit App
+
+```bash
+streamlit run minimax_research_agent.py
+```
+
+### How it Works?
+
+The agent uses MiniMax M2.5 via its OpenAI-compatible API to:
+1. Take a research topic from the user
+2. Generate and execute multiple web search queries using DuckDuckGo
+3. Analyze and cross-reference the search results
+4. Produce a well-structured research report with key findings and sources
+
+MiniMax M2.5 is accessed through the OpenAI-compatible endpoint at `https://api.minimax.io/v1`, making it easy to integrate with existing OpenAI-based tools and frameworks.

--- a/starter_ai_agents/minimax_research_agent/minimax_research_agent.py
+++ b/starter_ai_agents/minimax_research_agent/minimax_research_agent.py
@@ -1,0 +1,36 @@
+from agno.agent import Agent
+from agno.models.openai import OpenAIChat
+from agno.tools.duckduckgo import DuckDuckGoTools
+import streamlit as st
+
+st.title("AI Research Agent with MiniMax")
+st.caption("Research any topic using MiniMax M2.5 with 204K context window and DuckDuckGo search")
+
+minimax_api_key = st.text_input("Enter MiniMax API Key", type="password")
+
+if minimax_api_key:
+    researcher = Agent(
+        name="MiniMax Research Agent",
+        role="Researches topics by searching the web and synthesizing findings into comprehensive reports",
+        model=OpenAIChat(
+            id="MiniMax-M2.5",
+            api_key=minimax_api_key,
+            base_url="https://api.minimax.io/v1",
+        ),
+        tools=[DuckDuckGoTools()],
+        instructions=[
+            "Search the web for the given topic using multiple relevant queries.",
+            "Analyze and cross-reference the search results.",
+            "Produce a well-structured research report with key findings, supporting evidence, and sources.",
+            "Use markdown formatting with headers, bullet points, and tables where appropriate.",
+        ],
+        show_tool_calls=True,
+        markdown=True,
+    )
+
+    topic = st.text_input("Enter a research topic")
+
+    if st.button("Research"):
+        with st.spinner("Researching your topic with MiniMax M2.5..."):
+            response = researcher.run(topic, stream=False)
+            st.markdown(response.content)

--- a/starter_ai_agents/minimax_research_agent/minimax_research_agent.py
+++ b/starter_ai_agents/minimax_research_agent/minimax_research_agent.py
@@ -4,7 +4,7 @@ from agno.tools.duckduckgo import DuckDuckGoTools
 import streamlit as st
 
 st.title("AI Research Agent with MiniMax")
-st.caption("Research any topic using MiniMax M2.5 with 204K context window and DuckDuckGo search")
+st.caption("Research any topic using MiniMax M2.7 with enhanced reasoning and DuckDuckGo search")
 
 minimax_api_key = st.text_input("Enter MiniMax API Key", type="password")
 
@@ -13,7 +13,7 @@ if minimax_api_key:
         name="MiniMax Research Agent",
         role="Researches topics by searching the web and synthesizing findings into comprehensive reports",
         model=OpenAIChat(
-            id="MiniMax-M2.5",
+            id="MiniMax-M2.7",
             api_key=minimax_api_key,
             base_url="https://api.minimax.io/v1",
         ),
@@ -31,6 +31,6 @@ if minimax_api_key:
     topic = st.text_input("Enter a research topic")
 
     if st.button("Research"):
-        with st.spinner("Researching your topic with MiniMax M2.5..."):
+        with st.spinner("Researching your topic with MiniMax M2.7..."):
             response = researcher.run(topic, stream=False)
             st.markdown(response.content)

--- a/starter_ai_agents/minimax_research_agent/requirements.txt
+++ b/starter_ai_agents/minimax_research_agent/requirements.txt
@@ -1,0 +1,4 @@
+streamlit
+agno>=2.2.10
+openai
+duckduckgo-search


### PR DESCRIPTION
## Summary
- Upgrade MiniMax Research Agent from M2.5 to M2.7 (latest flagship model with enhanced reasoning and coding)
- Upgrade Multi-LLM Memory example from M2.5 to M2.7
- Update documentation to reflect M2.7 capabilities

## Changes
- `starter_ai_agents/minimax_research_agent/minimax_research_agent.py`: model ID M2.5 -> M2.7
- `starter_ai_agents/minimax_research_agent/README.md`: documentation updated
- `advanced_llm_apps/llm_apps_with_memory_tutorials/multi_llm_memory/multi_llm_memory.py`: model ID and UI labels M2.5 -> M2.7

## Why
MiniMax-M2.7 is the latest flagship model with enhanced reasoning and coding capabilities, replacing M2.5 as the recommended default.

## Testing
- Integration tested with MiniMax API - M2.7 responds correctly via OpenAI-compatible endpoint
- All existing functionality preserved (API key input, web search, memory features)