### PR TITLE
Add tday to Advanced AI Agents list

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ streamlit run travel_agent.py
 *   [🎧 AI Social Media News and Podcast Agent](advanced_ai_agents/multi_agent_apps/ai_news_and_podcast_agents/)
 *   [🌐 Openwork - Open Browser Automation Agent](https://github.com/accomplish-ai/openwork) <sub>↗ external</sub>
 *   [🛡️ Trust-Gated Multi-Agent Research Team](advanced_ai_agents/multi_agent_apps/trust_gated_agent_team/)
+*   [🖥️ Tday - Terminal Launcher for Coding Agents](https://github.com/unbug/tday) <sub>↗ external</sub>
 
 ### 🎮 Autonomous Game-Playing Agents
 *Agents that play games end-to-end - reasoning, strategy, and action.*


### PR DESCRIPTION
Adds [tday](https://github.com/unbug/tday) — a terminal meta-layer for coding-agent CLIs (Claude Code, Codex, OpenCode, etc.) — to the Advanced AI Agents section. Provides browser-style agent tabs, unified provider config, shared long-term memory, local inference auto-discovery, and cross-agent token analytics backed by a Rust core.