### PR TITLE
fix: upgrade h11 to 0.16.0 (CVE-2025-43859)

### DIFF
--- a/advanced_ai_agents/autonomous_game_playing_agent_apps/ai_tic_tac_toe_agent/requirements.txt
+++ b/advanced_ai_agents/autonomous_game_playing_agent_apps/ai_tic_tac_toe_agent/requirements.txt
@@ -57,7 +57,7 @@ google-genai==1.3.0
     # via -r cookbook/examples/apps/tic_tac_toe/requirements.in
 groq==0.18.0
     # via -r cookbook/examples/apps/tic_tac_toe/requirements.in
-h11==0.14.0
+h11==0.16.0
     # via httpcore
 httpcore==1.0.7
     # via httpx


### PR DESCRIPTION
## Summary
Upgrade h11 from 0.14.0 to 0.16.0 to fix CVE-2025-43859.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | CVE-2025-43859 |
| **Severity** | CRITICAL |
| **Scanner** | trivy |
| **Rule** | `CVE-2025-43859` |
| **File** | `advanced_ai_agents/autonomous_game_playing_agent_apps/ai_tic_tac_toe_agent/requirements.txt` |

**Description**: h11: h11 accepts some malformed Chunked-Encoding bodies

## Changes
- `advanced_ai_agents/autonomous_game_playing_agent_apps/ai_tic_tac_toe_agent/requirements.txt`

## Verification
- [ ] Build not verified
- [ ] Scanner re-scan not performed
- [ ] LLM code review not performed

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
