### PR TITLE
Add Swiss Truth MCP — verified knowledge base for hallucination-free LLM apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,6 +225,7 @@ streamlit run travel_agent.py
 *   [🖼️ Vision RAG](rag_tutorials/vision_rag/)
 *   [🩺 RAG Failure Diagnostics Clinic](rag_tutorials/rag_failure_diagnostics_clinic/)
 *   [🕸️ Knowledge Graph RAG with Citations](rag_tutorials/knowledge_graph_rag_citations/)
+- [Swiss Truth MCP](https://github.com/swisstruthorg/swiss-truth-mcp) - Verified knowledge base for hallucination-free LLM apps. 3000+ certified facts, 38 domains, 10 languages. MCP server + LangChain/CrewAI/AutoGen integrations. No API key required. ![GitHub Repo stars](https://img.shields.io/github/stars/swisstruthorg/swiss-truth-mcp?style=social)
 
 ### 🧩 Awesome Agent Skills
 *Ready-to-use agent skill files you can plug into any AI agent or LLM workflow.*


### PR DESCRIPTION
Adding Swiss Truth MCP to the Knowledge Base / RAG section.

**Swiss Truth** is a verified knowledge base that gives LLM apps access to 3000+ certified facts across 38 domains. It's the missing ground-truth layer for apps that need reliable answers on Swiss/EU regulatory topics, health, finance, AI/ML, and more.

**MCP:** `npx -y mcp-remote https://swisstruth.org/mcp`
**LangChain:** `pip install swiss-truth-langchain`
**CrewAI:** `pip install swiss-truth-crewai`
**GitHub:** https://github.com/swisstruthorg/swiss-truth-mcp

- 3000+ certified facts, 38 domains, 10 languages
- 5-stage human+AI validation pipeline
- SHA256 integrity hashes on every claim
- No API key required