### PR TITLE
Add Helium MCP (MCP AI Agents)

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ A curated collection of **Awesome LLM apps built with RAG, AI Agents, Multi-agen
 *   [📑 Notion MCP Agent](mcp_ai_agents/notion_mcp_agent) 
 *   [🌍 AI Travel Planner MCP Agent](mcp_ai_agents/ai_travel_planner_mcp_agent_team)
 *   [🔀 Multi-MCP Agent Router](mcp_ai_agents/multi_mcp_agent_router/)
+*   [🎈 Helium MCP](mcp_ai_agents/helium_mcp/)
 
 ### 📀 RAG (Retrieval Augmented Generation)
 *   [🔥 Agentic RAG with Embedding Gemma](rag_tutorials/agentic_rag_embedding_gemma)

--- a/mcp_ai_agents/helium_mcp/README.md
+++ b/mcp_ai_agents/helium_mcp/README.md
@@ -1,0 +1,17 @@
+# Helium MCP
+
+[MCP](https://modelcontextprotocol.io) server with **10 tools** for news, markets, and bias-aware research.
+
+- News search across 3.2M+ articles from 5,000+ sources with bias scoring  
+- Balanced multi-perspective news synthesis  
+- Live stock, ETF, and crypto data with AI bull/bear cases  
+- ML options pricing and strategies  
+- Media bias analysis  
+
+## Links
+
+- **Streamable HTTP:** [https://heliumtrades.com/mcp](https://heliumtrades.com/mcp)  
+- **GitHub:** [https://github.com/connerlambden/helium-mcp](https://github.com/connerlambden/helium-mcp)  
+- **Docs:** [https://heliumtrades.com/mcp-page/](https://heliumtrades.com/mcp-page/)  
+
+Configure your MCP client to use the streamable HTTP endpoint (see docs for auth and transport).


### PR DESCRIPTION
## Summary
Adds [Helium MCP](https://github.com/connerlambden/helium-mcp) to the **MCP AI Agents** section: main README index link plus `mcp_ai_agents/helium_mcp/README.md` with a concise tool overview and links (streamable HTTP, docs, source).

## Helium MCP
- 10 tools: news search (3.2M+ articles, 5,000+ sources) with bias scoring, balanced synthesis, live stock/ETF/crypto with bull/bear cases, ML options pricing/strategies, media bias analysis
- Streamable HTTP: https://heliumtrades.com/mcp
- Docs: https://heliumtrades.com/mcp-page/

Replaces prior attempt (#716) with a minimal in-repo README matching other MCP agent entries.

Made with [Cursor](https://cursor.com)