### PR TITLE
Add TideMind to MCP AI Agents section

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ A curated collection of **Awesome LLM apps built with RAG, AI Agents, Multi-agen
 *   [📑 Notion MCP Agent](mcp_ai_agents/notion_mcp_agent) 
 *   [🌍 AI Travel Planner MCP Agent](mcp_ai_agents/ai_travel_planner_mcp_agent_team)
 *   [🔀 Multi-MCP Agent Router](mcp_ai_agents/multi_mcp_agent_router/)
+*   [🧠 TideMind](https://github.com/SawyerHan-AI/TideMind) - Open-source AI memory layer with a living knowledge graph. Connects AI tools and notes via MCP. Local-first, SQLite-backed.
 
 ### 📀 RAG (Retrieval Augmented Generation)
 *   [🔥 Agentic RAG with Embedding Gemma](rag_tutorials/agentic_rag_embedding_gemma)


### PR DESCRIPTION
## Summary
- Add [TideMind](https://github.com/SawyerHan-AI/TideMind) to the MCP AI Agents section
- TideMind is an open-source AI memory layer with a living knowledge graph that connects AI tools and notes via MCP, local-first and SQLite-backed

## Test plan
- [x] Entry follows the existing list format
- [x] Link points to the correct public repository