### PR TITLE
Add lean-ctx to LLM Optimization Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,8 +281,9 @@ streamlit run travel_agent.py
 ### 🎯 LLM Optimization Tools
 *Reduce token usage, context size, and API cost without losing quality.*
 
-*   [🎯 Toonify Token Optimization](advanced_llm_apps/llm_optimization_tools/toonify_token_optimization/) - Reduce LLM API costs by 30–60% using TOON format
 *   [🧠 Headroom Context Optimization](advanced_llm_apps/llm_optimization_tools/headroom_context_optimization/) - Reduce LLM API costs by 50–90%
+*   [⚡ lean-ctx](https://github.com/yvgude/lean-ctx) - MCP context runtime for coding agents; session caching, tree-sitter reads (18 languages), compressed shell output. [leanctx.com](https://leanctx.com). Apache-2.0. <sub>↗ external</sub>
+*   [🎯 Toonify Token Optimization](advanced_llm_apps/llm_optimization_tools/toonify_token_optimization/) - Reduce LLM API costs by 30–60% using TOON format
 
 ### 🔧 LLM Fine-tuning Tutorials
 *End-to-end fine-tuning recipes for open-source models.*


### PR DESCRIPTION
Adds [lean-ctx](https://github.com/yvgude/lean-ctx) (MCP context runtime for coding agents) to the **LLM Optimization Tools** section, next to Headroom and Toonify. Uses the same bullet and external-link format as other non-template entries. Reorders that section alphabetically by project name (Headroom, lean-ctx, Toonify).\n\n- GitHub: https://github.com/yvgude/lean-ctx\n- Site: https://leanctx.com\n- License: Apache-2.0