### PR TITLE
Add DataSpoc Data Lake Agent to MCP AI Agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,6 +202,7 @@ streamlit run travel_agent.py
 *   [📑 Notion MCP Agent](mcp_ai_agents/notion_mcp_agent)
 *   [🌍 AI Travel Planner MCP Agent](mcp_ai_agents/ai_travel_planner_mcp_agent_team)
 *   [🔀 Multi-MCP Agent Router](mcp_ai_agents/multi_mcp_agent_router/)
+*   [📊 DataSpoc Data Lake Agent](mcp_ai_agents/dataspoc_data_lake_agent/)
 
 ### 📀 RAG (Retrieval Augmented Generation)
 *Retrieval pipelines - from simple chains to agentic and multi-source.*

--- a/mcp_ai_agents/dataspoc_data_lake_agent/README.md
+++ b/mcp_ai_agents/dataspoc_data_lake_agent/README.md
@@ -1,0 +1,64 @@
+# DataSpoc Data Lake Agent
+
+An AI agent that manages data ingestion and queries a cloud data lake using [DataSpoc](https://github.com/dataspoclab) — an open-source data platform with native MCP and SDK support.
+
+## What it does
+
+- Discovers available tables and their schemas
+- Checks cache freshness and refreshes stale data automatically
+- Answers questions in natural language (generates SQL, executes, explains)
+- Lists and runs data ingestion pipelines
+- Works with S3, GCS, Azure, or local Parquet files
+
+## Stack
+
+- **DataSpoc Pipe** — data ingestion (400+ Singer sources to Parquet)
+- **DataSpoc Lens** — SQL queries via DuckDB + AI natural language queries
+- **Anthropic Claude** — for interpreting results and handling edge cases
+
+## Setup
+
+```bash
+pip install -r requirements.txt
+
+# Initialize DataSpoc
+dataspoc-pipe init
+dataspoc-lens init
+
+# Add a data source (example: local CSV)
+dataspoc-pipe add my-source
+
+# Register the bucket with Lens
+dataspoc-lens add-bucket file:///path/to/lake
+
+# Set your Anthropic API key
+export ANTHROPIC_API_KEY=sk-...
+
+# Run the agent
+python dataspoc_data_lake_agent.py
+```
+
+## MCP Alternative
+
+Instead of the Python SDK, you can use DataSpoc as MCP servers with Claude Desktop:
+
+```json
+{
+  "mcpServers": {
+    "dataspoc-lens": {
+      "command": "dataspoc-lens",
+      "args": ["mcp"]
+    },
+    "dataspoc-pipe": {
+      "command": "dataspoc-pipe",
+      "args": ["mcp"]
+    }
+  }
+}
+```
+
+## Links
+
+- [DataSpoc Website](https://dataspoc.com)
+- [Pipe GitHub](https://github.com/dataspoclab/dataspoc-pipe)
+- [Lens GitHub](https://github.com/dataspoclab/dataspoc-lens)

--- a/mcp_ai_agents/dataspoc_data_lake_agent/dataspoc_data_lake_agent.py
+++ b/mcp_ai_agents/dataspoc_data_lake_agent/dataspoc_data_lake_agent.py
@@ -1,0 +1,126 @@
+"""
+DataSpoc Data Lake Agent
+
+An AI agent that ingests data, queries it with SQL and natural language,
+and manages cache freshness — all through DataSpoc's MCP servers and Python SDK.
+
+Setup:
+    pip install -r requirements.txt
+    dataspoc-pipe init
+    dataspoc-lens init
+
+Usage:
+    python dataspoc_data_lake_agent.py
+"""
+
+import os
+from anthropic import Anthropic
+
+# DataSpoc SDK imports
+from dataspoc_lens import LensClient
+from dataspoc_pipe import PipeClient
+
+SYSTEM_PROMPT = """You are a data analyst agent with access to a data lake via DataSpoc.
+
+You have two tools:
+1. PipeClient — manage data ingestion (list pipelines, run them, check status, read logs)
+2. LensClient — query the data lake (list tables, get schemas, run SQL, ask in natural language, manage cache)
+
+When the user asks a question:
+1. First check if the data is cached and fresh. If stale, refresh it.
+2. Try to answer using SQL queries or natural language ask().
+3. Show the SQL you used and explain the results.
+4. If data is missing, suggest which pipeline to run.
+
+Always be honest about what data is available and what isn't."""
+
+
+def run_agent():
+    client = Anthropic()
+
+    # Initialize DataSpoc clients
+    pipe = PipeClient()
+    lens = LensClient()
+
+    # Show available data
+    tables = lens.tables()
+    pipelines = pipe.pipelines()
+
+    print("=" * 60)
+    print("  DataSpoc Data Lake Agent")
+    print("=" * 60)
+    print(f"\n  Tables available: {len(tables)}")
+    for t in tables:
+        print(f"    - {t}")
+    print(f"\n  Pipelines configured: {len(pipelines)}")
+    for p in pipelines:
+        print(f"    - {p}")
+    print(f"\n  Type your question or 'quit' to exit.\n")
+
+    messages = []
+
+    # Build context about available data
+    schema_context = ""
+    for t in tables[:10]:  # Limit to 10 tables for context
+        cols = lens.schema(t)
+        col_names = ", ".join([c["column_name"] for c in cols])
+        schema_context += f"Table '{t}': {col_names}\n"
+
+    while True:
+        user_input = input("You: ").strip()
+        if not user_input or user_input.lower() in ("quit", "exit"):
+            break
+
+        messages.append({"role": "user", "content": user_input})
+
+        # Try to answer with DataSpoc
+        try:
+            # Check cache freshness first
+            cache_status = lens.cache_status()
+            stale_tables = [s["table"] for s in cache_status if s["status"] == "stale"]
+            if stale_tables:
+                print(f"\n  [Refreshing {len(stale_tables)} stale table(s)...]")
+                lens.cache_refresh_stale()
+
+            # Use AI ask for natural language questions
+            result = lens.ask(user_input)
+
+            if result.get("error"):
+                # Fall back to Claude for interpretation
+                context = f"Available tables and schemas:\n{schema_context}\nUser question: {user_input}\nDataSpoc returned error: {result['error']}"
+                response = client.messages.create(
+                    model="claude-sonnet-4-20250514",
+                    max_tokens=1024,
+                    system=SYSTEM_PROMPT,
+                    messages=[{"role": "user", "content": context}],
+                )
+                answer = response.content[0].text
+            else:
+                sql = result.get("sql", "")
+                rows = result.get("rows", [])
+                columns = result.get("columns", [])
+                duration = result.get("duration", 0)
+
+                # Format results
+                answer = f"SQL: {sql}\n\n"
+                if columns and rows:
+                    answer += " | ".join(columns) + "\n"
+                    answer += "-" * 40 + "\n"
+                    for row in rows[:20]:  # Limit display
+                        answer += " | ".join(str(v) for v in row) + "\n"
+                    answer += f"\n({len(rows)} rows, {duration:.3f}s)"
+                else:
+                    answer += "No results returned."
+
+        except Exception as e:
+            answer = f"Error: {e}"
+
+        print(f"\nAgent: {answer}\n")
+        messages.append({"role": "assistant", "content": answer})
+
+    lens.close()
+    print("\nGoodbye!")
+
+
+if __name__ == "__main__":
+    run_agent()

--- a/mcp_ai_agents/dataspoc_data_lake_agent/requirements.txt
+++ b/mcp_ai_agents/dataspoc_data_lake_agent/requirements.txt
@@ -1,0 +1,3 @@
+dataspoc-lens[mcp,ai]
+dataspoc-pipe[mcp]
+anthropic>=0.50


### PR DESCRIPTION
Adds a new MCP AI Agent template using DataSpoc to build a data lake agent.

The agent discovers tables, refreshes cache, answers questions with SQL and natural language, and manages pipelines.

Stack: DataSpoc Pipe + Lens + Anthropic Claude
Files: mcp_ai_agents/dataspoc_data_lake_agent/

https://github.com/dataspoclab