### PR TITLE
Add Master-skill: Chinese Buddhist master AI teaching personas with RAG

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,6 +237,7 @@ A curated collection of **Awesome LLM apps built with RAG, AI Agents, Multi-agen
 ### 🧩 Awesome Agent Skills
 
 *   [♾️ Self-Improving Agent Skills](awesome_agent_skills/self-improving-agent-skills/) - Automatically optimize agent skills using Gemini and ADK
+*   [🧘 Master-skill](https://github.com/xr843/Master-skill) - Chinese Buddhist master AI teaching personas with RAG-powered CBETA source citations. 8 pre-built masters across 7 Buddhist traditions, powered by FoJin's 500+ source corpus.
 
 ## 🚀 Getting Started
 


### PR DESCRIPTION
## What is Master-skill?

[Master-skill](https://github.com/xr843/Master-skill) is an LLM app that creates AI teaching personas of Chinese Buddhist masters, powered by RAG with citations from CBETA (Chinese Buddhist Electronic Text Association).

## Key features

- 8 pre-built master personas across 7 Buddhist traditions (Chan, Pure Land, Tiantai, Huayan, Yogacara, Vinaya, Esoteric)
- RAG-powered answers with source citations from FoJin's 500+ Buddhist text corpus
- Each master responds in their authentic doctrinal style and language

## Why it fits this list

This project demonstrates a domain-specific RAG application with multiple AI agent personas — directly relevant to the RAG and AI Agents categories in this collection.