### PR TITLE
Add AI Trading Agent with Adversarial Debate (9 ML Models + Bull/Bear Pipeline)

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ A curated collection of **Awesome LLM apps built with RAG, AI Agents, Multi-agen
 
 *   [🧲 AI Competitor Intelligence Agent Team](advanced_ai_agents/multi_agent_apps/agent_teams/ai_competitor_intelligence_agent_team/)
 *   [💲 AI Finance Agent Team](advanced_ai_agents/multi_agent_apps/agent_teams/ai_finance_agent_team/)
+*   [📈 AI Trading Agent with Adversarial Debate](https://github.com/alex-jb/orallexa-ai-trading-agent)
 *   [🎨 AI Game Design Agent Team](advanced_ai_agents/multi_agent_apps/agent_teams/ai_game_design_agent_team/)
 *   [🧭 AG2 Adaptive Research Team](advanced_ai_agents/multi_agent_apps/agent_teams/ag2_adaptive_research_team/)
 *   [👨‍⚖️ AI Legal Agent Team (Cloud & Local)](advanced_ai_agents/multi_agent_apps/agent_teams/ai_legal_agent_team/)


### PR DESCRIPTION
Adds **Orallexa** to the Multi-Agent / Agent Teams section — an AI trading agent that uses adversarial debate for decision-making.

## What it does

- **9 ML models** (RF, XGB, EMAformer, MOIRAI-2, Chronos-2, DDPM, PPO RL, GNN, LR) scored by Sharpe ratio
- **Multi-agent adversarial debate** — Bull AI argues for the trade, Bear AI argues against, Judge AI decides
- **Dual-tier LLM routing** — Haiku for 80% of calls (~$0.001), Sonnet for reasoning (~$0.005)
- **Full-stack**: FastAPI backend + Next.js 16 dashboard + desktop pixel bull agent
- **Paper trading** via Alpaca with bracket orders (stop-loss + take-profit)
- **Daily intelligence** — 50+ tickers, sector rotation, volume spikes, AI morning brief
- **277 automated tests**, CI/CD, Docker, live demo

## Links

- **Repository**: https://github.com/alex-jb/orallexa-ai-trading-agent
- **Live Demo**: https://orallexa-ui.vercel.app
- **Tech**: Python, Claude Sonnet 4.6 + Haiku 4.5, LangGraph, Next.js, PyTorch

Placed next to the existing "AI Finance Agent Team" entry since it's a multi-agent finance application.