### PR TITLE
Add x402 Agent Kit to Advanced AI Agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ A curated collection of **Awesome LLM apps built with RAG, AI Agents, Multi-agen
 *   [🧬 AI Self-Evolving Agent](advanced_ai_agents/multi_agent_apps/ai_self_evolving_agent/)
 *   [👨🏻‍💼 AI Sales Intelligence Agent Team](advanced_ai_agents/multi_agent_apps/agent_teams/ai_sales_intelligence_agent_team)
 *   [🎧 AI Social Media News and Podcast Agent](advanced_ai_agents/multi_agent_apps/ai_news_and_podcast_agents/)
+*   [💸 x402 Agent Kit](https://github.com/hypeprinter007-stack/x402-agent-kit) - Python SDK that lets AI agents pay for any API with USDC on Base using the x402 protocol
 *   [🌐 Openwork - Open Browser Automation Agent](https://github.com/accomplish-ai/openwork)
 
 ### 🎮 Autonomous Game Playing Agents


### PR DESCRIPTION
## Summary

- Adds [x402 Agent Kit](https://github.com/hypeprinter007-stack/x402-agent-kit) to the **Advanced AI Agents** section
- Python SDK that lets AI agents pay for any API with USDC on Base using the x402 protocol — enabling autonomous agent-to-service payments

## Details

x402 Agent Kit provides a simple Python interface for AI agents to make HTTP-native payments via the [x402 payment protocol](https://www.x402.org/). It wraps USDC transactions on Base so agents can autonomously pay for APIs, data feeds, and services without human intervention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)