### PR TITLE
Upgrade travel planner agent team to agno 2.x (CVE-2026-35002)

### DIFF
--- a/advanced_ai_agents/multi_agent_apps/agent_teams/ai_travel_planner_agent_team/backend/agents/destination.py
+++ b/advanced_ai_agents/multi_agent_apps/agent_teams/ai_travel_planner_agent_team/backend/agents/destination.py
@@ -60,8 +60,7 @@ destination_agent = Agent(
     - Standard tourist advice
     """,
     markdown=True,
-    show_tool_calls=True,
-    add_datetime_to_instructions=True,
+    add_datetime_to_context=True,
     retries=3,
     delay_between_retries=2,
     exponential_backoff=True,

--- a/advanced_ai_agents/multi_agent_apps/agent_teams/ai_travel_planner_agent_team/backend/agents/flight.py
+++ b/advanced_ai_agents/multi_agent_apps/agent_teams/ai_travel_planner_agent_team/backend/agents/flight.py
@@ -60,7 +60,6 @@ flight_search_agent = Agent(
       - stops (int): The number of stops of the flight
     """,
     markdown=True,
-    show_tool_calls=True,
     debug_mode=True,
     retries=3,
     delay_between_retries=2,

--- a/advanced_ai_agents/multi_agent_apps/agent_teams/ai_travel_planner_agent_team/backend/agents/food.py
+++ b/advanced_ai_agents/multi_agent_apps/agent_teams/ai_travel_planner_agent_team/backend/agents/food.py
@@ -108,7 +108,6 @@ dining_agent = Agent(
       Use emojis and clear formatting for better readability.
     """,
     markdown=True,
-    show_tool_calls=True,
     debug_mode=True,
     retries=3,
     delay_between_retries=2,

--- a/advanced_ai_agents/multi_agent_apps/agent_teams/ai_travel_planner_agent_team/backend/agents/hotel.py
+++ b/advanced_ai_agents/multi_agent_apps/agent_teams/ai_travel_planner_agent_team/backend/agents/hotel.py
@@ -74,7 +74,6 @@ hotel_search_agent = Agent(
       - url (str): The url of the hotel
     """,
     markdown=True,
-    show_tool_calls=True,
     debug_mode=True,
     retries=3,
     delay_between_retries=2,

--- a/advanced_ai_agents/multi_agent_apps/agent_teams/ai_travel_planner_agent_team/backend/agents/itinerary.py
+++ b/advanced_ai_agents/multi_agent_apps/agent_teams/ai_travel_planner_agent_team/backend/agents/itinerary.py
@@ -119,8 +119,7 @@ itinerary_agent = Agent(
         - **Backup Plans**: {alternative schedules for weather/closures}
         """
     ),
-    add_datetime_to_instructions=True,
-    show_tool_calls=True,
+    add_datetime_to_context=True,
     retries=2,
     delay_between_retries=2,
     exponential_backoff=True,

--- a/advanced_ai_agents/multi_agent_apps/agent_teams/ai_travel_planner_agent_team/backend/agents/team.py
+++ b/advanced_ai_agents/multi_agent_apps/agent_teams/ai_travel_planner_agent_team/backend/agents/team.py
@@ -32,7 +32,6 @@ trip_planning_team = Team(
         flight_search_agent,
         itinerary_agent,
     ],
-    show_tool_calls=True,
     markdown=True,
     description=(
         "You are the lead orchestrator of the TripCraft AI planning team. "
@@ -312,23 +311,11 @@ Format the entire itinerary with:
 • Local emergency numbers
 • Relevant photos and maps
 """,
-    success_criteria=[
-        "✅ Complete itinerary with all travel days and activities",
-        "✅ Stays within budget constraints",
-        "✅ Matches user priorities and travel style",
-        "✅ Well-structured daily schedule matching user's pace",
-        "✅ Real flights and accommodations with costs and links",
-        "✅ Daily activities aligned with selected vibes",
-        "✅ Clear Markdown format with good visuals",
-        "✅ Realistic budget breakdown",
-        "✅ Personalized tips based on user profile",
-        "✅ Verified, real-world locations only",
-    ],
-    enable_agentic_context=True,
+    enable_agentic_state=True,
     share_member_interactions=True,
     show_members_responses=True,
-    add_datetime_to_instructions=True,
-    add_member_tools_to_system_message=True,
+    add_datetime_to_context=True,
+    add_member_tools_to_context=True,
     # debug_mode=True,
     telemetry=False,
 )

--- a/advanced_ai_agents/multi_agent_apps/agent_teams/ai_travel_planner_agent_team/backend/pyproject.toml
+++ b/advanced_ai_agents/multi_agent_apps/agent_teams/ai_travel_planner_agent_team/backend/pyproject.toml
@@ -5,7 +5,7 @@ description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
-    "agno>=1.5.6",
+    "agno>=2.3.24",
     "asyncpg>=0.30.0",
     "boto3>=1.38.27",
     "cuid2>=2.0.1",


### PR DESCRIPTION
Migrates the AI travel planner agent team from agno 1.x to 2.x, fixing the critical eval injection vulnerability (CVE-2026-35002).

API changes: show_tool_calls removed, add_datetime_to_instructions renamed to add_datetime_to_context, add_member_tools_to_system_message renamed to add_member_tools_to_context, enable_agentic_context renamed to enable_agentic_state, success_criteria removed.