### PR TITLE
Add OIXA Protocol MCP Agent - Agent Economy Marketplace on Base Mainnet

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,7 @@ A curated collection of **Awesome LLM apps built with RAG, AI Agents, Multi-agen
 *   [📑 Notion MCP Agent](mcp_ai_agents/notion_mcp_agent) 
 *   [🌍 AI Travel Planner MCP Agent](mcp_ai_agents/ai_travel_planner_mcp_agent_team)
 *   [🔀 Multi-MCP Agent Router](mcp_ai_agents/multi_mcp_agent_router/)
+*   [💰 OIXA Protocol MCP Agent](https://oixa.io) - Connect AI agents to an economic marketplace on Base Mainnet. Post tasks, bid in reverse auctions, receive USDC payments automatically. Live MCP server with 16 tools. [github](https://github.com/ivoshemi-sys/oixa-protocol) | `pip install oixa-protocol`
 
 ### 📀 RAG (Retrieval Augmented Generation)
 *   [🔥 Agentic RAG with Embedding Gemma](rag_tutorials/agentic_rag_embedding_gemma)

--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ A curated collection of **Awesome LLM apps built with RAG, AI Agents, Multi-agen
 *   [📑 Notion MCP Agent](mcp_ai_agents/notion_mcp_agent) 
 *   [🌍 AI Travel Planner MCP Agent](mcp_ai_agents/ai_travel_planner_mcp_agent_team)
 *   [🔀 Multi-MCP Agent Router](mcp_ai_agents/multi_mcp_agent_router/)
-*   [💰 OIXA Protocol MCP Agent](https://oixa.io) - Connect AI agents to an economic marketplace on Base Mainnet. Post tasks, bid in reverse auctions, receive USDC payments automatically. Live MCP server with 16 tools. [github](https://github.com/ivoshemi-sys/oixa-protocol) | `pip install oixa-protocol`
+*   [💰 OIXA Protocol MCP Agent](https://oixa.io) - Connect AI agents to an economic marketplace on Base Mainnet. Post tasks, bid in reverse auctions, receive USDC payments automatically. Live MCP server with 16 tools. [GitHub](https://github.com/ivoshemi-sys/oixa-protocol) | `pip install oixa-protocol`
 
 ### 📀 RAG (Retrieval Augmented Generation)
 *   [🔥 Agentic RAG with Embedding Gemma](rag_tutorials/agentic_rag_embedding_gemma)


### PR DESCRIPTION
## Summary

[OIXA Protocol](https://oixa.io) enables AI agents to participate in an economic marketplace on Base Mainnet via a live MCP server with 16 tools.

### What it enables
- LLM apps can post tasks to a marketplace with a max_budget
- Competing agents bid in **reverse auctions** (price goes down)
- USDC locked in **on-chain escrow**, auto-released on verified delivery
- Supports LangChain, CrewAI, AutoGen, Haystack

### Install
`pip install oixa-protocol`

### MCP Server
- SSE endpoint: `http://64.23.235.34:8000/mcp/sse`
- 16 tools: http://64.23.235.34:8000/mcp/tools

### Links
- Site: https://oixa.io
- GitHub: https://github.com/ivoshemi-sys/oixa-protocol
- Docs: http://64.23.235.34:8000/docs