### PR TITLE
feat: add AI research agent with cross-provider adversarial fact-checking

### DIFF
--- a/advanced_ai_agents/single_agent_apps/ai_research_fact_checker/.gitignore
+++ b/advanced_ai_agents/single_agent_apps/ai_research_fact_checker/.gitignore
@@ -1,0 +1,4 @@
+__pycache__/
+*.pyc
+.venv/
+*.db

--- a/advanced_ai_agents/single_agent_apps/ai_research_fact_checker/README.md
+++ b/advanced_ai_agents/single_agent_apps/ai_research_fact_checker/README.md
@@ -1,0 +1,133 @@
+# AI Research Agent with Cross-Provider Adversarial Fact-Checking
+
+[![Python](https://img.shields.io/badge/Python-3.10%2B-blue)](https://python.org)
+[![OpenAI](https://img.shields.io/badge/Research-OpenAI-green)](https://openai.com)
+[![Anthropic](https://img.shields.io/badge/Fact--Check-Anthropic-purple)](https://anthropic.com)
+
+A research agent that **searches the web for real sources, writes a cited report, then fact-checks every claim using a completely different AI provider** — eliminating shared model biases.
+
+Most AI research tools check their own work with the same model that wrote it. This one uses **OpenAI for research** and **Anthropic Claude for fact-checking** — different training data, different biases, genuinely independent verification.
+
+---
+
+## Features
+
+- **Real web search** — DuckDuckGo search returns actual URLs (no hallucinated references, no API key needed for search)
+- **Clean content extraction** — newspaper4k for articles, BeautifulSoup fallback for docs/Wikipedia (no raw HTML noise)
+- **Inline citations** — every claim in the report links to a `[Source N]` reference
+- **Cross-provider fact-checking** — research (OpenAI) and fact-check (Anthropic Claude) use different AI systems with different training data
+- **Unsupported claim detection** — flags assertions that lack evidence
+- **Source quality assessment** — evaluates diversity and authority of sources
+- **Confidence scoring** — configurable threshold (default 0.75) below which reports are flagged
+- **Full audit trail** — every research session, source fetch, and fact-check logged to SQLite
+- **Streamlit web UI** — visual pipeline progress with claim-by-claim verification results
+- **CLI mode** — run from the terminal via `research_agent.py`
+
+---
+
+## Why Cross-Provider Fact-Checking?
+
+```
+┌─────────────────────┐         ┌─────────────────────┐
+│   OpenAI (GPT)      │         │  Anthropic (Claude)  │
+│                     │         │                     │
+│  • Plans research   │         │  • Reads the report │
+│  • Searches web     │         │  • Checks EVERY     │
+│  • Writes report    │         │    claim against     │
+│  • Cites sources    │         │    source material   │
+│                     │         │  • Flags fabricated  │
+│  Training data A    │         │    or unsupported    │
+│  Biases A           │         │    assertions        │
+│                     │         │                     │
+│                     │         │  Training data B     │
+│                     │         │  Biases B            │
+└─────────────────────┘         └─────────────────────┘
+```
+
+A single model checking its own work shares the same blind spots. By using a different provider for verification, the fact-checker can catch errors the research model is systematically blind to.
+
+---
+
+## Pipeline
+
+```
+Research topic
+    │
+    ▼
+1. Research Planning (OpenAI)
+   └─ Generates 3-6 targeted search queries
+    │
+    ▼
+2. Source Gathering (DuckDuckGo + newspaper4k)
+   └─ Real web search → fetch URLs → extract clean article text
+    │
+    ▼
+3. Report Synthesis (OpenAI)
+   └─ Writes a structured report with [Source N] inline citations
+    │
+    ▼
+4. Cross-Provider Fact-Check (Anthropic Claude)
+   └─ Independent verifier checks EVERY claim:
+      • Is it cited?
+      • Does the source actually say this?
+      • Was anything exaggerated or fabricated?
+    │
+    ▼
+VERIFIED (confidence ≥ 0.75)  —or—  FLAGGED (unsupported claims found)
+```
+
+---
+
+## Quickstart
+
+```bash
+# 1. Install dependencies
+pip install -r requirements.txt
+
+# 2. Set API keys (both required)
+export OPENAI_API_KEY=sk-...
+export ANTHROPIC_API_KEY=sk-ant-...
+
+# 3. Run the Streamlit app
+streamlit run app.py
+```
+
+### CLI mode
+
+```bash
+# Research a topic
+python research_agent.py "What are the health effects of intermittent fasting?"
+
+# List past research
+python research_agent.py --list
+
+# Inspect a specific session
+python research_agent.py --show a3f2
+```
+
+---
+
+## Environment Variables
+
+| Variable | Required | Description |
+|----------|----------|-------------|
+| `OPENAI_API_KEY` | Yes | OpenAI key for research planning and report synthesis |
+| `ANTHROPIC_API_KEY` | Yes | Anthropic key for independent fact-checking |
+| `OPENAI_BASE_URL` | No | Custom endpoint for OpenAI-compatible providers |
+| `RESEARCH_AGENT_MODEL` | No | Research model (default: `gpt-4o-mini`) |
+| `FACTCHECK_AGENT_MODEL` | No | Fact-check model (default: `claude-sonnet-4-20250514`) |
+
+---
+
+## Architecture
+
+```
+app.py               Streamlit frontend — topic input, pipeline progress, results
+research_agent.py    Core logic — plan, search, extract, synthesize, fact-check, CLI
+├── Search           ddgs — real DuckDuckGo web search, no API key needed
+├── Extraction       newspaper4k + beautifulsoup4 — clean text from web pages
+├── Research LLM     openai — JSON-mode completions for planning and synthesis
+├── Fact-Check LLM   anthropic — independent verification with different model
+├── Database         sqlite3 (stdlib) — research sessions / source fetches
+└── CLI              argparse — run / --list / --show
+```

--- a/advanced_ai_agents/single_agent_apps/ai_research_fact_checker/app.py
+++ b/advanced_ai_agents/single_agent_apps/ai_research_fact_checker/app.py
@@ -116,9 +116,11 @@ with tab_research:
             st.stop()
 
         # Configure
-        ra.RESEARCH_MODEL = research_model
-        ra.FACTCHECK_MODEL = factcheck_model
-        ra.THRESHOLD = threshold
+        config = ra.Config(
+            research_model=research_model,
+            factcheck_model=factcheck_model,
+            threshold=threshold,
+        )
         os.environ["OPENAI_API_KEY"] = openai_key
         os.environ["ANTHROPIC_API_KEY"] = anthropic_key
         if base_url:
@@ -140,7 +142,7 @@ with tab_research:
 
         # ── Stage 1: Research Plan (OpenAI) ──
         with st.status("Planning research...", expanded=True) as status:
-            plan = ra.plan_research(client, topic)
+            plan = ra.plan_research(client, topic, config)
             status.update(label="Research plan ready", state="complete")
 
         st.markdown(f"**Refined topic:** {plan.get('topic_refined', topic)}")
@@ -189,7 +191,7 @@ with tab_research:
             )
             conn.commit()
             report = ra.synthesize_report(
-                client, plan.get("topic_refined", topic), sources
+                client, plan.get("topic_refined", topic), sources, config
             )
             conn.execute(
                 "UPDATE research SET report=? WHERE id=?",
@@ -211,7 +213,7 @@ with tab_research:
                 (research_id,),
             )
             conn.commit()
-            fc = ra.fact_check(topic, report, sources)
+            fc = ra.fact_check(topic, report, sources, config)
 
             verdict = fc.get("verdict", "reject")
             try:

--- a/advanced_ai_agents/single_agent_apps/ai_research_fact_checker/app.py
+++ b/advanced_ai_agents/single_agent_apps/ai_research_fact_checker/app.py
@@ -1,0 +1,328 @@
+"""
+Streamlit frontend for the Research Agent with Cross-Provider Fact-Checking.
+
+Enter a research topic → agent searches DuckDuckGo for real sources → extracts
+clean text → writes a cited report (OpenAI) → adversarial fact-checker (Anthropic
+Claude) verifies every claim has supporting evidence.
+"""
+from __future__ import annotations
+
+import json
+import os
+import sqlite3
+import uuid
+
+import streamlit as st
+
+import research_agent as ra
+
+# ─── Page Config ────────────────────────────────────────────────────────────
+
+st.set_page_config(
+    page_title="AI Research Fact-Checker",
+    page_icon="🔍",
+    layout="wide",
+)
+st.title("AI Research Agent with Cross-Provider Fact-Checking")
+st.caption(
+    "Research any topic with real DuckDuckGo search, then verify every claim "
+    "using a completely different AI provider — eliminating shared model biases."
+)
+
+# ─── Sidebar ────────────────────────────────────────────────────────────────
+
+with st.sidebar:
+    st.header("Configuration")
+
+    st.subheader("Research (OpenAI)")
+    openai_key = st.text_input(
+        "OpenAI API Key",
+        type="password",
+        value=os.environ.get("OPENAI_API_KEY", ""),
+        help="Required for research planning and report synthesis.",
+    )
+    base_url = st.text_input(
+        "OpenAI Base URL (optional)",
+        value=os.environ.get("OPENAI_BASE_URL", ""),
+        help="For alternate OpenAI-compatible providers.",
+    )
+    research_model = st.selectbox(
+        "Research Model",
+        ["gpt-4o-mini", "gpt-4o", "gpt-4.1-mini", "gpt-4.1-nano"],
+        index=0,
+    )
+
+    st.subheader("Fact-Check (Anthropic)")
+    anthropic_key = st.text_input(
+        "Anthropic API Key",
+        type="password",
+        value=os.environ.get("ANTHROPIC_API_KEY", ""),
+        help="Required for independent fact-checking. Different provider = different biases.",
+    )
+    factcheck_model = st.text_input(
+        "Fact-Check Model",
+        value="claude-sonnet-4-20250514",
+        help="Anthropic model for adversarial verification.",
+    )
+
+    st.divider()
+    threshold = st.slider(
+        "Fact-check confidence threshold",
+        min_value=0.0, max_value=1.0, value=0.75, step=0.05,
+        help="Minimum confidence to mark research as verified.",
+    )
+
+    st.divider()
+    st.caption(
+        "**Why two providers?** The research model (OpenAI) and fact-checker "
+        "(Anthropic) have different training data and biases. This means the "
+        "fact-checker can catch errors the research model is blind to."
+    )
+
+# ─── Tabs ───────────────────────────────────────────────────────────────────
+
+tab_research, tab_history = st.tabs(["Research", "History"])
+
+# ─── Database ───────────────────────────────────────────────────────────────
+
+ra.DATA_DIR.mkdir(parents=True, exist_ok=True)
+
+
+@st.cache_resource
+def get_db() -> sqlite3.Connection:
+    conn = sqlite3.connect(str(ra.DB_PATH), check_same_thread=False)
+    ra.init_db(conn)
+    return conn
+
+
+conn = get_db()
+
+# ─── Research Tab ───────────────────────────────────────────────────────────
+
+with tab_research:
+    topic = st.text_area(
+        "What would you like to research?",
+        placeholder="What are the health effects of intermittent fasting?",
+        height=80,
+    )
+
+    both_keys = openai_key and anthropic_key
+    if not both_keys:
+        st.warning("Both OpenAI and Anthropic API keys are required.")
+
+    if st.button("Research & Fact-Check", type="primary", disabled=not both_keys):
+        if not topic.strip():
+            st.warning("Enter a research topic.")
+            st.stop()
+
+        # Configure
+        ra.RESEARCH_MODEL = research_model
+        ra.FACTCHECK_MODEL = factcheck_model
+        ra.THRESHOLD = threshold
+        os.environ["OPENAI_API_KEY"] = openai_key
+        os.environ["ANTHROPIC_API_KEY"] = anthropic_key
+        if base_url:
+            os.environ["OPENAI_BASE_URL"] = base_url
+
+        from openai import OpenAI
+        client = OpenAI(
+            api_key=openai_key,
+            base_url=base_url or None,
+        )
+
+        research_id = str(uuid.uuid4())
+        conn.execute(
+            "INSERT INTO research VALUES (?,?,?,?,?,?,?,?,?,?)",
+            (research_id, topic, "planning", None, None, None, None, None,
+             ra.now(), None),
+        )
+        conn.commit()
+
+        # ── Stage 1: Research Plan (OpenAI) ──
+        with st.status("Planning research...", expanded=True) as status:
+            plan = ra.plan_research(client, topic)
+            status.update(label="Research plan ready", state="complete")
+
+        st.markdown(f"**Refined topic:** {plan.get('topic_refined', topic)}")
+        for sq in plan.get("search_queries", []):
+            st.markdown(f"- {sq['query']}")
+
+        # ── Stage 2: Gather Sources (DuckDuckGo + newspaper4k) ──
+        with st.status("Searching DuckDuckGo & extracting content...", expanded=True) as status:
+            conn.execute(
+                "UPDATE research SET status='gathering' WHERE id=?",
+                (research_id,),
+            )
+            conn.commit()
+            sources = ra.gather_sources(conn, research_id, plan)
+
+            if not sources:
+                status.update(label="No sources found", state="error")
+                st.error("Could not fetch any sources. Try a different topic.")
+                conn.execute(
+                    "UPDATE research SET status='failed',finished_at=? WHERE id=?",
+                    (ra.now(), research_id),
+                )
+                conn.commit()
+                st.stop()
+
+            status.update(
+                label=f"Gathered {len(sources)} sources", state="complete"
+            )
+
+        conn.execute(
+            "UPDATE research SET sources_json=? WHERE id=?",
+            (json.dumps([{"url": s["url"], "title": s["title"]}
+                         for s in sources]), research_id),
+        )
+        conn.commit()
+
+        with st.expander(f"Sources ({len(sources)})", expanded=False):
+            for i, s in enumerate(sources):
+                st.markdown(f"**[Source {i+1}]** [{s['title'][:80]}]({s['url']})")
+
+        # ── Stage 3: Synthesize Report (OpenAI) ──
+        with st.status("Writing report (OpenAI)...", expanded=True) as status:
+            conn.execute(
+                "UPDATE research SET status='synthesizing' WHERE id=?",
+                (research_id,),
+            )
+            conn.commit()
+            report = ra.synthesize_report(
+                client, plan.get("topic_refined", topic), sources
+            )
+            conn.execute(
+                "UPDATE research SET report=? WHERE id=?",
+                (report, research_id),
+            )
+            conn.commit()
+            status.update(label="Report written", state="complete")
+
+        st.markdown("---")
+        st.markdown(report)
+        st.markdown("---")
+
+        # ── Stage 4: Cross-Provider Fact-Check (Anthropic Claude) ──
+        with st.status(
+            f"Fact-checking with {factcheck_model} (Anthropic)...", expanded=True
+        ) as status:
+            conn.execute(
+                "UPDATE research SET status='fact_checking' WHERE id=?",
+                (research_id,),
+            )
+            conn.commit()
+            fc = ra.fact_check(topic, report, sources)
+
+            verdict = fc.get("verdict", "reject")
+            try:
+                confidence = float(fc.get("confidence", 0))
+            except (ValueError, TypeError):
+                confidence = 0.0
+            reason = fc.get("overall_reason", "")
+
+            if verdict == "accept" and confidence < threshold:
+                verdict = "reject"
+                reason = (
+                    f"Confidence {confidence:.0%} below "
+                    f"{threshold:.0%}. " + reason
+                )
+
+            if verdict == "accept":
+                status.update(
+                    label=f"Verified ({confidence:.0%})", state="complete"
+                )
+            else:
+                status.update(
+                    label=f"Flagged ({confidence:.0%})", state="error"
+                )
+
+        # ── Verdict Display ──
+        if verdict == "accept":
+            st.success(f"**VERIFIED** — Confidence: {confidence:.0%}")
+        else:
+            st.error(f"**FLAGGED** — Confidence: {confidence:.0%}")
+
+        st.markdown(f"**Reason:** {reason}")
+        st.markdown(
+            f"**Source quality:** {fc.get('source_quality', 'unknown')}"
+        )
+
+        st.info(
+            f"**Research:** {research_model} (OpenAI) | "
+            f"**Fact-check:** {factcheck_model} (Anthropic)"
+        )
+
+        claims = fc.get("claims_checked", [])
+        if claims:
+            st.markdown("### Claim-by-Claim Check")
+            for claim in claims:
+                supported = claim.get("supported", False)
+                icon = "✅" if supported else "❌"
+                src = claim.get("source_cited", "none")
+                st.markdown(
+                    f"{icon} *\"{claim.get('claim', '')[:120]}\"* "
+                    f"— Source: {src}"
+                )
+                if claim.get("note"):
+                    st.caption(f"→ {claim['note']}")
+
+        unsupported = fc.get("unsupported_claims", [])
+        if unsupported:
+            st.markdown("### Unsupported Claims")
+            for uc in unsupported:
+                st.markdown(f"- ❌ {uc}")
+
+        conn.execute(
+            "UPDATE research SET status=?,verdict=?,confidence=?,"
+            "fact_check_json=?,finished_at=? WHERE id=?",
+            (verdict, verdict, confidence, json.dumps(fc), ra.now(),
+             research_id),
+        )
+        conn.commit()
+        st.caption(f"Research ID: `{research_id}`")
+
+# ─── History Tab ────────────────────────────────────────────────────────────
+
+with tab_history:
+    rows = conn.execute(
+        "SELECT id, status, verdict, confidence, created_at, topic "
+        "FROM research ORDER BY created_at DESC LIMIT 20"
+    ).fetchall()
+
+    if not rows:
+        st.info("No research yet. Enter a topic in the **Research** tab.")
+    else:
+        for row in rows:
+            rid, status, verdict, conf, created, t = row
+            icon = (
+                "✅" if verdict == "accept"
+                else ("❌" if verdict == "reject" else "⏳")
+            )
+            conf_str = f"{conf:.0%}" if conf is not None else "—"
+            with st.expander(
+                f"{icon} {t[:80]} — {conf_str}", expanded=False
+            ):
+                st.markdown(f"**ID:** `{rid}`")
+                st.markdown(
+                    f"**Status:** {status} | **Verdict:** "
+                    f"{verdict or '—'} | **Confidence:** {conf_str}"
+                )
+                st.markdown(f"**Created:** {created}")
+
+                # Show sources
+                fetches = conn.execute(
+                    "SELECT url, title FROM fetches WHERE research_id=?",
+                    (rid,),
+                ).fetchall()
+                if fetches:
+                    st.markdown("**Sources:**")
+                    for f in fetches:
+                        st.markdown(f"- [{f[1][:60]}]({f[0]})")
+
+                # Show report
+                report_row = conn.execute(
+                    "SELECT report FROM research WHERE id=?", (rid,)
+                ).fetchone()
+                if report_row and report_row[0]:
+                    st.markdown("**Report:**")
+                    st.markdown(report_row[0][:2000])

--- a/advanced_ai_agents/single_agent_apps/ai_research_fact_checker/requirements.txt
+++ b/advanced_ai_agents/single_agent_apps/ai_research_fact_checker/requirements.txt
@@ -1,0 +1,9 @@
+# Runtime dependencies — install with: pip install -r requirements.txt
+openai>=1.30.0           # Research LLM calls (plan / synthesize)
+anthropic>=0.40.0        # Independent fact-checking (different provider = different biases)
+httpx>=0.27.0            # HTTP fallback for content extraction
+ddgs>=7.0.0              # Real web search via DuckDuckGo (no API key needed)
+newspaper4k>=0.9.0       # Article text extraction
+beautifulsoup4>=4.12.0   # HTML parsing fallback for non-article pages
+rich>=13.0.0             # Optional: color-coded terminal output (degrades gracefully)
+streamlit>=1.30.0        # Web UI

--- a/advanced_ai_agents/single_agent_apps/ai_research_fact_checker/research_agent.py
+++ b/advanced_ai_agents/single_agent_apps/ai_research_fact_checker/research_agent.py
@@ -21,6 +21,7 @@ Environment:   OPENAI_API_KEY (research) + ANTHROPIC_API_KEY (fact-check)
 from __future__ import annotations
 
 import argparse, datetime, json, os, sqlite3, sys, uuid
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
@@ -44,10 +45,15 @@ except ImportError:
 
 DATA_DIR  = Path.home() / ".research_agent"
 DB_PATH   = DATA_DIR / "research.db"
-RESEARCH_MODEL  = os.environ.get("RESEARCH_AGENT_MODEL", "gpt-4o-mini")
-FACTCHECK_MODEL = os.environ.get("FACTCHECK_AGENT_MODEL", "claude-sonnet-4-20250514")
-THRESHOLD = 0.75   # min fact-check confidence to accept
 MAX_FETCH = 50_000  # chars per URL
+
+
+@dataclass
+class Config:
+    """Runtime configuration — pass explicitly instead of mutating globals."""
+    research_model: str = "gpt-4o-mini"
+    factcheck_model: str = "claude-sonnet-4-20250514"
+    threshold: float = 0.75
 
 # ─── Database ────────────────────────────────────────────────────────────────
 
@@ -93,8 +99,13 @@ def get_factcheck_client() -> anthropic.Anthropic:
     return anthropic.Anthropic(api_key=key)
 
 
-def chat(client: OpenAI, messages: list[dict], json_mode: bool = False) -> str:
-    kw: dict[str, Any] = {"model": RESEARCH_MODEL, "messages": messages}
+def chat(client: OpenAI, messages: list[dict], config: Config,
+         json_mode: bool = False) -> str:
+    kw: dict[str, Any] = {
+        "model": config.research_model,
+        "messages": messages,
+        "max_tokens": 4096,
+    }
     if json_mode:
         kw["response_format"] = {"type": "json_object"}
     return client.chat.completions.create(**kw).choices[0].message.content or ""
@@ -168,12 +179,12 @@ Rules:
 - Each query should target a DIFFERENT aspect of the topic"""
 
 
-def plan_research(client: OpenAI, topic: str) -> dict:
+def plan_research(client: OpenAI, topic: str, config: Config) -> dict:
     section("Planning Research")
     raw = chat(client,
                [{"role": "system", "content": PLAN_SYS},
                 {"role": "user", "content": topic}],
-               json_mode=True)
+               config, json_mode=True)
     try:
         return json.loads(raw)
     except json.JSONDecodeError:
@@ -188,6 +199,7 @@ def gather_sources(conn: sqlite3.Connection,
                    research_id: str, plan: dict) -> list[dict]:
     section("Gathering Sources")
     sources: list[dict] = []
+    seen_urls: set[str] = set()
 
     for i, sq in enumerate(plan.get("search_queries", [])):
         query = sq.get("query", "")
@@ -199,8 +211,9 @@ def gather_sources(conn: sqlite3.Connection,
         for result in results:
             url = result.get("href", "")
             title = result.get("title", url)
-            if not url:
+            if not url or url in seen_urls:
                 continue
+            seen_urls.add(url)
 
             pr(f"    Fetching: {url}", "dim")
             content = fetch_url(url)
@@ -242,7 +255,8 @@ Rules:
 - Be concise but thorough (500-1500 words)"""
 
 
-def synthesize_report(client: OpenAI, topic: str, sources: list[dict]) -> str:
+def synthesize_report(client: OpenAI, topic: str, sources: list[dict],
+                      config: Config) -> str:
     section("Synthesizing Report")
     source_text = "\n\n".join(
         f"[Source {i+1}] {s['url']}\n{s['content']}"
@@ -251,7 +265,8 @@ def synthesize_report(client: OpenAI, topic: str, sources: list[dict]) -> str:
     report = chat(client,
                   [{"role": "system", "content": SYNTHESIS_SYS},
                    {"role": "user", "content":
-                       f"Topic: {topic}\n\nSource Material:\n{source_text}"}])
+                       f"Topic: {topic}\n\nSource Material:\n{source_text}"}],
+                  config)
     return report
 
 
@@ -289,10 +304,11 @@ Return ONLY valid JSON:
  "overall_reason":"<paragraph explaining the fact-check result>"}"""
 
 
-def fact_check(topic: str, report: str, sources: list[dict]) -> dict:
+def fact_check(topic: str, report: str, sources: list[dict],
+               config: Config) -> dict:
     section("Cross-Provider Adversarial Fact-Check")
-    pr(f"  Research model: {RESEARCH_MODEL} (OpenAI)", "dim")
-    pr(f"  Fact-check model: {FACTCHECK_MODEL} (Anthropic)", "dim")
+    pr(f"  Research model: {config.research_model} (OpenAI)", "dim")
+    pr(f"  Fact-check model: {config.factcheck_model} (Anthropic)", "dim")
 
     client = get_factcheck_client()
     source_list = "\n".join(
@@ -301,7 +317,6 @@ def fact_check(topic: str, report: str, sources: list[dict]) -> dict:
     )
 
     user_content = (
-        f"{FACT_CHECK_SYS}\n\n"
         f"Topic: {topic}\n\n"
         f"Report to fact-check:\n{report}\n\n"
         f"Available source material:\n{source_list}"
@@ -309,8 +324,9 @@ def fact_check(topic: str, report: str, sources: list[dict]) -> dict:
 
     try:
         response = client.messages.create(
-            model=FACTCHECK_MODEL,
+            model=config.factcheck_model,
             max_tokens=4096,
+            system=FACT_CHECK_SYS,
             messages=[{"role": "user", "content": user_content}],
         )
         raw = response.content[0].text
@@ -340,7 +356,7 @@ def fact_check(topic: str, report: str, sources: list[dict]) -> dict:
 # ─── Main Pipeline ──────────────────────────────────────────────────────────
 
 def research_topic(client: OpenAI, conn: sqlite3.Connection,
-                   topic: str) -> str:
+                   topic: str, config: Config) -> str:
     research_id = str(uuid.uuid4())
     conn.execute(
         "INSERT INTO research VALUES (?,?,?,?,?,?,?,?,?,?)",
@@ -352,7 +368,7 @@ def research_topic(client: OpenAI, conn: sqlite3.Connection,
     pr(topic)
 
     # 1. Plan
-    plan = plan_research(client, topic)
+    plan = plan_research(client, topic, config)
     pr(f"\nRefined topic: {plan.get('topic_refined', topic)}", "bold")
     for i, sq in enumerate(plan.get("search_queries", [])):
         pr(f"  {i+1}. {sq.get('query', '')}", "dim")
@@ -381,7 +397,8 @@ def research_topic(client: OpenAI, conn: sqlite3.Connection,
     conn.execute("UPDATE research SET status='synthesizing' WHERE id=?",
                  (research_id,))
     conn.commit()
-    report = synthesize_report(client, plan.get("topic_refined", topic), sources)
+    report = synthesize_report(client, plan.get("topic_refined", topic), sources,
+                               config)
     pr(f"\n{report}")
 
     conn.execute("UPDATE research SET report=? WHERE id=?",
@@ -392,7 +409,7 @@ def research_topic(client: OpenAI, conn: sqlite3.Connection,
     conn.execute("UPDATE research SET status='fact_checking' WHERE id=?",
                  (research_id,))
     conn.commit()
-    fc = fact_check(topic, report, sources)
+    fc = fact_check(topic, report, sources, config)
 
     verdict = fc.get("verdict", "reject")
     try:
@@ -401,9 +418,9 @@ def research_topic(client: OpenAI, conn: sqlite3.Connection,
         confidence = 0.0
     reason = fc.get("overall_reason", "")
 
-    if verdict == "accept" and confidence < THRESHOLD:
+    if verdict == "accept" and confidence < config.threshold:
         verdict = "reject"
-        reason = f"Confidence {confidence:.0%} below {THRESHOLD:.0%}. " + reason
+        reason = f"Confidence {confidence:.0%} below {config.threshold:.0%}. " + reason
 
     # Display verdict
     section("Fact-Check Verdict")
@@ -482,17 +499,20 @@ def show_research(conn: sqlite3.Connection, prefix: str) -> None:
 
 
 def main() -> None:
-    global RESEARCH_MODEL, FACTCHECK_MODEL
+    defaults = Config()
     p = argparse.ArgumentParser(description="Research agent with cross-provider fact-checking")
     p.add_argument("topic", nargs="?", help="Research topic or question")
     p.add_argument("--list", action="store_true", help="List past research")
     p.add_argument("--show", help="Show research by ID prefix")
-    p.add_argument("--model", default=RESEARCH_MODEL, help="Research model (OpenAI)")
-    p.add_argument("--factcheck-model", default=FACTCHECK_MODEL, help="Fact-check model (Anthropic)")
+    p.add_argument("--model",
+                   default=os.environ.get("RESEARCH_AGENT_MODEL", defaults.research_model),
+                   help="Research model (OpenAI)")
+    p.add_argument("--factcheck-model",
+                   default=os.environ.get("FACTCHECK_AGENT_MODEL", defaults.factcheck_model),
+                   help="Fact-check model (Anthropic)")
     args = p.parse_args()
 
-    RESEARCH_MODEL = args.model
-    FACTCHECK_MODEL = args.factcheck_model
+    config = Config(research_model=args.model, factcheck_model=args.factcheck_model)
     DATA_DIR.mkdir(parents=True, exist_ok=True)
     conn = sqlite3.connect(DB_PATH)
     init_db(conn)
@@ -516,7 +536,7 @@ def main() -> None:
         topic = args.topic
 
     client = get_research_client()
-    rid = research_topic(client, conn, topic)
+    rid = research_topic(client, conn, topic, config)
     pr(f"\nResearch ID: {rid}", "dim")
     conn.close()
 

--- a/advanced_ai_agents/single_agent_apps/ai_research_fact_checker/research_agent.py
+++ b/advanced_ai_agents/single_agent_apps/ai_research_fact_checker/research_agent.py
@@ -1,0 +1,525 @@
+#!/usr/bin/env python3
+"""
+Research Agent with Cross-Provider Adversarial Fact-Checking
+============================================================
+Researches any topic using real web search (DuckDuckGo), synthesizes a report
+with inline citations, then adversarially fact-checks every claim using a
+completely different AI provider — eliminating shared model biases.
+
+Pipeline: topic → research plan → web search → fetch & extract → report → fact-check
+Research uses OpenAI. Fact-checking uses Anthropic Claude.
+All sessions are logged to SQLite (~/.research_agent/).
+
+Usage:
+    python research_agent.py "What are the health effects of intermittent fasting?"
+    python research_agent.py --list
+    python research_agent.py --show <id-prefix>
+
+Requirements:  pip install -r requirements.txt
+Environment:   OPENAI_API_KEY (research) + ANTHROPIC_API_KEY (fact-check)
+"""
+from __future__ import annotations
+
+import argparse, datetime, json, os, sqlite3, sys, uuid
+from pathlib import Path
+from typing import Any
+
+import anthropic
+import httpx
+from bs4 import BeautifulSoup
+from ddgs import DDGS
+from newspaper import Article
+from openai import OpenAI
+
+try:
+    from rich.console import Console
+    from rich.table import Table
+    console = Console()
+    HAS_RICH = True
+except ImportError:
+    console = None  # type: ignore
+    HAS_RICH = False
+
+# ─── Config ──────────────────────────────────────────────────────────────────
+
+DATA_DIR  = Path.home() / ".research_agent"
+DB_PATH   = DATA_DIR / "research.db"
+RESEARCH_MODEL  = os.environ.get("RESEARCH_AGENT_MODEL", "gpt-4o-mini")
+FACTCHECK_MODEL = os.environ.get("FACTCHECK_AGENT_MODEL", "claude-sonnet-4-20250514")
+THRESHOLD = 0.75   # min fact-check confidence to accept
+MAX_FETCH = 50_000  # chars per URL
+
+# ─── Database ────────────────────────────────────────────────────────────────
+
+DDL = """
+CREATE TABLE IF NOT EXISTS research (
+    id TEXT PRIMARY KEY, topic TEXT NOT NULL, status TEXT NOT NULL,
+    report TEXT, sources_json TEXT, verdict TEXT, confidence REAL,
+    fact_check_json TEXT, created_at TEXT NOT NULL, finished_at TEXT
+);
+CREATE TABLE IF NOT EXISTS fetches (
+    id TEXT PRIMARY KEY, research_id TEXT NOT NULL, url TEXT NOT NULL,
+    title TEXT, content_preview TEXT, fetched_at TEXT NOT NULL
+);"""
+
+
+def init_db(conn: sqlite3.Connection) -> None:
+    conn.executescript(DDL)
+    conn.commit()
+
+
+def now() -> str:
+    return datetime.datetime.now(datetime.timezone.utc).isoformat()
+
+
+# ─── LLM Clients ────────────────────────────────────────────────────────────
+
+def get_research_client() -> OpenAI:
+    base_url = os.environ.get("OPENAI_BASE_URL")
+    key = os.environ.get("OPENAI_API_KEY")
+    if not key:
+        sys.exit("ERROR: OPENAI_API_KEY not set. Required for research stage.")
+    return OpenAI(api_key=key, base_url=base_url) if base_url else OpenAI(api_key=key)
+
+
+def get_factcheck_client() -> anthropic.Anthropic:
+    key = os.environ.get("ANTHROPIC_API_KEY")
+    if not key:
+        sys.exit(
+            "ERROR: ANTHROPIC_API_KEY not set. Required for independent fact-checking.\n"
+            "The fact-checker uses a different AI provider (Anthropic Claude) to ensure\n"
+            "truly independent verification with different training data and biases."
+        )
+    return anthropic.Anthropic(api_key=key)
+
+
+def chat(client: OpenAI, messages: list[dict], json_mode: bool = False) -> str:
+    kw: dict[str, Any] = {"model": RESEARCH_MODEL, "messages": messages}
+    if json_mode:
+        kw["response_format"] = {"type": "json_object"}
+    return client.chat.completions.create(**kw).choices[0].message.content or ""
+
+
+# ─── Web Search & Content Extraction ────────────────────────────────────────
+
+def search_web(query: str, max_results: int = 3) -> list[dict]:
+    """Search DuckDuckGo and return real URLs with titles."""
+    try:
+        results = DDGS().text(query, max_results=max_results)
+        return results  # [{"title": ..., "href": ..., "body": ...}]
+    except Exception as e:
+        pr(f"    Search error: {e}", "dim")
+        return []
+
+
+def fetch_url(url: str) -> str:
+    """Fetch a URL and extract clean text content."""
+    # Try newspaper4k first (best for articles)
+    try:
+        article = Article(url)
+        article.download()
+        article.parse()
+        if article.text and len(article.text) > 100:
+            return article.text[:MAX_FETCH]
+    except Exception:
+        pass
+
+    # Fallback: fetch raw HTML and extract with BeautifulSoup
+    try:
+        with httpx.Client(timeout=15, follow_redirects=True) as h:
+            r = h.get(url, headers={"User-Agent": "research-agent/2.0"})
+            r.raise_for_status()
+            soup = BeautifulSoup(r.text[:MAX_FETCH], "html.parser")
+            # Remove non-content elements
+            for tag in soup(["script", "style", "nav", "footer", "header", "aside"]):
+                tag.decompose()
+            text = soup.get_text(separator="\n", strip=True)
+            return text[:MAX_FETCH] if text else "ERROR: No text content extracted"
+    except httpx.HTTPStatusError as e:
+        return f"ERROR: HTTP {e.response.status_code}"
+    except Exception as e:
+        return f"ERROR: {e}"
+
+
+# ─── UI ──────────────────────────────────────────────────────────────────────
+
+def pr(msg: str, style: str = "") -> None:
+    (console.print(msg, style=style) if HAS_RICH else print(msg))  # type: ignore
+
+
+def section(title: str) -> None:
+    (console.rule(f"[bold]{title}") if HAS_RICH  # type: ignore
+     else print(f"\n{'─'*60}\n  {title}\n{'─'*60}"))
+
+
+# ─── Stage 1: Research Plan ─────────────────────────────────────────────────
+
+PLAN_SYS = """You are a research planner. Given a topic, produce a research plan.
+
+Return ONLY valid JSON:
+{"topic_refined":"<clear restatement of the research question>",
+ "search_queries":[{"index":0,"query":"<search query>","rationale":"<why this source matters>"}],
+ "output_format":"<what the final report should contain>"}
+
+Rules:
+- Generate 3-6 search queries that would find authoritative sources
+- Prefer official sources, academic references, and reputable publications
+- Include at least one query targeting a contrarian or skeptical perspective
+- Each query should target a DIFFERENT aspect of the topic"""
+
+
+def plan_research(client: OpenAI, topic: str) -> dict:
+    section("Planning Research")
+    raw = chat(client,
+               [{"role": "system", "content": PLAN_SYS},
+                {"role": "user", "content": topic}],
+               json_mode=True)
+    try:
+        return json.loads(raw)
+    except json.JSONDecodeError:
+        return {"topic_refined": topic,
+                "search_queries": [{"index": 0, "query": topic, "rationale": "direct search"}],
+                "output_format": "structured report with citations"}
+
+
+# ─── Stage 2: Source Gathering ───────────────────────────────────────────────
+
+def gather_sources(conn: sqlite3.Connection,
+                   research_id: str, plan: dict) -> list[dict]:
+    section("Gathering Sources")
+    sources: list[dict] = []
+
+    for i, sq in enumerate(plan.get("search_queries", [])):
+        query = sq.get("query", "")
+        pr(f"  Searching: {query}", "dim")
+
+        # Real web search via DuckDuckGo
+        results = search_web(query, max_results=3)
+
+        for result in results:
+            url = result.get("href", "")
+            title = result.get("title", url)
+            if not url:
+                continue
+
+            pr(f"    Fetching: {url}", "dim")
+            content = fetch_url(url)
+
+            if content.startswith("ERROR"):
+                pr(f"    {content}", "dim")
+                continue
+
+            source = {
+                "url": url,
+                "title": title,
+                "content": content[:4000],
+                "query": query,
+            }
+            sources.append(source)
+
+            conn.execute(
+                "INSERT INTO fetches VALUES (?,?,?,?,?,?)",
+                (str(uuid.uuid4()), research_id, url, title,
+                 content[:500], now()),
+            )
+            conn.commit()
+
+    pr(f"\n  Gathered {len(sources)} sources", "bold")
+    return sources
+
+
+# ─── Stage 3: Report Synthesis ───────────────────────────────────────────────
+
+SYNTHESIS_SYS = """You are a research report writer. Given a topic and source material,
+write a well-structured report with inline citations.
+
+Rules:
+- Every factual claim MUST cite a source using [Source N] notation
+- Include a "Sources" section at the end listing each [Source N] with its URL
+- If sources disagree, note the disagreement explicitly
+- Flag any claims you make that are NOT supported by the provided sources
+- Structure: Introduction → Key Findings → Analysis → Limitations → Sources
+- Be concise but thorough (500-1500 words)"""
+
+
+def synthesize_report(client: OpenAI, topic: str, sources: list[dict]) -> str:
+    section("Synthesizing Report")
+    source_text = "\n\n".join(
+        f"[Source {i+1}] {s['url']}\n{s['content']}"
+        for i, s in enumerate(sources)
+    )
+    report = chat(client,
+                  [{"role": "system", "content": SYNTHESIS_SYS},
+                   {"role": "user", "content":
+                       f"Topic: {topic}\n\nSource Material:\n{source_text}"}])
+    return report
+
+
+# ─── Stage 4: Cross-Provider Adversarial Fact-Check ─────────────────────────
+
+FACT_CHECK_SYS = """You are a strict adversarial fact-checker. Your default stance is REJECT.
+Your job is to find unsupported claims, missing citations, and fabricated sources.
+
+IMPORTANT: You are a DIFFERENT AI system than the one that wrote this report.
+You have different training data and different biases. Use this independence
+to catch errors the original author's model might be blind to.
+
+For each claim in the report, check:
+1. Is it cited with a [Source N] reference?
+2. Does the source material actually support the claim, or was it fabricated/exaggerated?
+3. Are there important caveats the report omitted?
+
+Mandatory rejection rules — if ANY apply, verdict must be "reject":
+1. More than 30% of factual claims lack citations
+2. Any cited source URL is clearly fabricated (not a real website)
+3. A claim directly contradicts its cited source
+4. The report draws conclusions not supported by any provided source
+
+Confidence scale:
+- 0.0–0.4: serious factual problems (fabricated claims, missing citations)
+- 0.4–0.74: some unsupported claims or weak sourcing
+- 0.75+: all major claims are cited and supported by source material
+
+Return ONLY valid JSON:
+{"verdict":"accept|reject","confidence":0.0-1.0,
+ "claims_checked":[{"claim":"<quote from report>","source_cited":"<Source N or none>",
+   "supported":true,"note":"<explanation>"}],
+ "unsupported_claims":["<list of claims without adequate support>"],
+ "source_quality":"<assessment of source diversity and authority>",
+ "overall_reason":"<paragraph explaining the fact-check result>"}"""
+
+
+def fact_check(topic: str, report: str, sources: list[dict]) -> dict:
+    section("Cross-Provider Adversarial Fact-Check")
+    pr(f"  Research model: {RESEARCH_MODEL} (OpenAI)", "dim")
+    pr(f"  Fact-check model: {FACTCHECK_MODEL} (Anthropic)", "dim")
+
+    client = get_factcheck_client()
+    source_list = "\n".join(
+        f"[Source {i+1}] {s['url']}: {s['content'][:500]}"
+        for i, s in enumerate(sources)
+    )
+
+    user_content = (
+        f"{FACT_CHECK_SYS}\n\n"
+        f"Topic: {topic}\n\n"
+        f"Report to fact-check:\n{report}\n\n"
+        f"Available source material:\n{source_list}"
+    )
+
+    try:
+        response = client.messages.create(
+            model=FACTCHECK_MODEL,
+            max_tokens=4096,
+            messages=[{"role": "user", "content": user_content}],
+        )
+        raw = response.content[0].text
+    except Exception as e:
+        return {"verdict": "reject", "confidence": 0.0,
+                "claims_checked": [],
+                "unsupported_claims": [f"Fact-check failed: {e}"],
+                "source_quality": "unknown",
+                "overall_reason": f"Anthropic API error: {e}"}
+
+    # Parse JSON from response (Claude may wrap in markdown code blocks)
+    raw = raw.strip()
+    if raw.startswith("```"):
+        lines = raw.split("\n")
+        raw = "\n".join(lines[1:-1])
+
+    try:
+        return json.loads(raw)
+    except json.JSONDecodeError:
+        return {"verdict": "reject", "confidence": 0.0,
+                "claims_checked": [],
+                "unsupported_claims": ["Fact-check produced malformed output"],
+                "source_quality": "unknown",
+                "overall_reason": f"Fact-checker returned invalid JSON: {raw[:200]}"}
+
+
+# ─── Main Pipeline ──────────────────────────────────────────────────────────
+
+def research_topic(client: OpenAI, conn: sqlite3.Connection,
+                   topic: str) -> str:
+    research_id = str(uuid.uuid4())
+    conn.execute(
+        "INSERT INTO research VALUES (?,?,?,?,?,?,?,?,?,?)",
+        (research_id, topic, "planning", None, None, None, None, None,
+         now(), None),
+    )
+    conn.commit()
+    section("Research Topic")
+    pr(topic)
+
+    # 1. Plan
+    plan = plan_research(client, topic)
+    pr(f"\nRefined topic: {plan.get('topic_refined', topic)}", "bold")
+    for i, sq in enumerate(plan.get("search_queries", [])):
+        pr(f"  {i+1}. {sq.get('query', '')}", "dim")
+
+    # 2. Gather sources (no LLM needed — uses DuckDuckGo directly)
+    conn.execute("UPDATE research SET status='gathering' WHERE id=?",
+                 (research_id,))
+    conn.commit()
+    sources = gather_sources(conn, research_id, plan)
+
+    if not sources:
+        pr("[ERROR] No sources could be fetched. Aborting.", "bold red")
+        conn.execute(
+            "UPDATE research SET status='failed',finished_at=? WHERE id=?",
+            (now(), research_id),
+        )
+        conn.commit()
+        return research_id
+
+    conn.execute("UPDATE research SET sources_json=? WHERE id=?",
+                 (json.dumps([{"url": s["url"], "title": s["title"]}
+                              for s in sources]), research_id))
+    conn.commit()
+
+    # 3. Synthesize report (OpenAI)
+    conn.execute("UPDATE research SET status='synthesizing' WHERE id=?",
+                 (research_id,))
+    conn.commit()
+    report = synthesize_report(client, plan.get("topic_refined", topic), sources)
+    pr(f"\n{report}")
+
+    conn.execute("UPDATE research SET report=? WHERE id=?",
+                 (report, research_id))
+    conn.commit()
+
+    # 4. Cross-provider fact-check (Anthropic Claude)
+    conn.execute("UPDATE research SET status='fact_checking' WHERE id=?",
+                 (research_id,))
+    conn.commit()
+    fc = fact_check(topic, report, sources)
+
+    verdict = fc.get("verdict", "reject")
+    try:
+        confidence = float(fc.get("confidence", 0))
+    except (ValueError, TypeError):
+        confidence = 0.0
+    reason = fc.get("overall_reason", "")
+
+    if verdict == "accept" and confidence < THRESHOLD:
+        verdict = "reject"
+        reason = f"Confidence {confidence:.0%} below {THRESHOLD:.0%}. " + reason
+
+    # Display verdict
+    section("Fact-Check Verdict")
+    if verdict == "accept":
+        pr(f"VERIFIED ({confidence:.0%})", "bold green")
+    else:
+        pr(f"FLAGGED ({confidence:.0%})", "bold red")
+
+    pr(f"\n{reason}")
+    pr(f"\nSource quality: {fc.get('source_quality', 'unknown')}", "dim")
+
+    for claim in fc.get("claims_checked", []):
+        icon = "✓" if claim.get("supported") else "✗"
+        pr(f"  {icon} {claim.get('claim', '')[:80]}", "dim")
+        if claim.get("note"):
+            pr(f"    → {claim['note']}", "dim")
+
+    unsupported = fc.get("unsupported_claims", [])
+    if unsupported:
+        pr("\nUnsupported claims:", "bold red")
+        for uc in unsupported:
+            pr(f"  ✗ {uc}", "dim")
+
+    conn.execute(
+        "UPDATE research SET status=?,verdict=?,confidence=?,"
+        "fact_check_json=?,finished_at=? WHERE id=?",
+        (verdict, verdict, confidence, json.dumps(fc), now(), research_id),
+    )
+    conn.commit()
+    return research_id
+
+
+# ─── CLI ─────────────────────────────────────────────────────────────────────
+
+def list_research(conn: sqlite3.Connection) -> None:
+    rows = conn.execute(
+        "SELECT id, status, verdict, confidence, created_at, topic "
+        "FROM research ORDER BY created_at DESC LIMIT 20"
+    ).fetchall()
+    if not rows:
+        pr("No research sessions.")
+        return
+    if HAS_RICH:
+        t = Table(title="Recent Research", show_lines=True)
+        for col in ("ID", "Status", "Verdict", "Conf", "Created", "Topic"):
+            t.add_column(col)
+        for r in rows:
+            t.add_row(
+                r[0][:8], r[1], r[2] or "—",
+                f"{r[3]:.0%}" if r[3] is not None else "—",
+                r[4][:16], r[5][:60],
+            )
+        console.print(t)  # type: ignore
+    else:
+        for r in rows:
+            print(f"{r[0][:8]} | {r[1]:12} | {r[2] or '—':8} | {r[4][:16]} | {r[5][:60]}")
+
+
+def show_research(conn: sqlite3.Connection, prefix: str) -> None:
+    row = conn.execute("SELECT * FROM research WHERE id LIKE ?",
+                       (prefix + "%",)).fetchone()
+    if not row:
+        pr(f"No research matching '{prefix}'", "bold red")
+        return
+    pr(f"\nID: {row[0]}\nTopic: {row[1]}\nStatus: {row[2]}")
+    pr(f"Verdict: {row[5]} | Confidence: {row[6]}")
+    if row[3]:
+        pr(f"\n{row[3]}")
+    fetches = conn.execute(
+        "SELECT url, title FROM fetches WHERE research_id=?", (row[0],)
+    ).fetchall()
+    if fetches:
+        pr("\nSources fetched:", "bold")
+        for f in fetches:
+            pr(f"  • {f[1][:60]} — {f[0]}", "dim")
+
+
+def main() -> None:
+    global RESEARCH_MODEL, FACTCHECK_MODEL
+    p = argparse.ArgumentParser(description="Research agent with cross-provider fact-checking")
+    p.add_argument("topic", nargs="?", help="Research topic or question")
+    p.add_argument("--list", action="store_true", help="List past research")
+    p.add_argument("--show", help="Show research by ID prefix")
+    p.add_argument("--model", default=RESEARCH_MODEL, help="Research model (OpenAI)")
+    p.add_argument("--factcheck-model", default=FACTCHECK_MODEL, help="Fact-check model (Anthropic)")
+    args = p.parse_args()
+
+    RESEARCH_MODEL = args.model
+    FACTCHECK_MODEL = args.factcheck_model
+    DATA_DIR.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(DB_PATH)
+    init_db(conn)
+
+    if args.list:
+        list_research(conn)
+        return
+    if args.show:
+        show_research(conn, args.show)
+        return
+
+    if not args.topic:
+        try:
+            from rich.prompt import Prompt
+            topic = Prompt.ask("[bold]What would you like to research?[/bold]")
+        except ImportError:
+            topic = input("Research topic: ").strip()
+        if not topic:
+            sys.exit("No topic provided.")
+    else:
+        topic = args.topic
+
+    client = get_research_client()
+    rid = research_topic(client, conn, topic)
+    pr(f"\nResearch ID: {rid}", "dim")
+    conn.close()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Reworked version of #773, addressing all three review concerns:

| Feedback | Fix |
|----------|-----|
| "LLM suggests URLs — hallucinate frequently" | Replaced with real DuckDuckGo search (`ddgs` package, no API key needed) |
| "`fetch_url` returns raw HTML with scripts/noise" | newspaper4k for articles + BeautifulSoup fallback (strips scripts, nav, footers) |
| "Same model shares biases and knowledge gaps" | **OpenAI for research, Anthropic Claude for fact-check** — different provider, different training data, genuinely independent |

### What changed vs. #773

- **Search**: `SEARCH_SYS` prompt (LLM-generated URLs) → `DDGS().text()` (real web search)
- **Extraction**: Raw `r.text` → `newspaper4k` article parser + BS4 HTML cleanup
- **Independence**: Single `gpt-4o-mini` for everything → OpenAI research + Anthropic fact-check (both API keys required, no fallback mode)

### Pipeline

```
Topic → Plan (OpenAI) → Search (DuckDuckGo) → Extract (newspaper4k) → Report (OpenAI) → Fact-Check (Anthropic Claude) → Verdict
```

### How to run

```bash
pip install -r requirements.txt
export OPENAI_API_KEY=sk-...
export ANTHROPIC_API_KEY=sk-ant-...
streamlit run app.py
```

Or CLI: `python research_agent.py "your topic"`

### Files

- `research_agent.py` — Core pipeline + CLI (490 lines)
- `app.py` — Streamlit web UI (250 lines)
- `requirements.txt` — 8 dependencies
- `README.md` — Full documentation with architecture diagram