### PR TITLE
add RetainDB persistent cross-session memory chatbot

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,7 @@ A curated collection of **Awesome LLM apps built with RAG, AI Agents, Multi-agen
 *   [📝 LLM App with Personalized Memory](advanced_llm_apps/llm_apps_with_memory_tutorials/llm_app_personalized_memory/)
 *   [🗄️ Local ChatGPT Clone with Memory](advanced_llm_apps/llm_apps_with_memory_tutorials/local_chatgpt_with_memory/)
 *   [🧠 Multi-LLM Application with Shared Memory](advanced_llm_apps/llm_apps_with_memory_tutorials/multi_llm_memory/)
+*   [🔁 LLM App with Persistent Cross-Session Memory (RetainDB)](advanced_llm_apps/llm_apps_with_memory_tutorials/retaindb_persistent_memory/)
 
 
 ### 💬 Chat with X Tutorials

--- a/advanced_llm_apps/llm_apps_with_memory_tutorials/retaindb_persistent_memory/README.md
+++ b/advanced_llm_apps/llm_apps_with_memory_tutorials/retaindb_persistent_memory/README.md
@@ -1,0 +1,62 @@
+# LLM App with Persistent Memory using RetainDB
+
+A Streamlit chatbot that **remembers users across sessions** using [RetainDB](https://retaindb.com) — a persistent memory API for AI agents.
+
+Unlike in-memory solutions (which reset on every page refresh or server restart), RetainDB stores memories in the cloud. Come back tomorrow, open a new tab, or redeploy your app — the AI still knows who you are.
+
+## Features
+
+- 💾 **Cross-session memory** — memories survive restarts and redeployments
+- 🔍 **Semantic retrieval** — finds relevant past context, not just recent messages
+- ⚡ **Fast** — 13ms avg retrieval latency globally
+- 🔑 **Simple API** — two REST calls: `POST /v1/context/query` to retrieve, `POST /v1/learn` to store
+
+## How it works
+
+```
+User sends message
+       │
+       ▼
+POST /v1/context/query  ──► RetainDB retrieves relevant past memories
+       │
+       ▼
+GPT-4o-mini (with memories injected as system context)
+       │
+       ▼
+POST /v1/learn  ──► Stores the conversation turn for future sessions
+```
+
+## Setup
+
+### 1. Get API keys
+
+- **RetainDB**: free key at [retaindb.com](https://retaindb.com)
+- **OpenAI**: key at [platform.openai.com](https://platform.openai.com)
+
+### 2. Install dependencies
+
+```bash
+pip install -r requirements.txt
+```
+
+### 3. Run
+
+```bash
+streamlit run retaindb_memory_app.py
+```
+
+Open http://localhost:8501, enter your API keys, and start chatting.
+
+## Test cross-session memory
+
+1. Tell the AI something: *"My name is Alex and I'm building a SaaS in TypeScript"*
+2. Refresh the page (clears the session-level chat history)
+3. Ask: *"What do you know about me?"*
+
+The AI will recall what you told it — because the memory lives in RetainDB, not in the browser tab.
+
+## Learn more
+
+- [RetainDB docs](https://retaindb.com/docs)
+- [LongMemEval benchmark](https://retaindb.com/benchmark) — 88% preference recall (SOTA)
+- [npm SDK](https://www.npmjs.com/package/@retaindb/sdk) — for Node.js / TypeScript apps

--- a/advanced_llm_apps/llm_apps_with_memory_tutorials/retaindb_persistent_memory/requirements.txt
+++ b/advanced_llm_apps/llm_apps_with_memory_tutorials/retaindb_persistent_memory/requirements.txt
@@ -1,0 +1,3 @@
+streamlit
+openai
+requests

--- a/advanced_llm_apps/llm_apps_with_memory_tutorials/retaindb_persistent_memory/retaindb_memory_app.py
+++ b/advanced_llm_apps/llm_apps_with_memory_tutorials/retaindb_persistent_memory/retaindb_memory_app.py
@@ -1,0 +1,127 @@
+import os
+import requests
+import streamlit as st
+from openai import OpenAI
+
+st.title("LLM App with Persistent Memory 🧠")
+st.caption(
+    "AI chatbot powered by RetainDB — memories persist across sessions, "
+    "browser refreshes, and server restarts."
+)
+
+# ── API keys ──────────────────────────────────────────────────────────────────
+openai_api_key = st.text_input("OpenAI API Key", type="password")
+retaindb_api_key = st.text_input("RetainDB API Key — get free at retaindb.com", type="password")
+
+RETAINDB_BASE = "https://api.retaindb.com"
+
+def retaindb_headers():
+    return {
+        "Authorization": f"Bearer {retaindb_api_key}",
+        "Content-Type": "application/json",
+    }
+
+def get_context(user_id: str, query: str) -> str:
+    """Retrieve relevant memories for this user and query."""
+    resp = requests.post(
+        f"{RETAINDB_BASE}/v1/context/query",
+        headers=retaindb_headers(),
+        json={
+            "query": query,
+            "user_id": user_id,
+            "top_k": 8,
+            "include_memories": True,
+        },
+        timeout=10,
+    )
+    if resp.ok:
+        return resp.json().get("context", "")
+    return ""
+
+def remember(user_id: str, messages: list):
+    """Store the conversation turn so future sessions can recall it."""
+    requests.post(
+        f"{RETAINDB_BASE}/v1/learn",
+        headers=retaindb_headers(),
+        json={
+            "mode": "conversation",
+            "user_id": user_id,
+            "messages": messages,
+        },
+        timeout=10,
+    )
+
+def get_all_memories(user_id: str) -> list:
+    """List all stored memories for this user."""
+    resp = requests.get(
+        f"{RETAINDB_BASE}/v1/memories",
+        headers=retaindb_headers(),
+        params={"user_id": user_id, "limit": 50},
+        timeout=10,
+    )
+    if resp.ok:
+        return resp.json().get("memories", [])
+    return []
+
+
+# ── Chat UI ───────────────────────────────────────────────────────────────────
+if openai_api_key and retaindb_api_key:
+    openai_client = OpenAI(api_key=openai_api_key)
+
+    user_id = st.text_input("Username (used to scope your memories)", value="demo_user")
+
+    # Session-level chat history (display only — real persistence is in RetainDB)
+    if "messages" not in st.session_state:
+        st.session_state.messages = []
+
+    for msg in st.session_state.messages:
+        with st.chat_message(msg["role"]):
+            st.write(msg["content"])
+
+    prompt = st.chat_input("Say something…")
+
+    if prompt and user_id:
+        st.session_state.messages.append({"role": "user", "content": prompt})
+        with st.chat_message("user"):
+            st.write(prompt)
+
+        with st.chat_message("assistant"):
+            with st.spinner("Recalling memories…"):
+                # 1. Retrieve relevant memories
+                context = get_context(user_id, prompt)
+
+            system_prompt = "You are a helpful personal assistant with persistent memory."
+            if context:
+                system_prompt += f"\n\nWhat you know about this user:\n{context}"
+
+            # 2. Generate response
+            response = openai_client.chat.completions.create(
+                model="gpt-4o-mini",
+                messages=[
+                    {"role": "system", "content": system_prompt},
+                    *st.session_state.messages,
+                ],
+            )
+            reply = response.choices[0].message.content
+            st.write(reply)
+
+        st.session_state.messages.append({"role": "assistant", "content": reply})
+
+        # 3. Store the turn in RetainDB (fire-and-forget)
+        remember(user_id, [
+            {"role": "user", "content": prompt},
+            {"role": "assistant", "content": reply},
+        ])
+
+    # ── Sidebar: view stored memories ─────────────────────────────────────────
+    st.sidebar.title("🧠 Memory Store")
+    st.sidebar.caption(f"Memories for: **{user_id}**")
+    if st.sidebar.button("Load Memories"):
+        memories = get_all_memories(user_id)
+        if memories:
+            for mem in memories:
+                st.sidebar.markdown(f"- {mem.get('content', '')}")
+        else:
+            st.sidebar.info("No memories found yet — start chatting!")
+else:
+    st.info("Enter your API keys above to start chatting.")


### PR DESCRIPTION
Adds a Streamlit chatbot demo using RetainDB for persistent cross-session memory.

Unlike in-memory solutions that reset on page refresh or restart, RetainDB stores memories in the cloud — users are remembered across sessions, redeployments, and server restarts.

**Files added:**
- `retaindb_memory_app.py` — Streamlit chatbot using OpenAI + RetainDB REST API
- `requirements.txt` — `streamlit`, `openai`, `requests` (no heavy deps)
- `README.md` — setup guide + cross-session memory demo walkthrough

**How it differs from existing memory examples:**
The existing mem0 example requires a local Qdrant instance. This example uses RetainDB's hosted API — no vector DB to run, no infrastructure to manage, free tier available at retaindb.com.

RetainDB scores 88% on preference recall (SOTA on LongMemEval, +18pp over next best).