### PR TITLE
Add Karpathy LLM Wiki tutorial (llm_apps_with_memory_tutorials)

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,6 +267,7 @@ streamlit run travel_agent.py
 *   [📝 LLM App with Personalized Memory](advanced_llm_apps/llm_apps_with_memory_tutorials/llm_app_personalized_memory/)
 *   [🗄️ Local ChatGPT Clone with Memory](advanced_llm_apps/llm_apps_with_memory_tutorials/local_chatgpt_with_memory/)
 *   [🧠 Multi-LLM Application with Shared Memory](advanced_llm_apps/llm_apps_with_memory_tutorials/multi_llm_memory/)
+*   [📚 Karpathy LLM Wiki (L1/L2 Cache)](advanced_llm_apps/llm_apps_with_memory_tutorials/karpathy_llm_wiki/)
 
 ### 💬 Chat with X Tutorials
 *Turn any data source into a chat interface.*

--- a/advanced_llm_apps/llm_apps_with_memory_tutorials/karpathy_llm_wiki/README.md
+++ b/advanced_llm_apps/llm_apps_with_memory_tutorials/karpathy_llm_wiki/README.md
@@ -1,0 +1,78 @@
+## 🧠 Karpathy LLM Wiki — Persistent Knowledge Base with L1/L2 Cache
+
+A working implementation of [Andrej Karpathy's LLM Wiki pattern](https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94f) with Claude Code. Instead of scattering notes across a dozen tools, you let an LLM maintain a structured wiki for you. Feed it raw sources — it extracts facts, cross-references them, and keeps the whole thing internally consistent.
+
+The wiki becomes a **persistent, compounding artifact** — not a graveyard of stale notes.
+
+Full implementation, MIT licensed: **[github.com/MehmetGoekce/llm-wiki](https://github.com/MehmetGoekce/llm-wiki)**
+
+### The Problem
+
+If you run any kind of technical practice — freelancing, consulting, side projects — your knowledge scatters fast. Jira tickets, Confluence docs, Slack threads, half-finished notes. Traditional answer is RAG, but RAG re-discovers everything from scratch with every query. Personal wikis are the alternative — but they die. Everyone starts one. Almost nobody maintains one.
+
+As Karpathy puts it: *"the tedious part of maintaining a knowledge base is not the reading or the thinking — it's the bookkeeping."* Updating cross-references, fixing broken links, keeping metadata current. LLMs are perfect at bookkeeping. They do not get bored.
+
+### The L1/L2 Cache Insight
+
+The novel design choice in this implementation (not in Karpathy's gist): a **two-layer cache** modeled on CPU cache hierarchy.
+
+- **L1 = Claude Memory (auto-loaded).** Small, fast, always available. Rules, gotchas, identity, preferences, credentials. Loaded at the start of every session — no `/wiki query` needed.
+- **L2 = Wiki (on-demand).** Large, structured, queried when needed. Projects, workflows, research, deep knowledge.
+
+The routing rule: *Would the LLM making a mistake without this knowledge be dangerous or embarrassing?* → L1. *Merely inconvenient?* → L2.
+
+Credentials *must* live in L1 because the wiki is git-tracked. The L1 memory directory is excluded from git — making it the only safe place for secrets.
+
+### Features
+
+- **Five operations** — `/wiki ingest`, `/wiki query`, `/wiki lint`, `/wiki status`, `/wiki migrate`
+- **Schema-driven consistency** — required properties per page type, automated lint rules
+- **Health checks** — orphan detection, stale content (90+ days), broken references, credential leaks, hub completeness
+- **Append-never-overwrite** — existing wiki content is sacred; new ingests append blocks
+- **Logseq + Obsidian support** — outliner format ideal for LLM-generated content; flat markdown for manual editing
+- **Zero external APIs** — runs entirely on local files + Claude Code. No RAG service, no database, no cloud dependency.
+
+### How to Get Started
+
+1. Clone the standalone implementation:
+
+```bash
+git clone https://github.com/MehmetGoekce/llm-wiki.git
+cd llm-wiki
+```
+
+2. Run the setup script (interactive — picks Logseq or Obsidian, configures wiki path):
+
+```bash
+./setup.sh
+```
+
+3. Open the wiki in Claude Code and try the operations:
+
+```bash
+/wiki status        # show metrics dashboard
+/wiki ingest <url>  # process a source, update 5–15 wiki pages
+/wiki query <q>     # search wiki, synthesize answer with sources
+/wiki lint --fix    # health check + auto-repair
+```
+
+### Schema Example
+
+The schema is the contract between you and the LLM. See [`example_schema.md`](./example_schema.md) for a minimal Logseq schema definition (8 namespaces, 5 page types, lint rules, L1/L2 boundary).
+
+### Tech Stack
+
+- **Claude Code** — LLM brain. Custom slash commands, persistent memory, direct file access.
+- **Logseq** (recommended) or **Obsidian** — wiki UI. Local-first markdown.
+- **Git** — version control for the wiki content.
+- No Python runtime, no API keys (beyond Claude Code itself), no databases.
+
+### Background Reading
+
+- Karpathy's original gist: [LLM Wiki](https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94f)
+- Detailed write-up of this implementation: ["I Built Karpathy's LLM Wiki with Claude Code and Logseq"](https://m3mobytes.substack.com/p/i-built-karpathys-llm-wiki-with-claude)
+- Standalone repo (MIT, full source, schema templates, docs): [github.com/MehmetGoekce/llm-wiki](https://github.com/MehmetGoekce/llm-wiki)
+
+### Contributing
+
+Issues and PRs welcome on the standalone repo: [github.com/MehmetGoekce/llm-wiki/issues](https://github.com/MehmetGoekce/llm-wiki/issues)

--- a/advanced_llm_apps/llm_apps_with_memory_tutorials/karpathy_llm_wiki/example_schema.md
+++ b/advanced_llm_apps/llm_apps_with_memory_tutorials/karpathy_llm_wiki/example_schema.md
@@ -1,0 +1,68 @@
+- wiki-version:: 1.0
+- type:: schema
+- created:: 2026-04-26
+- updated:: 2026-04-26
+- ## About
+  - This is a minimal example schema for a Logseq-based LLM Wiki.
+  - The `/wiki` skill reads this file before every operation to know:
+    - which namespaces are valid
+    - which page types exist and their required properties
+    - which lint rules to enforce
+    - where the L1 / L2 boundary lies
+  - For the full reference schema and Obsidian variant, see the standalone repo:
+    - https://github.com/MehmetGoekce/llm-wiki
+- ## Namespace Conventions
+  - Top-Level: Wiki/Business, Wiki/Tech, Wiki/Content, Wiki/Projects, Wiki/People, Wiki/Learning, Wiki/Reference, Wiki/Careers
+  - Page Naming: Title Case, hyphens for multi-word
+  - Max depth: 3 levels (e.g. Wiki/Tech/Strapi/Migrations)
+  - Files on disk: Triple-underscore separator (Wiki___Tech___Strapi.md)
+- ## Page Types & Required Properties
+  - ### Entity (Person, Client, Tool)
+    - type:: entity
+    - entity-type:: person | client | tool
+    - created:: YYYY-MM-DD
+    - updated:: YYYY-MM-DD
+    - status:: active | inactive | archived
+  - ### Project
+    - type:: project
+    - status:: active | completed | on-hold
+    - created:: YYYY-MM-DD
+    - updated:: YYYY-MM-DD
+  - ### Knowledge
+    - type:: knowledge
+    - domain:: tech | business | content
+    - confidence:: high | medium | low | stale
+    - updated:: YYYY-MM-DD
+  - ### Feedback (Lessons Learned)
+    - type:: feedback
+    - severity:: critical | important | nice-to-know
+    - created:: YYYY-MM-DD
+  - ### Hub (Namespace Index)
+    - type:: hub
+    - namespace:: (the namespace this hub indexes)
+- ## Lint Rules
+  - Orphan Detection: pages with 0 incoming `[[links]]` (hub pages excluded)
+  - Stale Detection: `updated::` > 90 days AND `confidence:: high`
+  - Missing Properties: pages without their type-specific required properties
+  - Broken References: `[[links]]` to pages that do not exist
+  - Hub Completeness: hub pages missing children in their namespace
+  - Credential Leak: regex scan for `token::`, `password::`, `secret::`, `api.key::`
+  - Empty Pages: only properties, no content
+  - Cross-Ref Minimum: pages with fewer than 1 outgoing `[[link]]`
+  - L1/L2 Duplicates: same info in Memory AND Wiki → warning
+- ## L1 / L2 Boundary
+  - L1 (Memory, auto-loaded every session)
+    - Rules and gotchas (e.g. "always use UTF-8 encoding")
+    - Identity and preferences (name, address, language)
+    - Credentials (API keys, tokens — never in L2)
+    - Heuristic: would a mistake here be dangerous or embarrassing?
+  - L2 (Wiki, queried on demand)
+    - Projects and their history
+    - Workflows and processes
+    - Research and learning notes
+    - Heuristic: would a mistake here be merely inconvenient?
+  - Same info in both? → Lint warning. L1 wins for atomic rules; L2 wins for narratives.
+- ## Cross-References
+  - [[Wiki/Reference/Schema-Reference]] — full reference schema
+  - [[Wiki/Reference/Lint-Rules]] — lint-rule details with examples
+  - [[Wiki/Tech/Logseq]] — Logseq-specific conventions

--- a/advanced_llm_apps/llm_apps_with_memory_tutorials/karpathy_llm_wiki/requirements.txt
+++ b/advanced_llm_apps/llm_apps_with_memory_tutorials/karpathy_llm_wiki/requirements.txt
@@ -1,0 +1,11 @@
+# Karpathy LLM Wiki has no Python runtime requirements.
+#
+# Dependencies are external tools:
+#   - Claude Code  (https://docs.anthropic.com/claude/docs/claude-code)
+#   - Logseq       (https://logseq.com/)  -- recommended
+#     OR Obsidian  (https://obsidian.md/) -- alternative
+#   - git          (for wiki version control)
+#
+# Run ./setup.sh to clone the standalone implementation and configure
+# your wiki path interactively. The standalone repo is at:
+#   https://github.com/MehmetGoekce/llm-wiki

--- a/advanced_llm_apps/llm_apps_with_memory_tutorials/karpathy_llm_wiki/setup.sh
+++ b/advanced_llm_apps/llm_apps_with_memory_tutorials/karpathy_llm_wiki/setup.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Bootstrap script for Karpathy LLM Wiki.
+#
+# This is a thin wrapper. The full setup lives in the standalone repo:
+#   https://github.com/MehmetGoekce/llm-wiki
+#
+# Run this to clone the standalone implementation and launch its interactive
+# setup (which configures Logseq vs. Obsidian, wiki path, schema, and the
+# /wiki Claude Code skill).
+
+set -euo pipefail
+
+REPO_URL="https://github.com/MehmetGoekce/llm-wiki.git"
+TARGET_DIR="${LLM_WIKI_DIR:-$HOME/llm-wiki}"
+
+if [ -d "$TARGET_DIR" ]; then
+  echo "llm-wiki already exists at $TARGET_DIR — pulling latest."
+  git -C "$TARGET_DIR" pull --ff-only
+else
+  echo "Cloning llm-wiki to $TARGET_DIR..."
+  git clone --depth 1 "$REPO_URL" "$TARGET_DIR"
+fi
+
+cd "$TARGET_DIR"
+echo
+echo "Running interactive setup..."
+exec ./setup.sh


### PR DESCRIPTION
## Summary

Adds a tutorial subdirectory `advanced_llm_apps/llm_apps_with_memory_tutorials/karpathy_llm_wiki/` that implements [Andrej Karpathy's LLM Wiki gist](https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94f) as a runnable knowledge-base pattern with **persistent memory** for the LLM.

The Karpathy gist defines the *what* (three layers: Sources → Wiki → Schema; three operations: Ingest, Query, Lint). This tutorial provides the *how* — wired up with Claude Code as the LLM brain and Logseq (or Obsidian) as the wiki UI.

## Why it fits LLM Apps with Memory

The existing entries in this section all give an LLM **persistent state across sessions**. This entry does the same thing — but instead of remembering conversations, it remembers structured knowledge that compounds over time. Two memory layers:

- **L1 = Auto-loaded memory** (rules, gotchas, identity, credentials) — available every session without query
- **L2 = On-demand wiki** (projects, workflows, research) — queried via `/wiki query` when needed

The L1/L2 cache split is modeled on CPU cache hierarchy and is the design choice that makes the pattern practical at scale (it is not in the original Karpathy gist).

## What is included

- `README.md` — problem statement, L1/L2 concept, quick-start
- `setup.sh` — bootstrap script that clones the standalone implementation and runs its interactive setup
- `example_schema.md` — minimal Logseq schema (8 namespaces, 5 page types, lint rules, L1/L2 boundary)
- `requirements.txt` — no Python deps; documents the external tools needed (Claude Code + Logseq/Obsidian + git)

## Standalone implementation

Full source, docs, examples, and Obsidian variant: **[github.com/MehmetGoekce/llm-wiki](https://github.com/MehmetGoekce/llm-wiki)** (MIT, 65★, production-validated against a 46-page wiki in daily use).

Detailed write-up of the design: ["I Built Karpathy's LLM Wiki with Claude Code and Logseq"](https://m3mobytes.substack.com/p/i-built-karpathys-llm-wiki-with-claude).

## Test plan

- [x] New subdirectory follows the pattern of existing entries (`ai_arxiv_agent_memory/`, etc.) — README + setup script + minimal example
- [x] Top-level `README.md` updated with new bullet under `LLM Apps with Memory Tutorials`
- [x] All links resolve (Karpathy gist, standalone repo, Substack write-up)
- [x] `setup.sh` is executable and idempotent (re-run pulls latest)