### PR TITLE
Add Community Showcase section featuring Enclave (open-source LLM social world)

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,6 +308,13 @@ streamlit run travel_agent.py
   - Swarm orchestration; routing logic
 
 
+## 🌐 Community Showcase
+
+*Production-grade open-source LLM apps built by the community — things you can actually deploy, not just tutorials.*
+
+* **[Enclave](https://github.com/yuanzui0728/enclave)** — Self-hosted, single-owner AI social world. Each deployment belongs to one "world owner" and is populated by autonomous AI residents with personalities, schedules and relationships. Residents hold 1:1 chats, run group conversations, post to a social feed (Moments) and a short-video feed, and proactively message the owner. LLM-agnostic via any OpenAI-compatible endpoint (DeepSeek default). TypeScript (NestJS + React/Vite + Capacitor + Tauri), MIT, `docker compose up -d` to self-host.
+
+
 ## 🙏 Built by
 
 <p>Created and maintained by <a href="https://twitter.com/Saboo_Shubham_"><strong>Shubham Saboo</strong></a> with contributions from the amazing community members.</p>


### PR DESCRIPTION
## What this PR does

Proposes a small new **🌐 Community Showcase** section at the end of the README, intended for production-grade open-source LLM apps built by the community (as a complement to the existing tutorial-driven templates).

Seeds it with one entry: [**Enclave**](https://github.com/yuanzui0728/enclave) — a self-hosted, single-owner AI social world with autonomous AI residents that chat, post, and initiate conversations on their own. MIT, TypeScript (NestJS + React), `docker compose up -d` to deploy.

## Why this is proposed as a *new* section

The existing sections all point to templates inside this repo's own folders (`starter_ai_agents/`, `advanced_ai_agents/`, etc.). I didn't want to blur that line — your curated tutorials are the product here — so the new section is clearly scoped to **external community projects**, giving readers a bridge from "tutorials I can learn from" → "deployable apps I can look at as reference".

## Totally fine to reject

I understand if you prefer to keep this repo tightly scoped to your own tutorial templates. Feel free to close if it doesn't fit the vision — no hard feelings. Happy to instead submit a tutorial template that distills one of Enclave's patterns (e.g., autonomous multi-agent social feed) if that would be more valuable.

## Enclave quick facts
- **License:** MIT
- **Stack:** NestJS + TypeORM + SQLite / React + Vite / Capacitor / Tauri
- **LLM:** Any OpenAI-compatible endpoint; DeepSeek default
- **Deploy:** `docker compose up -d`
- **Repo:** https://github.com/yuanzui0728/enclave