### PR TITLE
Add FERPA-compliant RAG pipeline tutorial

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,7 @@ A curated collection of **Awesome LLM apps built with RAG, AI Agents, Multi-agen
 *   [🔀 Multi-MCP Agent Router](mcp_ai_agents/multi_mcp_agent_router/)
 
 ### 📀 RAG (Retrieval Augmented Generation)
+*   [🔒 FERPA-Compliant RAG Pipeline](rag_tutorials/ferpa_compliant_rag/) - Identity-scoped pre-filtering for regulated higher-education AI; two-layer enforcement + 34 CFR § 99.32 audit logging
 *   [🔥 Agentic RAG with Embedding Gemma](rag_tutorials/agentic_rag_embedding_gemma)
 *   [🧐 Agentic RAG with Reasoning](rag_tutorials/agentic_rag_with_reasoning/)
 *   [📰 AI Blog Search (RAG)](rag_tutorials/ai_blog_search/)

--- a/rag_tutorials/ferpa_compliant_rag/README.md
+++ b/rag_tutorials/ferpa_compliant_rag/README.md
@@ -1,0 +1,97 @@
+# FERPA-Compliant RAG Pipeline
+
+A complete, runnable reference implementation of a retrieval-augmented generation
+pipeline that enforces FERPA (Family Educational Rights and Privacy Act) identity
+boundaries before documents reach the LLM context window.
+
+Designed for higher education AI systems where student records must not cross
+institutional or identity boundaries during retrieval.
+
+## What this demonstrates
+
+- **Pre-filter identity enforcement:** student records are filtered *before*
+  semantic ranking — unauthorized documents never enter the retrieval pipeline
+- **Two-layer access control:** Layer 1 = identity scope (student_id + institution_id);
+  Layer 2 = category authorization (transcript, financial, counseling, etc.)
+- **Structured audit logging:** every retrieval event produces a typed `AuditRecord`
+  compliant with 34 CFR § 99.32 disclosure record requirements
+- **Cross-institution blocking:** documents belonging to a different institution
+  are excluded even if semantically relevant to the query
+- **Platform-agnostic design:** works with any vector store that supports metadata
+  filtering (Pinecone, Weaviate, Qdrant, pgvector, Chroma, and others)
+
+## Architecture
+
+```
+Query
+  │
+  ▼
+Identity Scope Construction
+(student_id + institution_id + allowed_categories)
+  │
+  ▼
+Vector Store Pre-filter
+(metadata constraint: student_id match + institution_id match)
+  │
+  ▼
+Semantic Ranking
+(only authorized documents scored)
+  │
+  ▼
+Category Authorization
+(second pass: filter by allowed document types)
+  │
+  ▼
+Context Assembly
+  │
+  ▼
+LLM Call
+  │
+  ▼
+Audit Log (34 CFR § 99.32)
+```
+
+## Requirements
+
+```
+pip install enterprise-rag-patterns
+```
+
+Or to run with this demo:
+
+```
+pip install -r requirements.txt
+```
+
+## Usage
+
+```python
+python app.py
+```
+
+The script demonstrates:
+1. A compliant retrieval for an authorized student
+2. Cross-institution blocking (different institution_id = no results)
+3. Category authorization (counseling_notes not in allowed_categories = filtered)
+4. Audit record output for each retrieval event
+
+## Technologies
+
+- **Compliance framework:** [enterprise-rag-patterns](https://github.com/ashutoshrana/enterprise-rag-patterns)
+- **Pattern:** Identity-scoped pre-filter + category authorization
+- **Regulation:** FERPA (20 U.S.C. § 1232g; 34 CFR Part 99)
+- **Vector store integration:** Platform-agnostic (mock store in demo; swap for any provider)
+- **Python version:** 3.10+
+
+## Extending this example
+
+- **Replace the mock vector store** with your actual provider — the
+  `FERPAContextPolicy.filter_retrieved_documents()` call is provider-agnostic
+- **Wire a real audit sink** — replace `audit_log.append` with a write to
+  your compliance database or structured log stream
+- **Apply to HIPAA or GLBA** — the same two-layer enforcement pattern applies
+  to any regulation requiring identity-scoped record access
+
+## Source
+
+Full documentation and additional modules: [enterprise-rag-patterns](https://github.com/ashutoshrana/enterprise-rag-patterns)

--- a/rag_tutorials/ferpa_compliant_rag/app.py
+++ b/rag_tutorials/ferpa_compliant_rag/app.py
@@ -1,0 +1,303 @@
+"""
+FERPA-Compliant RAG Pipeline Demo
+
+Demonstrates identity-scoped pre-filtering for higher-education AI systems.
+Documents belonging to a different student or institution are excluded before
+they reach the LLM context window — not after.
+
+Requirements:
+    pip install enterprise-rag-patterns
+
+Run:
+    python app.py
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+
+from enterprise_rag_patterns.compliance import (
+    AuditRecord,
+    FERPAContextPolicy,
+    StudentIdentityScope,
+    make_enrollment_advisor_policy,
+)
+
+
+# ---------------------------------------------------------------------------
+# Mock vector store
+# ---------------------------------------------------------------------------
+# In production, replace this with a call to your actual vector store
+# (Pinecone, Weaviate, Qdrant, pgvector, Chroma, etc.) that returns
+# document dicts with metadata fields.
+
+MOCK_DOCUMENTS: list[dict[str, Any]] = [
+    {
+        "doc_id": "doc-001",
+        "student_id": "student-alice",
+        "institution_id": "univ-east",
+        "category": "academic_record",
+        "content": "Alice enrolled full-time, GPA 3.7, 15 credit hours this term.",
+    },
+    {
+        "doc_id": "doc-002",
+        "student_id": "student-alice",
+        "institution_id": "univ-east",
+        "category": "financial_record",
+        "content": "Alice: tuition balance $0. Financial aid disbursed 2026-01-15.",
+    },
+    {
+        "doc_id": "doc-003",
+        "student_id": "student-alice",
+        "institution_id": "univ-east",
+        "category": "counseling_notes",
+        "content": "Session notes: career planning discussion, 2026-02-10.",
+    },
+    {
+        "doc_id": "doc-004",
+        "student_id": "student-bob",
+        "institution_id": "univ-east",
+        "category": "academic_record",
+        "content": "Bob: enrolled part-time, 6 credit hours.",  # different student
+    },
+    {
+        "doc_id": "doc-005",
+        "student_id": "student-carol",
+        "institution_id": "univ-west",
+        "category": "academic_record",
+        "content": "Carol: enrolled at West University, 12 credit hours.",  # different institution
+    },
+    {
+        "doc_id": "doc-006",
+        "student_id": "shared",
+        "institution_id": "univ-east",
+        "category": "policy_document",
+        "content": "Enrollment policy: students must register by the add/drop deadline.",
+    },
+]
+
+
+def mock_vector_search(
+    query: str,
+    student_id: str,
+    institution_id: str,
+) -> list[dict[str, Any]]:
+    """
+    Simulates a vector store metadata pre-filter query.
+
+    In a real implementation, this is a single query to your vector store with
+    a metadata filter expression such as:
+        {"$and": [{"student_id": student_id}, {"institution_id": institution_id}]}
+    or the equivalent for your vector store's filter syntax.
+
+    The key point: the filter is applied AT QUERY TIME, before semantic ranking.
+    Unauthorized documents are never retrieved — they are excluded from the
+    candidate set, not filtered out afterward.
+    """
+    print(f"\n[vector store] query='{query}'")
+    print(f"[vector store] metadata filter: student_id='{student_id}' OR shared, institution_id='{institution_id}'")
+
+    results = [
+        doc for doc in MOCK_DOCUMENTS
+        if doc["institution_id"] == institution_id
+        and (doc["student_id"] == student_id or doc["student_id"] == "shared")
+    ]
+    print(f"[vector store] {len(results)} documents match the pre-filter")
+    return results
+
+
+# ---------------------------------------------------------------------------
+# Audit sink
+# ---------------------------------------------------------------------------
+
+audit_log: list[AuditRecord] = []
+
+
+def audit_sink(record: AuditRecord) -> None:
+    """Collects audit records. In production: write to your compliance database."""
+    audit_log.append(record)
+
+
+# ---------------------------------------------------------------------------
+# Scenario 1: Compliant retrieval — authorized student
+# ---------------------------------------------------------------------------
+
+def scenario_authorized_retrieval() -> None:
+    print("\n" + "=" * 60)
+    print("SCENARIO 1: Authorized student retrieval")
+    print("=" * 60)
+
+    scope = StudentIdentityScope(
+        student_id="student-alice",
+        institution_id="univ-east",
+        allowed_categories={"academic_record", "financial_record", "policy_document"},
+    )
+
+    policy = FERPAContextPolicy(scope=scope)
+
+    # Step 1: Vector store pre-filter (returns only Alice's + shared docs at univ-east)
+    raw_docs = mock_vector_search(
+        query="What is my current enrollment status and balance?",
+        student_id=scope.student_id,
+        institution_id=scope.institution_id,
+    )
+
+    # Step 2: Category authorization pass (second layer)
+    authorized_docs = policy.filter_retrieved_documents(raw_docs)
+
+    print(f"\n[policy] {len(authorized_docs)} documents authorized for context window:")
+    for doc in authorized_docs:
+        print(f"  - [{doc['category']}] {doc['doc_id']}: {doc['content'][:60]}...")
+
+    # Step 3: Audit log
+    policy.record_access(
+        documents_retrieved=len(raw_docs),
+        documents_filtered=len(authorized_docs),
+        audit_sink=audit_sink,
+        requester_context={"session_id": "sess-001", "channel": "web"},
+    )
+    print(f"\n[audit] AuditRecord recorded. record_id={audit_log[-1].record_id}")
+
+
+# ---------------------------------------------------------------------------
+# Scenario 2: Cross-institution block
+# ---------------------------------------------------------------------------
+
+def scenario_cross_institution_block() -> None:
+    print("\n" + "=" * 60)
+    print("SCENARIO 2: Cross-institution block")
+    print("Student from univ-west querying the univ-east system")
+    print("=" * 60)
+
+    scope = StudentIdentityScope(
+        student_id="student-carol",
+        institution_id="univ-west",
+        allowed_categories={"academic_record"},
+    )
+
+    policy = FERPAContextPolicy(scope=scope)
+
+    # Vector store pre-filter: carol + univ-west — no documents match univ-east corpus
+    raw_docs = mock_vector_search(
+        query="Show me my enrollment record",
+        student_id=scope.student_id,
+        institution_id=scope.institution_id,
+    )
+
+    authorized_docs = policy.filter_retrieved_documents(raw_docs)
+    print(f"\n[policy] {len(authorized_docs)} documents authorized (expected 0 — cross-institution)")
+
+    policy.record_access(
+        documents_retrieved=len(raw_docs),
+        documents_filtered=len(authorized_docs),
+        audit_sink=audit_sink,
+        requester_context={"session_id": "sess-002", "channel": "voice"},
+    )
+    print(f"[audit] Cross-institution access attempt logged. record_id={audit_log[-1].record_id}")
+
+
+# ---------------------------------------------------------------------------
+# Scenario 3: Category authorization — counseling notes restricted
+# ---------------------------------------------------------------------------
+
+def scenario_category_restriction() -> None:
+    print("\n" + "=" * 60)
+    print("SCENARIO 3: Category restriction — counseling notes excluded")
+    print("Alice's scope does NOT include counseling_notes")
+    print("=" * 60)
+
+    scope = StudentIdentityScope(
+        student_id="student-alice",
+        institution_id="univ-east",
+        allowed_categories={"academic_record", "policy_document"},
+        # Note: financial_record and counseling_notes not included
+    )
+
+    policy = FERPAContextPolicy(scope=scope)
+
+    # Pre-filter returns Alice's docs at univ-east (including counseling_notes)
+    raw_docs = mock_vector_search(
+        query="Tell me about my academic standing",
+        student_id=scope.student_id,
+        institution_id=scope.institution_id,
+    )
+
+    authorized_docs = policy.filter_retrieved_documents(raw_docs)
+
+    print(f"\n[policy] {len(raw_docs)} docs from pre-filter → {len(authorized_docs)} after category auth:")
+    for doc in authorized_docs:
+        print(f"  - [{doc['category']}] {doc['doc_id']}")
+
+    excluded = set(d["doc_id"] for d in raw_docs) - set(d["doc_id"] for d in authorized_docs)
+    print(f"[policy] Excluded by category restriction: {excluded}")
+
+    policy.record_access(
+        documents_retrieved=len(raw_docs),
+        documents_filtered=len(authorized_docs),
+        audit_sink=audit_sink,
+        requester_context={"session_id": "sess-003", "channel": "dashboard"},
+    )
+
+
+# ---------------------------------------------------------------------------
+# Scenario 4: Factory method for common enrollment advisor use case
+# ---------------------------------------------------------------------------
+
+def scenario_enrollment_advisor() -> None:
+    print("\n" + "=" * 60)
+    print("SCENARIO 4: Enrollment advisor policy (factory method)")
+    print("=" * 60)
+
+    policy = make_enrollment_advisor_policy(
+        student_id="student-alice",
+        institution_id="univ-east",
+    )
+
+    raw_docs = mock_vector_search(
+        query="What courses am I eligible for next term?",
+        student_id="student-alice",
+        institution_id="univ-east",
+    )
+
+    authorized_docs = policy.filter_retrieved_documents(raw_docs)
+
+    print(f"\n[policy] Enrollment advisor scope: {policy.scope.allowed_categories}")
+    print(f"[policy] {len(authorized_docs)} documents authorized")
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def main() -> None:
+    print("FERPA-Compliant RAG Pipeline Demo")
+    print("enterprise-rag-patterns — https://github.com/ashutoshrana/enterprise-rag-patterns")
+
+    scenario_authorized_retrieval()
+    scenario_cross_institution_block()
+    scenario_category_restriction()
+    scenario_enrollment_advisor()
+
+    print("\n" + "=" * 60)
+    print(f"AUDIT LOG: {len(audit_log)} records captured")
+    print("=" * 60)
+    for record in audit_log:
+        entry = record.to_log_entry()
+        print(
+            f"  record_id={entry['record_id'][:8]}... "
+            f"student={entry['student_id']} "
+            f"retrieved={entry['documents_retrieved']} "
+            f"authorized={entry['documents_filtered']} "
+            f"ts={entry['timestamp'][:19]}"
+        )
+
+    print("\nKey takeaways:")
+    print("  1. Pre-filter at the vector store: unauthorized docs never enter the pipeline")
+    print("  2. Category authorization: second layer blocks restricted document types")
+    print("  3. Every retrieval event is logged with a typed AuditRecord (34 CFR § 99.32)")
+    print("  4. Platform-agnostic: swap mock_vector_search() for any vector store provider")
+
+
+if __name__ == "__main__":
+    main()

--- a/rag_tutorials/ferpa_compliant_rag/requirements.txt
+++ b/rag_tutorials/ferpa_compliant_rag/requirements.txt
@@ -1,0 +1,1 @@
+enterprise-rag-patterns>=0.1.0


### PR DESCRIPTION
## Summary

This PR adds a complete, runnable FERPA-compliant RAG pipeline tutorial to `rag_tutorials/ferpa_compliant_rag/`.

FERPA (Family Educational Rights and Privacy Act) is the primary data privacy regulation governing AI systems in US higher education. There are no existing examples in the RAG tutorials section that address regulated record-access environments.

## What this adds

**`rag_tutorials/ferpa_compliant_rag/`**
- `app.py` — Four-scenario demo covering:
  1. Authorized retrieval (student gets their own records from their institution)
  2. Cross-institution block (different institution_id = zero results — no cross-institution leakage)
  3. Category restriction (counseling_notes excluded even when identity passes — two-layer enforcement)
  4. Enrollment advisor factory (common higher-ed use case pattern)
- `README.md` — Architecture diagram, usage instructions, extension guidance
- `requirements.txt` — `enterprise-rag-patterns>=0.1.0`

## Key pattern

Identity boundary is enforced **at the vector store query** (pre-filter), not after retrieval. This is the correct approach for regulated environments:

```
Vector Store Pre-filter (student_id + institution_id)
    → Semantic Ranking (only authorized docs scored)
        → Category Authorization (second enforcement layer)
            → LLM Context Window
                → Audit Log (34 CFR § 99.32)
```

## Why this matters

Enterprise and higher-education teams building on LLMs frequently ask about FERPA compliance. This tutorial shows the specific RAG pattern that satisfies the identity isolation requirement — applicable to any vector store that supports metadata filtering (Pinecone, Weaviate, Qdrant, pgvector, Chroma, etc.).

The same pattern extends to HIPAA, GLBA, and similar record-access regulations.

## Source library

[enterprise-rag-patterns](https://github.com/ashutoshrana/enterprise-rag-patterns) — MIT license, Python 3.10+