### PR TITLE
Link OutcomeOps context-engineering reference repo in RAG section

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,7 @@ streamlit run travel_agent.py
 *   [🖼️ Vision RAG](rag_tutorials/vision_rag/)
 *   [🩺 RAG Failure Diagnostics Clinic](rag_tutorials/rag_failure_diagnostics_clinic/)
 *   [🕸️ Knowledge Graph RAG with Citations](rag_tutorials/knowledge_graph_rag_citations/)
+*   [🧠 Context Engineering Reference Implementation](https://github.com/outcomeops/context-engineering) <sub>↗ external</sub>
 
 ### 🧩 Awesome Agent Skills
 *Ready-to-use agent skill files you can plug into any AI agent or LLM workflow.*


### PR DESCRIPTION
 ## Summary
Adds a single link in the **📀 RAG (Retrieval Augmented Generation)** section pointing to [outcomeops/context-engineering](https://github.com/outcomeops/context-engineering) — a runnable, end-to-end reference implementation of context  engineering on Amazon Bedrock (Claude + Titan embeddings).

Marked `↗ external` to match the convention used for the other off-repo links (Openwork, Wispr clone).

## Why it fits
The repo is structured as a five-component reference (corpus → retrieval → injection → output → enforcement), each folder with its own `requirements.txt` and runnable command — same shape as the other RAG entries. It explicitly frames itself as "RAG + output + enforcement layers," so it sits naturally alongside the existing RAG tutorials.

## Test plan
- [x] Link resolves and points to a public GitHub repo with a runnable example
- [x] Entry placed at the end of the RAG section, follows existing formatting (emoji + title + `<sub>↗ external</sub>` tag)
- [x] No other sections, headers, or links modified