### PR TITLE
Add AgentForge Marketplace — agent marketplace & API gateway

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,6 +238,10 @@ A curated collection of **Awesome LLM apps built with RAG, AI Agents, Multi-agen
 
 *   [♾️ Self-Improving Agent Skills](awesome_agent_skills/self-improving-agent-skills/) - Automatically optimize agent skills using Gemini and ADK
 
+### 🛒 Agent Marketplaces & Platforms
+
+*   [🔗 AgentForge Marketplace](https://github.com/doggychip/agentforge) - Unified API gateway for 300+ AI agents. One API key, REST + streaming, Stripe Connect payouts, self-hostable. React + Express + PostgreSQL (MIT).
+
 ## 🚀 Getting Started
 
 1. **Clone the repository** 


### PR DESCRIPTION
Adding a new "Agent Marketplaces & Platforms" subsection with [AgentForge Marketplace](https://github.com/doggychip/agentforge).

**What it is:** Self-hostable unified API gateway and marketplace for 300+ AI agents. Built with React + Express + PostgreSQL + Stripe.

**Key features:**
- One API key to invoke any agent via REST
- Creator economy with 90% revenue share
- Google OAuth, 2FA, Stripe Connect
- Agent health monitoring, auto-import from GitHub/HuggingFace
- MIT license, fully self-hostable

**Links:**
- GitHub: https://github.com/doggychip/agentforge
- Live demo: https://patreon.zeabur.app