### PR TITLE
Add Cabinet Agent Workstation to Agent Teams

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ A curated collection of **Awesome LLM apps built with RAG, AI Agents, Multi-agen
 *   [✨ Multimodal Design Agent Team](advanced_ai_agents/multi_agent_apps/agent_teams/multimodal_design_agent_team/)
 *   [🎨 🍌 Multimodal UI/UX Feedback Agent Team with Nano Banana](advanced_ai_agents/multi_agent_apps/agent_teams/multimodal_uiux_feedback_agent_team/)
 *   [🌏 AI Travel Planner Agent Team](/advanced_ai_agents/multi_agent_apps/agent_teams/ai_travel_planner_agent_team/)
+*   [🗄️ Cabinet Agent Workstation](https://github.com/8676311081/cabinet) — Self-hosted desktop app: kanban board + multi-agent execution + knowledge base auto-accumulation. Combines Cabinet KB with Multica task scheduler. ([DMG download](https://github.com/8676311081/cabinet/releases))
 
 ### 🗣️ Voice AI Agents
 


### PR DESCRIPTION
Adds [Cabinet Agent Workstation](https://github.com/8676311081/cabinet) to the Agent Teams section.

A self-hosted macOS desktop app that combines Cabinet (AI knowledge base) with Multica (agent task scheduler). Multi-agent parallel execution with automatic knowledge accumulation.

- Source: https://github.com/8676311081/cabinet
- DMG: https://github.com/8676311081/cabinet/releases
- Upstream: hilash/cabinet + multica-ai/multica
- Co-created with GPT-5 and Claude Opus 4.6