### PR TITLE
Add Repull booking agent team — vacation-rental MCP example

### DIFF
--- a/mcp_ai_agents/repull_booking_agent_team/.env.example
+++ b/mcp_ai_agents/repull_booking_agent_team/.env.example
@@ -1,0 +1,6 @@
+# Sign up at https://repull.dev/dashboard to get an API key.
+# Test keys look like sk_test_..., live keys look like sk_live_...
+REPULL_API_KEY=sk_test_your_key_here
+
+# Default LLM provider for the example. Get yours at https://platform.openai.com/api-keys
+OPENAI_API_KEY=sk-...

--- a/mcp_ai_agents/repull_booking_agent_team/README.md
+++ b/mcp_ai_agents/repull_booking_agent_team/README.md
@@ -1,0 +1,97 @@
+# 🏠 Repull Booking Agent Team
+
+A multi-agent vacation-rental assistant powered by the [Repull MCP server](https://repull.dev/docs/mcp-server). One Repull API key fans out to 50+ PMS platforms and the major OTAs (Airbnb, Booking.com, VRBO, Plumguide), so the agents can read reservations, properties, listings, guests, and conversations across an entire short-term rental portfolio through a single MCP connection.
+
+The team is built on [Agno](https://github.com/agno-agi/agno) and ships three specialists plus a coordinator:
+
+- **Listing Specialist** — properties and listings catalog (`repull_list_properties`, `repull_list_listings`, `repull_list_airbnb_listings`)
+- **Reservation Specialist** — bookings, guests, and conversations (`repull_list_reservations`, `repull_get_reservation`, `repull_list_guests`, `repull_list_conversations`)
+- **Connections Specialist** — connected channels and plan info (`repull_whoami`, `repull_list_connections`, `repull_list_connect_providers`)
+- **Coordinator** routes user queries to the right specialist and stitches the final answer together.
+
+## Features
+
+- 🧭 **Routing** — the coordinator decides which specialist handles each ask. Account-level questions ("what's connected?") go to Connections; reservation lookups go to Reservations; listing catalog work goes to Listings.
+- 🔍 **Discovery built in** — the MCP server exposes `repull_list_endpoints` and `repull_get_docs` so the agents can self-serve when they hit something they don't know.
+- 📑 **Cursor pagination** — list tools accept `cursor`. The agents are instructed to fetch one page, summarize, and ask before paging further (LLMs do better when paging is explicit).
+- 🛡️ **Read-only by design** — `@repull/mcp` v0.2 deliberately omits write tools. An LLM that "tidies up" a live booking calendar is a footgun. Mutating tools will land in a follow-up release with explicit per-tool opt-in.
+
+## What you'll need
+
+1. **A Repull API key.** Sign up at [repull.dev/dashboard](https://repull.dev/dashboard) — test keys look like `sk_test_...`. The MCP server respects whichever you pass.
+2. **An OpenAI API key.** Get one at [platform.openai.com/api-keys](https://platform.openai.com/api-keys). The example uses `gpt-4o`. Prefer Anthropic? Swap `OpenAIChat` for `Claude` from `agno.models.anthropic` and set `ANTHROPIC_API_KEY` — the rest of the team wiring is identical.
+3. **Node.js 18+** on your `PATH`. The MCP server is `@repull/mcp` on npm and is launched via `npx -y @repull/mcp`. Verify with `node --version` and `npx --version`.
+
+> Markets / pricing-intel endpoints exist on the Repull API, but `@repull/mcp` v0.2 does not expose them yet. The agent will pick them up automatically once they're added — `repull_list_endpoints` is how it discovers what's available, so no agent code change is needed when new tools land.
+
+## Run it
+
+```bash
+git clone https://github.com/Shubhamsaboo/awesome-llm-apps.git
+cd awesome-llm-apps/mcp_ai_agents/repull_booking_agent_team
+
+pip install -r requirements.txt
+
+cp .env.example .env       # then edit .env with your keys
+streamlit run app.py
+```
+
+Open the browser tab Streamlit prints (default `http://localhost:8501`). If you skipped the `.env` step, you can paste keys into the sidebar at runtime instead.
+
+## Try these prompts
+
+| Prompt | What the team does |
+|---|---|
+| `What's connected to my account?` | Connections Specialist calls `repull_whoami` and reports plan + connected channels. |
+| `Show me upcoming reservations on Airbnb.` | Reservation Specialist calls `repull_list_reservations` with `platform=airbnb` and `check_in_after=<today>`. |
+| `List my Airbnb listings, then find this week's bookings for the first one.` | Listing Specialist runs `repull_list_airbnb_listings`; Reservation Specialist follows up with a filtered `repull_list_reservations`. |
+| `What can Repull actually do?` | Connections Specialist falls back to `repull_list_endpoints` for discovery. |
+| `Who is the guest on reservation 123, and what was their last message?` | Reservation Specialist chains `repull_get_reservation` → `repull_list_conversations` → `repull_list_conversation_messages`. |
+
+### Example session
+
+```
+You: What's connected to my account?
+
+Routed to: Connections Specialist
+Tool calls: repull_whoami
+
+> Workspace: "Sample Vacation Rentals" — Pro plan
+> Connected channels: Airbnb (active), Booking.com (active), Hostaway (PMS)
+> Disconnected: VRBO, Plumguide
+```
+
+```
+You: Show me 5 upcoming Airbnb reservations.
+
+Routed to: Reservation Specialist
+Tool calls: repull_list_reservations(limit=5, platform=airbnb, check_in_after=2026-05-03)
+
+> | id   | guest      | check-in   | nights | total |
+> |------|------------|------------|--------|-------|
+> | 9123 | Alex K.    | 2026-05-09 | 3      | $612  |
+> | 9118 | Diana R.   | 2026-05-11 | 7      | $1,540|
+> ...
+```
+
+## Troubleshooting
+
+| Symptom | Fix |
+|---|---|
+| `Error: spawn npx ENOENT` | Install Node.js 18+ and re-open your shell. |
+| `unauthorized (401)` | The `REPULL_API_KEY` is missing or invalid. Re-check it at [repull.dev/dashboard](https://repull.dev/dashboard). |
+| `forbidden (403)` on a specific tool | The key is valid but the workspace doesn't have access. Run "what's connected?" first to see plan + entitlements. |
+| `provider_unavailable (503)` | A downstream PMS/OTA is having a moment. Try again in a minute; the error envelope includes a `request_id` for support. |
+| Agent invents a listing or channel | Re-run with the prompt "ground every claim in tool output, do not fabricate" — and file an issue, that's a real bug. |
+
+## Links
+
+- 📦 npm package: [`@repull/mcp`](https://www.npmjs.com/package/@repull/mcp)
+- 📚 MCP server docs: [repull.dev/docs/mcp-server](https://repull.dev/docs/mcp-server)
+- 🌐 Repull docs: [repull.dev/docs](https://repull.dev/docs)
+- 🤖 Agno framework: [github.com/agno-agi/agno](https://github.com/agno-agi/agno)
+- 🛠️ MCP spec: [modelcontextprotocol.io](https://modelcontextprotocol.io)
+
+## License
+
+Same as the parent repo. The MCP server itself is MIT-licensed.

--- a/mcp_ai_agents/repull_booking_agent_team/app.py
+++ b/mcp_ai_agents/repull_booking_agent_team/app.py
@@ -1,0 +1,309 @@
+"""Repull Booking Agent Team — vacation-rental MCP example.
+
+A multi-agent team that talks to a property manager's vacation-rental data
+through the Repull MCP server (`@repull/mcp` on npm). One Repull API key
+fans out to 50+ PMS platforms and the major OTAs (Airbnb, Booking.com,
+VRBO, Plumguide).
+
+Three specialist personas plus a coordinator:
+
+  - Listing Specialist     -> properties + listings catalog
+  - Reservation Specialist -> guest bookings, status, dates, pricing
+  - Connections Specialist -> connected channels, plan, what is wired up
+
+Coordinator routes the user query to the right specialist and stitches the
+final answer together.
+
+Docs: https://repull.dev/docs/mcp-server
+Package: https://www.npmjs.com/package/@repull/mcp
+"""
+
+import asyncio
+import os
+from textwrap import dedent
+
+import streamlit as st
+from agno.agent import Agent
+from agno.models.openai import OpenAIChat
+from agno.team import Team
+from agno.tools.mcp import MCPTools
+from dotenv import load_dotenv
+
+load_dotenv()
+
+
+# ---------- UI shell ----------
+
+st.set_page_config(
+    page_title="Repull Booking Agent Team",
+    page_icon="\U0001f3e0",
+    layout="wide",
+)
+
+st.title("\U0001f3e0 Repull Booking Agent Team")
+st.markdown(
+    "A multi-agent vacation-rental assistant powered by the "
+    "[Repull MCP server](https://repull.dev/docs/mcp-server). "
+    "One API key reads reservations, properties, listings, guests, and "
+    "conversations across 50+ PMS platforms and the major OTAs."
+)
+
+
+# ---------- Sidebar config ----------
+
+with st.sidebar:
+    st.header("\U0001f511 Configuration")
+
+    repull_key_default = os.getenv("REPULL_API_KEY", "")
+    openai_key_default = os.getenv("OPENAI_API_KEY", "")
+
+    repull_key = st.text_input(
+        "Repull API Key",
+        type="password",
+        value=repull_key_default,
+        help="Get yours at https://repull.dev/dashboard. Test keys start with `sk_test_`.",
+    )
+    openai_key = st.text_input(
+        "OpenAI API Key",
+        type="password",
+        value=openai_key_default,
+        help="Get yours at https://platform.openai.com/api-keys",
+    )
+
+    st.markdown("---")
+    st.subheader("\U0001f916 Specialists")
+    st.markdown(
+        "- **Listing Specialist** — properties & listings catalog\n"
+        "- **Reservation Specialist** — guest bookings & details\n"
+        "- **Connections Specialist** — connected channels & plan info"
+    )
+
+    st.markdown("---")
+    st.caption(
+        "This example uses `@repull/mcp` v0.2 (read-only). "
+        "Mutating tools are intentionally not exposed yet — see the "
+        "[MCP server docs](https://repull.dev/docs/mcp-server) for why."
+    )
+
+    st.markdown("---")
+    st.caption(
+        "**Heads up:** Markets / pricing-intel endpoints exist on the Repull "
+        "API but are not exposed by `@repull/mcp` v0.2. Once they are, the "
+        "agent will pick them up automatically via `repull_list_endpoints`."
+    )
+
+
+# ---------- Agent team factory ----------
+
+def build_team(mcp_tools: MCPTools, openai_api_key: str) -> Team:
+    """Build the Repull booking agent team around a connected MCP toolset."""
+
+    listing_specialist = Agent(
+        name="Listing Specialist",
+        role="Property and listings catalog expert",
+        model=OpenAIChat(id="gpt-4o", api_key=openai_api_key),
+        tools=[mcp_tools],
+        instructions=dedent(
+            """
+            You are the Listing Specialist on a vacation-rental ops team.
+
+            Stay in your lane: properties (the underlying PMS records),
+            listings (the canonical Repull objects published to channels),
+            and the Airbnb-side view of those listings.
+
+            Preferred tools:
+              - repull_list_properties          (filter by `provider`)
+              - repull_get_property             (by id)
+              - repull_list_listings            (canonical Repull listings)
+              - repull_list_airbnb_listings     (Airbnb's view)
+
+            Rules:
+              - Always paginate explicitly via `cursor`. Do not loop blindly
+                — fetch one page, summarize, ask if the user wants more.
+              - Quote IDs verbatim so other specialists can re-use them.
+              - If a tool returns an error envelope, surface `code`, `fix`,
+                and `docs_url` to the user instead of swallowing it.
+            """
+        ).strip(),
+        markdown=True,
+    )
+
+    reservation_specialist = Agent(
+        name="Reservation Specialist",
+        role="Guest reservations and conversations expert",
+        model=OpenAIChat(id="gpt-4o", api_key=openai_api_key),
+        tools=[mcp_tools],
+        instructions=dedent(
+            """
+            You are the Reservation Specialist on a vacation-rental ops team.
+
+            Stay in your lane: reservations across every connected channel,
+            guest profiles, and message threads with guests.
+
+            Preferred tools:
+              - repull_list_reservations         (filters: status, platform,
+                                                  listing_id, check_in_after,
+                                                  check_in_before)
+              - repull_get_reservation           (full detail by id)
+              - repull_list_guests               (cursor paginated)
+              - repull_get_guest                 (single guest profile)
+              - repull_list_conversations        (message threads)
+              - repull_list_conversation_messages
+
+            Rules:
+              - When a date range is implied ("this week", "next month"),
+                compute the ISO dates and pass them as `check_in_after` /
+                `check_in_before` rather than fetching everything and
+                filtering client-side.
+              - To find a guest's latest thread for a reservation, fetch the
+                reservation, pull the guest id, then list conversations and
+                messages in two cheap calls — do not scan every message.
+              - v0.2 of the MCP server is read-only. If the user asks to
+                cancel, modify, refund, or message a guest, explain that
+                writes are not exposed yet and point them at the Repull SDK
+                (https://repull.dev/docs).
+            """
+        ).strip(),
+        markdown=True,
+    )
+
+    connections_specialist = Agent(
+        name="Connections Specialist",
+        role="Account and integrations expert",
+        model=OpenAIChat(id="gpt-4o", api_key=openai_api_key),
+        tools=[mcp_tools],
+        instructions=dedent(
+            """
+            You are the Connections Specialist on a vacation-rental ops team.
+
+            Stay in your lane: which PMS / OTA channels are connected, the
+            workspace plan and entitlements, and the catalog of channels
+            this account *could* connect.
+
+            Preferred tools:
+              - repull_whoami                       (call FIRST whenever a
+                                                    new session starts)
+              - repull_health_check
+              - repull_list_connections
+              - repull_list_connect_providers
+
+            Rules:
+              - Always ground answers in the actual `repull_whoami` result.
+                Never invent connected channels or plan info.
+              - If the user is missing a needed channel (e.g. "show
+                Booking.com reservations" but Booking.com is not connected),
+                say so plainly and link them to the Connect docs at
+                https://repull.dev/docs.
+              - If you need to learn what an endpoint does, fall back to
+                `repull_list_endpoints` (discovery) and `repull_get_docs`.
+            """
+        ).strip(),
+        markdown=True,
+    )
+
+    return Team(
+        name="Repull Booking Team",
+        model=OpenAIChat(id="gpt-4o", api_key=openai_api_key),
+        members=[
+            listing_specialist,
+            reservation_specialist,
+            connections_specialist,
+        ],
+        instructions=dedent(
+            """
+            You are the coordinator of a vacation-rental ops team. The user
+            is a property manager. Their data lives behind the Repull API
+            and is exposed to you via the Repull MCP server.
+
+            Routing rules:
+              - Account / plan / "what is connected" / channel setup
+                  -> Connections Specialist
+              - Properties, listings, the catalog of stays
+                  -> Listing Specialist
+              - Reservations, guests, message threads, dates, pricing
+                  -> Reservation Specialist
+              - Mixed asks -> chain them. Always call the Connections
+                Specialist FIRST on a fresh session to ground the team in
+                what is actually connected.
+
+            Output rules:
+              - Use markdown. Tables when you have rows, bullets otherwise.
+              - Cite every concrete number / status / date back to the tool
+                that produced it.
+              - Do not fabricate listings, reservations, or channels. If
+                a list comes back empty, say "no results" instead of
+                inventing examples.
+              - This MCP server is read-only in v0.2 — never claim you
+                made a change.
+            """
+        ).strip(),
+        markdown=True,
+        show_members_responses=True,
+    )
+
+
+# ---------- Async runner ----------
+
+async def run_query(repull_api_key: str, openai_api_key: str, query: str) -> str:
+    """Spawn the Repull MCP server, build the team, run one query."""
+
+    env = {**os.environ, "REPULL_API_KEY": repull_api_key}
+
+    # `npx -y @repull/mcp` is the published, public way to start the server.
+    # The `-y` skips the install confirmation. Set NPM_CONFIG_YES too in case
+    # an older npx is in PATH.
+    env.setdefault("NPM_CONFIG_YES", "true")
+
+    async with MCPTools(
+        command="npx -y @repull/mcp",
+        env=env,
+        timeout_seconds=120,
+    ) as mcp_tools:
+        team = build_team(mcp_tools, openai_api_key)
+        result = await team.arun(query)
+        return result.content if hasattr(result, "content") else str(result)
+
+
+def run_sync(repull_api_key: str, openai_api_key: str, query: str) -> str:
+    """Sync wrapper around `run_query` so Streamlit can call it directly."""
+    return asyncio.run(run_query(repull_api_key, openai_api_key, query))
+
+
+# ---------- Chat UI ----------
+
+if "messages" not in st.session_state:
+    st.session_state.messages = []
+
+for msg in st.session_state.messages:
+    with st.chat_message(msg["role"]):
+        st.markdown(msg["content"])
+
+placeholder = (
+    "Try: 'What's connected to my account?' or "
+    "'Show me upcoming Airbnb reservations'"
+)
+
+if prompt := st.chat_input(placeholder):
+    if not repull_key:
+        st.error("Please enter your Repull API key in the sidebar.")
+    elif not openai_key:
+        st.error("Please enter your OpenAI API key in the sidebar.")
+    else:
+        st.session_state.messages.append({"role": "user", "content": prompt})
+        with st.chat_message("user"):
+            st.markdown(prompt)
+
+        with st.chat_message("assistant"):
+            with st.spinner("Routing to specialists and fetching from Repull..."):
+                try:
+                    answer = run_sync(repull_key, openai_key, prompt)
+                except Exception as exc:
+                    answer = (
+                        f"**Error:** {exc}\n\n"
+                        "Common causes:\n"
+                        "- Node.js / `npx` not on PATH (the MCP server runs via npx)\n"
+                        "- Invalid `REPULL_API_KEY` (check at https://repull.dev/dashboard)\n"
+                        "- Network blocked from reaching `api.repull.dev`"
+                    )
+            st.markdown(answer)
+            st.session_state.messages.append({"role": "assistant", "content": answer})

--- a/mcp_ai_agents/repull_booking_agent_team/requirements.txt
+++ b/mcp_ai_agents/repull_booking_agent_team/requirements.txt
@@ -1,0 +1,5 @@
+streamlit>=1.28.0
+agno>=2.2.10
+openai>=1.0.0
+python-dotenv>=1.0.0
+mcp>=1.0.0


### PR DESCRIPTION
## Summary

Adds a new example under `mcp_ai_agents/repull_booking_agent_team/` — a multi-agent vacation-rental ops assistant powered by the [Repull MCP server](https://repull.dev/docs/mcp-server) (`@repull/mcp` on npm).

One Repull API key fans out to 50+ PMS platforms and the major OTAs (Airbnb, Booking.com, VRBO, Plumguide), so the team can read reservations, properties, listings, guests, and conversations across an entire short-term-rental portfolio through a single MCP connection.

## Why it fits this directory

There's a clear precedent for travel/MCP agent teams here — most directly [`ai_travel_planner_mcp_agent_team`](https://github.com/Shubhamsaboo/awesome-llm-apps/tree/main/mcp_ai_agents/ai_travel_planner_mcp_agent_team), which uses a similar Streamlit + Agno + MCP-via-npx pattern for the trip-planning side of vacation rentals. This PR adds the **operator** (property manager) side: instead of helping a guest plan a trip, it helps a host run their bookings.

It also follows the structural conventions of the rest of `mcp_ai_agents/`:

- `app.py` (Streamlit + agno)
- `README.md` (intro, prereqs, run, prompts, troubleshooting, links)
- `requirements.txt` (no local SDK deps — MCP server runs via `npx`)
- `.env.example`

## What it demonstrates

A coordinator agent routing user queries to three specialists, all sharing the same MCP toolset but staying in their lanes via system-prompt contracts:

- **Listing Specialist** — `repull_list_properties`, `repull_list_listings`, `repull_list_airbnb_listings`
- **Reservation Specialist** — `repull_list_reservations`, `repull_get_reservation`, `repull_list_guests`, `repull_list_conversations`, `repull_list_conversation_messages`
- **Connections Specialist** — `repull_whoami`, `repull_list_connections`, `repull_list_connect_providers`, plus discovery via `repull_list_endpoints` / `repull_get_docs`

The coordinator is instructed to call the Connections Specialist first on a fresh session so the team grounds itself in what's actually connected before suggesting actions.

## Test plan

- [x] `pip install -r requirements.txt` succeeds in a fresh venv
- [x] `npx -y @repull/mcp` boots and registers all 18 tools
- [x] `app.py` imports cleanly
- [x] `build_team()` wires the 3 specialists + coordinator
- [x] End-to-end smoke: real OpenAI gpt-4o turn through the team — agent picks the right tool, hits the live Repull API, and surfaces the full error envelope (`code`, `fix`, `docs_url`) verbatim per the system prompt
- [ ] Reviewer can run `streamlit run app.py`, paste a Repull test key + OpenAI key in the sidebar, and ask "what's connected to my account?"

## Notes

- **Read-only by design.** `@repull/mcp` v0.2 deliberately omits write tools (cancel, modify, push pricing, message guests) — letting an LLM "tidy up" a live booking calendar is a known footgun. A future release will add mutating tools individually behind explicit per-tool opt-in env flags.
- **No local SDK deps** — the MCP server is launched via `npx -y @repull/mcp` so a fresh clone + `pip install` + `streamlit run` is enough.
- **OpenAI by default**, but the README calls out the one-line swap to Anthropic Claude via `agno.models.anthropic`.