### PR TITLE
Add ZettelForge — agentic CTI memory with RAG

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,6 +225,7 @@ streamlit run travel_agent.py
 *   [🖼️ Vision RAG](rag_tutorials/vision_rag/)
 *   [🩺 RAG Failure Diagnostics Clinic](rag_tutorials/rag_failure_diagnostics_clinic/)
 *   [🕸️ Knowledge Graph RAG with Citations](rag_tutorials/knowledge_graph_rag_citations/)
+*   [🛡️ ZettelForge — Agentic CTI Memory](https://github.com/rolandpg/zettelforge) <sub>↗ external</sub>
 
 ### 🧩 Awesome Agent Skills
 *Ready-to-use agent skill files you can plug into any AI agent or LLM workflow.*


### PR DESCRIPTION
Adds [ZettelForge](https://github.com/rolandpg/zettelforge) to the RAG section.

**ZettelForge** — Agentic memory for cyber threat intelligence with entity extraction, STIX 2.1 knowledge graph, and intent-classified RAG. Offline-first.

Follows the existing external-project format used elsewhere in the list.