### PR TITLE
Add CATAI to Multi-agent Teams (external)

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,7 @@ streamlit run travel_agent.py
 *   [✨ Multimodal Design Agent Team](advanced_ai_agents/multi_agent_apps/agent_teams/multimodal_design_agent_team/)
 *   [🎨 🍌 Multimodal UI/UX Feedback Agent Team with Nano Banana](advanced_ai_agents/multi_agent_apps/agent_teams/multimodal_uiux_feedback_agent_team/)
 *   [🌏 AI Travel Planner Agent Team](/advanced_ai_agents/multi_agent_apps/agent_teams/ai_travel_planner_agent_team/)
+*   [🐱 CATAI - Multi-Personality Cat Debate Agents (macOS)](https://github.com/wil-pe/CATAI) <sub>↗ external</sub>
 
 ### 🗣️ Voice AI Agents
 *Speech-in, speech-out agents using real-time voice APIs.*


### PR DESCRIPTION
## Adds [CATAI](https://github.com/wil-pe/CATAI)

A macOS desktop app where up to **7 pixel-art cats with distinct personalities debate any topic together** using local Ollama LLMs.

### Why it fits Multi-agent Teams
- Each cat is an agent with its own system prompt / persona (philosopher, scientist, poet, geek, storyteller, comforter, retro-90s)
- Structured 3-round debate orchestrator with strict topic-anchoring rules
- Moderator cat synthesises the artefact (poem, plan, idea...) at the end
- Stateful debate engine with generation-counter invalidation (handles agents joining/leaving mid-debate)
- 100% local — uses any installed Ollama model

### Repo facts
- 🐱 Native Swift, single file (~2000 lines), zero dependencies
- 🪟 Cats walk on the macOS dock and perch on active windows
- 📜 MIT licensed, actively maintained
- 🌍 i18n: French, English, Spanish

Marked as `↗ external` per the existing convention for non-template entries.