### PR TITLE
Add Helium to MCP AI Agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,7 @@ A curated collection of **Awesome LLM apps built with RAG, AI Agents, Multi-agen
 *   [🐙 GitHub MCP Agent](mcp_ai_agents/github_mcp_agent/)
 *   [📑 Notion MCP Agent](mcp_ai_agents/notion_mcp_agent) 
 *   [🌍 AI Travel Planner MCP Agent](mcp_ai_agents/ai_travel_planner_mcp_agent_team)
+*   [📡 Helium MCP](https://github.com/connerlambden/helium-mcp) - MCP/REST data layer for LLM apps: real-time news with bias scoring, financial market data, and ML options pricing; use it to ground agents on live information ([overview](https://heliumtrades.com/mcp-page/))
 
 ### 📀 RAG (Retrieval Augmented Generation)
 *   [🔥 Agentic RAG with Embedding Gemma](rag_tutorials/agentic_rag_embedding_gemma)


### PR DESCRIPTION
Adds [Helium MCP](https://github.com/connerlambden/helium-mcp) to the MCP AI Agents section of the README.

Helium is an MCP/REST data layer for LLM apps: real-time news with bias scoring, financial market data, and ML options pricing—useful for agents that need grounded, live context.

- Repo: https://github.com/connerlambden/helium-mcp
- Overview: https://heliumtrades.com/mcp-page/