### PR TITLE
Add Resources section with Agentic Engineering Jobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,6 +261,10 @@ A curated collection of **Awesome LLM apps built with RAG, AI Agents, Multi-agen
 4. **Follow the project-specific instructions** in each project's `README.md` file to set up and run the app.
 
 
+## 📚 Resources
+
+*   [💼 Agentic Engineering Jobs](https://agentic-engineering-jobs.com) - Free job board with 500+ listings for engineers building AI agents, RAG pipelines, and LLM-powered products.
+
 ### <img src="https://cdn.simpleicons.org/github"  alt="github logo" width="25" height="20"> Thank You, Community, for the Support! 🙏
 
 [![Star History Chart](https://api.star-history.com/svg?repos=Shubhamsaboo/awesome-llm-apps&type=Date)](https://star-history.com/#Shubhamsaboo/awesome-llm-apps&Date)


### PR DESCRIPTION
Adding a small Resources section between Getting Started and the star history chart, with a link to https://agentic-engineering-jobs.com.

It's a free job board with 500+ listings for engineers building AI agents, RAG pipelines, and LLM-powered products — the same audience learning from this repo.

- Placed at the bottom, doesn't clutter the project listings
- Matches the existing entry format (emoji + link + description)
- Free resource, directly relevant to the repo's audience

Happy to adjust placement if needed.