### PR TITLE
Add CTI Memory with ZettelForge tutorial (rag_tutorials)

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,6 +225,7 @@ streamlit run travel_agent.py
 *   [🖼️ Vision RAG](rag_tutorials/vision_rag/)
 *   [🩺 RAG Failure Diagnostics Clinic](rag_tutorials/rag_failure_diagnostics_clinic/)
 *   [🕸️ Knowledge Graph RAG with Citations](rag_tutorials/knowledge_graph_rag_citations/)
+*   [🛡️ CTI Memory with ZettelForge](rag_tutorials/cti_memory_zettelforge/)
 
 ### 🧩 Awesome Agent Skills
 *Ready-to-use agent skill files you can plug into any AI agent or LLM workflow.*

--- a/rag_tutorials/cti_memory_zettelforge/README.md
+++ b/rag_tutorials/cti_memory_zettelforge/README.md
@@ -1,0 +1,137 @@
+## 🛡️ Agentic CTI Memory with ZettelForge
+
+A runnable tutorial showing how to give an AI agent **persistent memory for cyber threat intelligence** — with automatic entity extraction, threat-actor alias resolution, a STIX 2.1 knowledge graph, and intent-classified blended retrieval. Powered by [ZettelForge](https://github.com/rolandpg/zettelforge).
+
+Runs entirely in-process. No API keys. No cloud.
+
+### The problem
+
+Every SOC loses analysts. When a senior one leaves, two or three years of investigation context walks out with them. General-purpose AI memory tools can't fix this for security teams — they can't tell APT28 from Fancy Bear, don't know CVE-2024-3094 is the XZ backdoor, and can't parse Sigma or YARA. ZettelForge is built for analysts who think in threat graphs instead of chat histories.
+
+### What this tutorial demonstrates
+
+- **Automatic entity extraction** — CVEs, threat actors, IOCs (IPs, domains, hashes, URLs, emails), MITRE ATT&CK techniques, tools, campaigns, intrusion sets, and 10 more STIX 2.1 types extracted from free-text reports without manual tagging
+- **Threat-actor alias resolution** — `APT28`, `Fancy Bear`, `STRONTIUM`, `FOREST BLIZZARD`, and `Sofacy` all resolve to the same actor node. Recall against one name returns notes written with any of them
+- **STIX 2.1 knowledge graph** — entities become nodes, co-occurrence becomes edges, and LLM-inferred causal triples (e.g. `APT28 uses Cobalt Strike`) feed multi-hop queries
+- **Intent-classified blended retrieval** — queries are classified as factual, temporal, relational, causal, or exploratory, and each intent weights vector similarity vs. knowledge-graph traversal differently
+- **Cross-memory synthesis** — natural-language answer across everything the agent has ever stored
+
+### How it works
+
+Each `mm.remember(report)` call triggers:
+
+1. Regex + (optional) LLM NER extracts 19 STIX 2.1 entity types
+2. Entities become nodes in the knowledge graph; co-occurrence becomes edges; LLM infers causal triples
+3. 768-dim embedding is stored in LanceDB (in-process, ~7ms/embed via fastembed)
+4. Entity-overlap supersession marks stale notes so new intel doesn't get drowned in old
+
+Each `mm.recall(query)` call triggers:
+
+1. Intent classifier tags the query
+2. Vector similarity (LanceDB) and BFS graph traversal (knowledge graph) run in parallel
+3. Results are merged by policy weights, then reranked with a cross-encoder
+4. Ranked list of relevant memories returned
+
+Each `mm.synthesize(query)` call retrieves the same way, then asks the LLM to produce a direct answer grounded in the retrieved memories.
+
+### How to get started
+
+1. Clone the repository and change into this directory:
+
+   ```bash
+   git clone https://github.com/Shubhamsaboo/awesome-llm-apps.git
+   cd awesome-llm-apps/rag_tutorials/cti_memory_zettelforge
+   ```
+
+2. Install dependencies:
+
+   ```bash
+   pip install -r requirements.txt
+   ```
+
+3. Run the tutorial:
+
+   ```bash
+   python cti_memory_zettelforge.py
+   ```
+
+That's it — the tutorial ships with five short CTI reports baked into the script. First run downloads the fastembed ONNX model (~100 MB); subsequent runs are fast.
+
+### Optional: Enable LLM features
+
+Entity extraction and synthesis get significantly richer when an LLM is available. ZettelForge auto-detects Ollama on `localhost:11434`:
+
+```bash
+# Install Ollama from https://ollama.com/download
+ollama pull qwen2.5:3b
+ollama serve
+```
+
+Re-run the tutorial and you'll see `mm.synthesize()` return a real LLM-generated summary across all the stored intel.
+
+### What's next
+
+- **Ingest detection rules**: Sigma and YARA rules are first-class memory primitives in ZettelForge — their MITRE/CVE/actor tags become graph edges in the same ontology as your free-text notes:
+
+  ```python
+  from zettelforge.sigma import ingest_rule as ingest_sigma
+  from zettelforge.yara  import ingest_rule as ingest_yara
+
+  ingest_sigma("rules/proc_creation_win_office_macro.yml", mm)
+  ingest_yara("rules/webshell_china_chopper.yar", mm, tier="warn")
+  ```
+
+- **Wire the MCP server into Claude Code** so your agent has persistent CTI memory across sessions:
+
+  ```json
+  {
+    "mcpServers": {
+      "zettelforge": {
+        "command": "python3",
+        "args": ["-m", "zettelforge.mcp"]
+      }
+    }
+  }
+  ```
+
+  Exposed tools: `remember`, `recall`, `synthesize`, `entity`, `graph`, `stats`.
+
+### Expected output (abridged)
+
+```
+==============================================================================
+  STEP 1 — Initialize CTI memory
+==============================================================================
+MemoryManager ready. Storage defaults to ~/.amem.
+Embeddings: fastembed (768-dim ONNX, in-process, ~7ms/embed).
+LLM features activate automatically if Ollama is reachable on :11434.
+
+==============================================================================
+  STEP 2 — Ingest 5 CTI reports
+==============================================================================
+  remember() <- [2024-03-12 analyst-notes] APT28 was observed using Cobalt Strike...
+  remember() <- [2024-05-04 threat-brief] Fancy Bear has shifted tactics — Microsoft...
+  remember() <- [2024-03-29 vuln-intel] CVE-2024-3094 — the XZ Utils backdoor — was...
+  remember() <- [2024-02-18 hunt-report] STRONTIUM infrastructure overlaps with a...
+  remember() <- [2024-04-02 patch-notes] Microsoft patched CVE-2024-21412 in the...
+
+Stored 5 reports. Entity extraction, graph updates, and vector indexing ran automatically.
+
+==============================================================================
+  STEP 3 — Alias resolution: APT28 = Fancy Bear = STRONTIUM
+==============================================================================
+Different reports used different names for the same threat actor.
+A single recall() returns notes across ALL aliases:
+
+  1. APT28 was observed using Cobalt Strike for lateral movement via T1021.002...
+  2. Fancy Bear has shifted tactics — Microsoft now tracks them as FOREST BLIZZARD...
+  3. STRONTIUM infrastructure overlaps with a 2023 Sandworm campaign targeting...
+  ...
+```
+
+### Resources
+
+- **Repo**: https://github.com/rolandpg/zettelforge
+- **PyPI**: https://pypi.org/project/zettelforge/
+- **Docs**: https://docs.threatrecall.ai/
+- **License**: MIT

--- a/rag_tutorials/cti_memory_zettelforge/cti_memory_zettelforge.py
+++ b/rag_tutorials/cti_memory_zettelforge/cti_memory_zettelforge.py
@@ -1,0 +1,143 @@
+"""
+CTI Memory with ZettelForge — runnable tutorial.
+
+Demonstrates a CTI-specialized agentic memory system:
+  1. Ingests 5 short threat-intel reports
+  2. Shows automatic entity extraction (CVEs, threat actors, IOCs, ATT&CK)
+  3. Shows threat-actor alias resolution (APT28 = Fancy Bear = STRONTIUM)
+  4. Shows intent-classified blended retrieval (vector + knowledge graph)
+  5. Shows cross-memory synthesis
+
+Runs fully in-process — no API keys, no cloud. Entity extraction uses
+regex + STIX 2.1 types out of the box. If Ollama is running locally,
+LLM-powered extraction and synthesis automatically activate.
+
+Usage:
+    pip install -r requirements.txt
+    python cti_memory_zettelforge.py
+"""
+
+from zettelforge import MemoryManager
+
+
+# ---------------------------------------------------------------------------
+# Demo data — five short CTI reports. Notice the aliases used across reports:
+# "APT28" vs "Fancy Bear" vs "STRONTIUM" all refer to the same threat actor.
+# ZettelForge resolves them to a single node in the knowledge graph.
+# ---------------------------------------------------------------------------
+REPORTS = [
+    (
+        "2024-03-12 analyst-notes",
+        "APT28 was observed using Cobalt Strike for lateral movement via "
+        "T1021.002 (SMB/Windows Admin Shares) against a defense contractor. "
+        "The loader beaconed to 185.244.25.xx over port 443.",
+    ),
+    (
+        "2024-05-04 threat-brief",
+        "Fancy Bear has shifted tactics — Microsoft now tracks them as "
+        "FOREST BLIZZARD. Recent campaigns exploit CVE-2024-21412 in "
+        "Windows SmartScreen to bypass Mark-of-the-Web protections.",
+    ),
+    (
+        "2024-03-29 vuln-intel",
+        "CVE-2024-3094 — the XZ Utils backdoor — was introduced by a "
+        "long-running supply-chain operation attributed to the actor 'Jia Tan'. "
+        "Affects liblzma and any tool that links it (including sshd on most "
+        "Linux distros).",
+    ),
+    (
+        "2024-02-18 hunt-report",
+        "STRONTIUM infrastructure overlaps with a 2023 Sandworm campaign "
+        "targeting Ukrainian telecoms. Shared C2 at 91.219.239.xx. "
+        "Technique chain: T1566.001 -> T1059.001 -> T1021.002.",
+    ),
+    (
+        "2024-04-02 patch-notes",
+        "Microsoft patched CVE-2024-21412 in the March 2024 rollout. "
+        "Detection rules for FOREST BLIZZARD tooling now live in the "
+        "SigmaHQ repo under rules/windows/process_creation/.",
+    ),
+]
+
+
+QUERIES = [
+    # Factual — direct entity lookup
+    "What tools does Fancy Bear use?",
+    # Relational — multi-hop across alias boundary
+    "Which CVEs are APT28 exploiting?",
+    # Temporal — when did what happen
+    "What happened with the XZ Utils backdoor?",
+    # Causal — cross-report synthesis across aliases
+    "Summarize known STRONTIUM / FOREST BLIZZARD / APT28 tooling and CVEs.",
+]
+
+
+def rule(title: str) -> None:
+    print("\n" + "=" * 78)
+    print(f"  {title}")
+    print("=" * 78)
+
+
+def main() -> None:
+    rule("STEP 1 — Initialize CTI memory")
+    mm = MemoryManager()
+    print("MemoryManager ready. Storage defaults to ~/.amem.")
+    print("Embeddings: fastembed (768-dim ONNX, in-process, ~7ms/embed).")
+    print("LLM features activate automatically if Ollama is reachable on :11434.")
+
+    rule("STEP 2 — Ingest 5 CTI reports")
+    for source, body in REPORTS:
+        print(f"  remember() <- [{source}] {body[:68]}...")
+        mm.remember(body, domain="cti")
+    print(f"\nStored {len(REPORTS)} reports. Entity extraction, graph updates,")
+    print("and vector indexing ran automatically.")
+
+    rule("STEP 3 — Alias resolution: APT28 = Fancy Bear = STRONTIUM")
+    print("Different reports used different names for the same threat actor.")
+    print("A single recall() returns notes across ALL aliases:\n")
+    results = mm.recall("What does APT28 do?")
+    for i, note in enumerate(results[:5], 1):
+        snippet = getattr(note, "content", str(note))[:110]
+        print(f"  {i}. {snippet}...")
+
+    rule("STEP 4 — Intent-classified blended retrieval")
+    for q in QUERIES:
+        print(f"\n? {q}")
+        hits = mm.recall(q)
+        for note in hits[:3]:
+            snippet = getattr(note, "content", str(note))[:100]
+            print(f"    -> {snippet}...")
+
+    rule("STEP 5 — Cross-memory synthesis")
+    question = (
+        "Summarize what we know about APT28 / Fancy Bear / STRONTIUM — "
+        "tooling, CVEs exploited, and techniques."
+    )
+    print(f"? {question}\n")
+    try:
+        answer = mm.synthesize(question)
+        print(answer)
+    except Exception as exc:
+        # Synthesize requires an LLM provider (Ollama or llama-cpp). If neither
+        # is configured, fall back to listing the raw notes the retriever found.
+        print(f"[synthesize() requires an LLM provider — {type(exc).__name__}: {exc}]")
+        print("\nFalling back to ranked recall:")
+        for note in mm.recall(question)[:5]:
+            snippet = getattr(note, "content", str(note))[:120]
+            print(f"  -> {snippet}...")
+
+    rule("Done")
+    print("Next steps:")
+    print("  * Start Ollama (`ollama pull qwen2.5:3b && ollama serve`) to enable")
+    print("    LLM-powered entity extraction and synthesize().")
+    print("  * Ingest Sigma/YARA rules as first-class memory primitives:")
+    print("      from zettelforge.sigma import ingest_rule as ingest_sigma")
+    print("      from zettelforge.yara  import ingest_rule as ingest_yara")
+    print("  * Wire the built-in MCP server into Claude Code:")
+    print('      "zettelforge": {"command": "python3", "args": ["-m", "zettelforge.mcp"]}')
+    print("\nDocs: https://docs.threatrecall.ai/")
+    print("Repo: https://github.com/rolandpg/zettelforge")
+
+
+if __name__ == "__main__":
+    main()

--- a/rag_tutorials/cti_memory_zettelforge/requirements.txt
+++ b/rag_tutorials/cti_memory_zettelforge/requirements.txt
@@ -1,0 +1,1 @@
+zettelforge>=2.3.0


### PR DESCRIPTION
Adds `rag_tutorials/cti_memory_zettelforge/` — a **self-contained, runnable** tutorial demonstrating CTI-specialized agentic memory with ZettelForge.

This resubmits (in the correct format) the content behind closed PR #727. That PR was rightly rejected because it tried to add a link-only bullet. This PR follows this repo's actual contribution model: **a dedicated folder with runnable code, a walkthrough README, and a requirements file**.

## What the tutorial does

Runs end-to-end in two commands (`pip install -r requirements.txt` and `python cti_memory_zettelforge.py`) against five bundled CTI reports and demonstrates:

- **Automatic entity extraction** — 19 STIX 2.1 types (CVEs, threat actors, IOCs, MITRE ATT&CK techniques, tools, campaigns, intrusion sets, etc.) pulled from free-text reports with no manual tagging
- **Threat-actor alias resolution** — `APT28`, `Fancy Bear`, `STRONTIUM`, `FOREST BLIZZARD`, and `Sofacy` all resolve to the same knowledge-graph node, so recall against any name returns notes written with any other
- **Intent-classified blended retrieval** — queries are routed across vector similarity and BFS graph traversal based on a 5-class intent classifier (factual / temporal / relational / causal / exploratory), then cross-encoder reranked
- **Cross-memory synthesis** — natural-language summary grounded in everything the agent has stored

## Files

```
rag_tutorials/cti_memory_zettelforge/
├── README.md                         # walkthrough + expected output
├── cti_memory_zettelforge.py         # 5-step runnable demo (~130 LOC)
└── requirements.txt                  # single dep: zettelforge>=2.3.0
```

Top-level `README.md` is also updated to link the tutorial under the RAG tutorials list.

## Runtime / dependencies

- Python 3.10+
- Single `pip install` — no Docker, no TypeDB, no Ollama required
- Embeddings run in-process via fastembed (ONNX, ~7ms/embed). First run downloads ~100 MB of model weights
- **Optional**: if Ollama is running on `localhost:11434`, LLM-powered extraction and `synthesize()` automatically activate. The tutorial has a try/except so it degrades gracefully when Ollama isn't present

## Network behavior

- The fastembed ONNX model downloads once from HuggingFace Hub on first run
- No other outbound requests in the default configuration — no API keys, no cloud calls
- Optional Ollama integration hits only localhost

## License

- Tutorial code: MIT (same as this repo)
- ZettelForge dependency: MIT

## Disclosure

Tutorial written by @rolandpg, the maintainer of ZettelForge. Agent-assisted authoring; all code human-reviewed. I'm the same author whose link-only PR #727 was correctly closed — this is the right-shaped resubmission.