### PR TITLE
feat(browser_mcp_agent): document and unblock local Ollama / OpenAI-compatible providers

### DIFF
--- a/mcp_ai_agents/browser_mcp_agent/README.md
+++ b/mcp_ai_agents/browser_mcp_agent/README.md
@@ -43,12 +43,45 @@ A Streamlit application that allows you to browse and interact with websites usi
    ```
    Both commands should return version numbers. If they don't, please install Node.js.
 
-4. Set up your API keys:
-   - Set OpenAI API Key as an environment variable:
-     ```bash
-     export OPENAI_API_KEY=your-openai-api-key
-     ```
+4. Set up your API keys. Pick **one** of:
 
+   **a) Via environment variable (simplest for OpenAI):**
+   ```bash
+   export OPENAI_API_KEY=your-openai-api-key
+   ```
+
+   **b) Via `mcp_agent.secrets.yaml` (required for Ollama / any custom base URL):**
+   ```bash
+   cp mcp_agent.secrets.yaml.example mcp_agent.secrets.yaml
+   # edit mcp_agent.secrets.yaml and put your key under openai.api_key
+   ```
+
+### Running with a local Ollama model
+
+Because `mcp-agent` talks to an OpenAI-compatible endpoint and Ollama exposes one at `http://localhost:11434/v1`, this agent runs against a local model with just config changes — no code edits or extra dependencies. See discussion in [#329](https://github.com/Shubhamsaboo/awesome-llm-apps/issues/329).
+
+1. Install and start Ollama, then pull a tool-capable model:
+   ```bash
+   ollama pull llama3.2
+   ollama serve
+   ```
+
+2. Edit `mcp_agent.config.yaml` and replace the `openai:` block with:
+   ```yaml
+   openai:
+     base_url: "http://localhost:11434/v1"
+     default_model: "llama3.2"
+   ```
+
+3. In `mcp_agent.secrets.yaml`, set any non-empty `api_key` (Ollama ignores it):
+   ```yaml
+   openai:
+     api_key: "ollama"
+   ```
+
+4. Run as normal — `streamlit run main.py`. No `OPENAI_API_KEY` env var is required in this path.
+
+> Note: browser automation benefits from a reasoning-capable model. Smaller local models may struggle with multi-step Playwright tasks.
 
 ### Running the App
 

--- a/mcp_ai_agents/browser_mcp_agent/main.py
+++ b/mcp_ai_agents/browser_mcp_agent/main.py
@@ -88,9 +88,19 @@ async def setup_agent():
 
 # Main function to run agent
 async def run_mcp_agent(message):
-    if not os.getenv("OPENAI_API_KEY"):
-        return "Error: OpenAI API key not provided"
-    
+    # Credentials come from mcp_agent.secrets.yaml (api_key) and
+    # mcp_agent.config.yaml (base_url, default_model). Both OpenAI and any
+    # OpenAI-compatible server (e.g. Ollama at http://localhost:11434/v1)
+    # are supported via the same `openai:` config section — see README.
+    if not os.getenv("OPENAI_API_KEY") and not os.path.exists(
+        os.path.join(os.path.dirname(__file__), "mcp_agent.secrets.yaml")
+    ):
+        return (
+            "Error: no LLM credentials found. Either set OPENAI_API_KEY in "
+            "your environment, or create mcp_agent.secrets.yaml from the "
+            "provided example (works for OpenAI and local Ollama)."
+        )
+
     try:
         # Make sure agent is initialized
         error = await setup_agent()

--- a/mcp_ai_agents/browser_mcp_agent/mcp_agent.config.yaml
+++ b/mcp_ai_agents/browser_mcp_agent/mcp_agent.config.yaml
@@ -18,3 +18,14 @@ mcp:
 openai:
   # Secrets (API keys, etc.) are stored in an mcp_agent.secrets.yaml file which can be gitignored
   default_model: "gpt-4o-mini"
+
+# To run against a local Ollama (or any OpenAI-compatible) server, override
+# the `openai` block above with the commented example below and put a dummy
+# api_key (e.g. "ollama") in mcp_agent.secrets.yaml. Ollama exposes an
+# OpenAI-compatible endpoint at /v1, so no framework changes are needed —
+# this was confirmed by the mcp-agent maintainer in issue #329.
+#
+# openai:
+#   base_url: "http://localhost:11434/v1"
+#   default_model: "llama3.2"
+

--- a/mcp_ai_agents/browser_mcp_agent/mcp_agent.secrets.yaml.example
+++ b/mcp_ai_agents/browser_mcp_agent/mcp_agent.secrets.yaml.example
@@ -1,2 +1,7 @@
 openai:
   api_key: YOUR_OPENAI_API_KEY
+
+# For a local Ollama backend, any non-empty api_key works because Ollama
+# doesn't authenticate; the important part is the base_url in config.yaml.
+# openai:
+#   api_key: "ollama"


### PR DESCRIPTION
## Summary

Issue [#329](https://github.com/Shubhamsaboo/awesome-llm-apps/issues/329) (7 comments, unresolved) asked how to run `browser_mcp_agent` against a local Ollama instance. As @AndrewHoh (mcp-agent maintainer) noted in that thread, the framework already supports this — Ollama's `/v1` endpoint is OpenAI-compatible, so no new dependency is required. The friction is:

1. `main.py` has a hardcoded `os.getenv(\"OPENAI_API_KEY\")` gate that unconditionally rejects users who correctly configured credentials via `mcp_agent.secrets.yaml` — both OpenAI **and** Ollama users hit this spurious error.
2. There is no Ollama example in `mcp_agent.config.yaml` / `mcp_agent.secrets.yaml.example`.
3. The README tells users to `export OPENAI_API_KEY=...` in step 4 but the on-page UI text says \"Enter your OpenAI API key in your mcp_agent.secrets.yaml file\" — two contradictory setup paths.

This PR fixes all three with minimal code churn.

## Changes

- `main.py`: the env-var gate now accepts a present `mcp_agent.secrets.yaml` as valid credentials. Error message points users to both paths (env var or secrets file) and mentions Ollama.
- `mcp_agent.config.yaml`: added a commented Ollama example block showing `base_url: http://localhost:11434/v1` + `default_model: llama3.2`. OpenAI default is unchanged.
- `mcp_agent.secrets.yaml.example`: added commented Ollama example noting Ollama ignores api_key.
- `README.md`: new \"Running with a local Ollama model\" section; step 4 now clearly offers env var **or** secrets.yaml (pick one), which matches the on-page help text.

## Test plan

- [x] `main.py` parses with \`ast.parse\`; no new imports
- [x] Unit-tested the credential-gate logic across 4 scenarios (env-only, secrets-only, both, neither) — all correct, including the previously-broken secrets-only path
- [x] YAML files parse with \`yaml.safe_load\`
- [ ] Maintainer: spot-check \`streamlit run main.py\` with an OpenAI key (regression) and with local Ollama (\`ollama pull llama3.2 && ollama serve\`)

No functional change for existing OpenAI-env-var users.

Refs #329
Credit to @AndrewHoh for the framework-level pointer that made this a config + docs change rather than a code rewrite.

Made with [Cursor](https://cursor.com)