### PR TITLE
Add Bitcoin MCP Server to MCP AI Agents section

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,7 @@ A curated collection of **Awesome LLM apps built with RAG, AI Agents, Multi-agen
 *   [📑 Notion MCP Agent](mcp_ai_agents/notion_mcp_agent) 
 *   [🌍 AI Travel Planner MCP Agent](mcp_ai_agents/ai_travel_planner_mcp_agent_team)
 *   [🔀 Multi-MCP Agent Router](mcp_ai_agents/multi_mcp_agent_router/)
+*   [₿ Bitcoin MCP Server](https://github.com/Bortlesboat/bitcoin-mcp)
 
 ### 📀 RAG (Retrieval Augmented Generation)
 *   [🔥 Agentic RAG with Embedding Gemma](rag_tutorials/agentic_rag_embedding_gemma)


### PR DESCRIPTION
## Summary

- Adds [bitcoin-mcp](https://github.com/Bortlesboat/bitcoin-mcp) to the MCP AI Agents section
- Bitcoin MCP server with 49 tools for AI agents: fees, mempool, blocks, transactions, mining, price, and supply
- Listed on the [Anthropic MCP Registry](https://github.com/modelcontextprotocol/servers), MIT licensed, available on PyPI (`bitcoin-mcp`)
- Zero config — works instantly with Claude, Cursor, VS Code, and Windsurf