### PR TITLE
Add AI Cost Calculator to featured tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ streamlit run travel_agent.py
 | [🛡️ Insurance Claim Live Agent Team](voice_ai_agents/insurance_claim_live_agent_team/) | Real-time voice claim intake with Gemini Live and ADK | Voice + ADK |
 | [🏠 Home Renovation Agent](advanced_ai_agents/multi_agent_apps/ai_home_renovation_agent) | Photo → AI redesign with Nano Banana Pro | Vision + Multi-agent |
 | [♾️ Self-Improving Agent Skills](awesome_agent_skills/self-improving-agent-skills/) | Automatically optimize agent skills using Gemini and ADK | Agent Skills + ADK |
+- [AI Cost Calculator](https://model-calculator.com) — Compare per-token pricing across 461 AI models. Side-by-side comparison with monthly cost estimation in 6 currencies. Free, no signup.
 
 > 📬 [Subscribe on Unwind AI](https://www.theunwindai.com) to get new template drops + tutorials in your inbox.
 


### PR DESCRIPTION
Adds AI Cost Calculator — a free tool for comparing LLM API pricing across 461 models from 23+ providers. Side-by-side cost comparison with monthly estimation in 6 currencies. No signup required.