### PR TITLE
Add Hlido MCP review tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,6 +203,7 @@ streamlit run travel_agent.py
 *   [📑 Notion MCP Agent](mcp_ai_agents/notion_mcp_agent)
 *   [🌍 AI Travel Planner MCP Agent](mcp_ai_agents/ai_travel_planner_mcp_agent_team)
 *   [🔀 Multi-MCP Agent Router](mcp_ai_agents/multi_mcp_agent_router/)
+*   [🧾 Hlido MCP Reviews](https://hlido.eu/mcp) <sub>↗ external</sub> - Query proof-backed AI agent reviews, scores, and C2PA evidence through a 9-tool MCP server
 
 ### 📀 RAG (Retrieval Augmented Generation)
 *Retrieval pipelines - from simple chains to agentic and multi-source.*


### PR DESCRIPTION
Adds Hlido's MCP review endpoint to the MCP AI Agents section. Hlido publishes proof-backed AI agent reviews with C2PA-signed evidence and exposes them through a 9-tool MCP server for LLM apps that need trust checks before integrating an agent: https://hlido.eu. Disclosure: Hlido is submitted by its founder.