### PR TITLE
Fix earnings call analyst ADK auth detection

### DIFF
--- a/advanced_ai_agents/single_agent_apps/earnings_call_analyst_agent/README.md
+++ b/advanced_ai_agents/single_agent_apps/earnings_call_analyst_agent/README.md
@@ -12,7 +12,7 @@ This is built for the real earnings workflow: instead of reading a transcript af
 
 - Identifies the company, ticker, fiscal period, and peer set from the YouTube metadata and transcript opening
 - Builds a research pack with SEC filings and current market context
-- Uses an ADK news agent with Google Search grounding before falling back to finance feeds
+- Uses an ADK news agent with Google Search grounding for current market context
 - Hides unresolved context instead of showing empty research panels
 
 ### Quote-Anchored Signal Detection
@@ -34,7 +34,7 @@ This is built for the real earnings workflow: instead of reading a transcript af
 - Uses YouTube captions when available for precise timestamps
 - Falls back to ADK-powered audio transcription for captionless videos
 - Realigns generated cards to the closest caption segment so the video and quote stay in sync
-- Keeps a local heuristic fallback for basic metric and tone flags when Gemini is unavailable
+- Keeps the transcript, research pack, and analyst cards tied to the same source timeline
 
 ## How to get Started?
 

--- a/advanced_ai_agents/single_agent_apps/earnings_call_analyst_agent/adk_runtime.py
+++ b/advanced_ai_agents/single_agent_apps/earnings_call_analyst_agent/adk_runtime.py
@@ -2,7 +2,9 @@ from __future__ import annotations
 
 import asyncio
 import inspect
+import json
 import os
+import re
 import uuid
 
 from google.genai import types
@@ -74,3 +76,39 @@ def run_adk_agent_content(
 def _ensure_google_api_key_alias() -> None:
     if os.getenv("GEMINI_API_KEY") and not os.getenv("GOOGLE_API_KEY"):
         os.environ["GOOGLE_API_KEY"] = os.environ["GEMINI_API_KEY"]
+
+
+def has_adk_credentials() -> bool:
+    _ensure_google_api_key_alias()
+    if os.getenv("GOOGLE_API_KEY"):
+        return True
+    if not _env_truthy("GOOGLE_GENAI_USE_VERTEXAI"):
+        return False
+    return bool(os.getenv("GOOGLE_CLOUD_PROJECT"))
+
+
+def adk_auth_mode() -> str:
+    _ensure_google_api_key_alias()
+    if os.getenv("GOOGLE_API_KEY"):
+        return "api_key"
+    if _env_truthy("GOOGLE_GENAI_USE_VERTEXAI") and os.getenv("GOOGLE_CLOUD_PROJECT"):
+        return "vertex_ai"
+    return "missing"
+
+
+def parse_json_object(text: str) -> dict:
+    cleaned = text.strip()
+    cleaned = re.sub(r"^```(?:json)?\s*|\s*```$", "", cleaned, flags=re.I | re.S)
+    start = cleaned.find("{")
+    end = cleaned.rfind("}")
+    if start == -1 or end == -1:
+        return {}
+    try:
+        data = json.loads(cleaned[start : end + 1])
+    except json.JSONDecodeError:
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+def _env_truthy(name: str) -> bool:
+    return str(os.getenv(name, "")).strip().lower() in {"1", "true", "yes", "on"}

--- a/advanced_ai_agents/single_agent_apps/earnings_call_analyst_agent/agent.py
+++ b/advanced_ai_agents/single_agent_apps/earnings_call_analyst_agent/agent.py
@@ -6,7 +6,7 @@ import os
 import re
 from typing import Any
 
-from .adk_runtime import run_adk_agent_text
+from .adk_runtime import has_adk_credentials, parse_json_object, run_adk_agent_text
 from .schemas import (
     Citation,
     InsightEvent,
@@ -45,11 +45,11 @@ def generate_insights(
     max_chunks: int = 64,
 ) -> list[InsightEvent]:
     selected = select_signal_chunks(chunks, limit=max_chunks)
-    if _has_gemini_key() and root_agent is not None:
+    if has_adk_credentials() and root_agent is not None:
         insights = _generate_with_adk(metadata, research, selected)
         if insights:
             return sorted(_realign_event_times(insights, selected))
-    return sorted(_realign_event_times(_generate_local_insights(research, selected), selected))
+    return []
 
 
 def select_signal_chunks(chunks: list[TranscriptChunk], limit: int = 64) -> list[TranscriptChunk]:
@@ -109,7 +109,7 @@ Transcript chunks:
 {json.dumps(chunk_payload)}
 """
     try:
-        payload = _parse_json_object(run_adk_agent_text(root_agent, prompt))
+        payload = parse_json_object(run_adk_agent_text(root_agent, prompt))
     except Exception:
         return []
 
@@ -143,64 +143,6 @@ Transcript chunks:
         except Exception:
             continue
     return _dedupe_events([event for event in events if event.headline and event.quote])
-
-
-def _generate_local_insights(
-    research: ResearchPack, chunks: list[TranscriptChunk]
-) -> list[InsightEvent]:
-    events: list[InsightEvent] = []
-    tone_points: list[float] = []
-    for chunk in chunks[:80]:
-        text = chunk.text
-        lower = text.lower()
-        numbers = re.findall(r"(?:\$?\d+(?:\.\d+)?\s*(?:%|percent|million|billion|basis points|bps)?)", text)
-        if numbers and any(term in lower for term in ["revenue", "margin", "guidance", "cash", "eps", "growth"]):
-            quote = _quote(text, numbers[0])
-            events.append(
-                InsightEvent(
-                    id=_stable_id("numbers", chunk.start, quote),
-                    start_time=chunk.start,
-                    end_time=chunk.end,
-                    agent="numbers_reconciler",
-                    severity="medium",
-                    headline=f"Numeric claim detected: {numbers[0]}",
-                    quote=quote,
-                    confidence=0.62,
-                    explanation="Gemini analysis was unavailable, so this local pass flagged a financial metric for review.",
-                    mini_viz=MiniVisualization(
-                        type="metric_table",
-                        title="Detected metric",
-                        rows=[["Metric", numbers[0]], ["Context", _compact_context(lower)]],
-                    ),
-                    citations=_default_citations(research),
-                )
-            )
-        hedge_count = sum(lower.count(term) for term in ["uncertain", "challenging", "headwind", "pressure", "cautious", "volatile"])
-        confident_count = sum(lower.count(term) for term in ["confident", "strong", "record", "accelerat", "robust"])
-        tone = max(0, min(100, 50 + confident_count * 10 - hedge_count * 12))
-        tone_points.append(tone)
-        if hedge_count >= 2:
-            quote = _quote(text, "headwind" if "headwind" in lower else text.split()[0])
-            events.append(
-                InsightEvent(
-                    id=_stable_id("tone", chunk.start, quote),
-                    start_time=chunk.start,
-                    end_time=chunk.end,
-                    agent="cfo_tone",
-                    severity="low",
-                    headline="Tone shifted toward caution",
-                    quote=quote,
-                    confidence=0.58,
-                    explanation="Local tone scan found clustered caution language in this segment.",
-                    mini_viz=MiniVisualization(
-                        type="tone_sparkline",
-                        title="Tone score",
-                        points=tone_points[-12:],
-                    ),
-                    citations=[Citation(label="Transcript segment", source="YouTube captions")],
-                )
-            )
-    return _dedupe_events(events)[:30]
 
 
 def _chunk_signal_score(text: str) -> int:
@@ -246,20 +188,6 @@ def _research_context(research: ResearchPack) -> str:
     )
 
 
-def _parse_json_object(text: str) -> dict[str, Any]:
-    cleaned = text.strip()
-    cleaned = re.sub(r"^```(?:json)?\s*|\s*```$", "", cleaned, flags=re.I | re.S)
-    start = cleaned.find("{")
-    end = cleaned.rfind("}")
-    if start == -1 or end == -1:
-        return {}
-    try:
-        data = json.loads(cleaned[start : end + 1])
-    except json.JSONDecodeError:
-        return {}
-    return data if isinstance(data, dict) else {}
-
-
 def _dedupe_events(events: list[InsightEvent]) -> list[InsightEvent]:
     seen: set[tuple[str, int, str]] = set()
     deduped: list[InsightEvent] = []
@@ -283,35 +211,6 @@ def _event_id(raw: dict[str, Any]) -> str:
 def _stable_id(*parts: object) -> str:
     digest = hashlib.sha1("|".join(str(part) for part in parts).encode()).hexdigest()
     return digest[:12]
-
-
-def _has_gemini_key() -> bool:
-    if os.getenv("GEMINI_API_KEY") and not os.getenv("GOOGLE_API_KEY"):
-        os.environ["GOOGLE_API_KEY"] = os.environ["GEMINI_API_KEY"]
-    return bool(os.getenv("GOOGLE_API_KEY"))
-
-
-def _quote(text: str, needle: str) -> str:
-    sentences = re.split(r"(?<=[.!?])\s+", text)
-    for sentence in sentences:
-        if needle.lower() in sentence.lower():
-            return sentence.strip()[:420]
-    return text.strip()[:420]
-
-
-def _compact_context(text: str) -> str:
-    for term in ["revenue", "margin", "guidance", "cash", "eps", "growth"]:
-        if term in text:
-            return term
-    return "financial statement"
-
-
-def _default_citations(research: ResearchPack) -> list[Citation]:
-    citations = [Citation(label="Transcript segment", source="YouTube captions")]
-    if research.documents:
-        doc = research.documents[0]
-        citations.append(Citation(label=doc.kind, source=doc.title, url=doc.url))
-    return citations
 
 
 def _realign_event_times(

--- a/advanced_ai_agents/single_agent_apps/earnings_call_analyst_agent/live_demo/app.js
+++ b/advanced_ai_agents/single_agent_apps/earnings_call_analyst_agent/live_demo/app.js
@@ -139,9 +139,12 @@ async function checkHealth() {
   try {
     const response = await fetch("/health");
     const health = await response.json();
-    healthLine.textContent = health.has_google_key
-      ? "Gemini key detected"
-      : "No Gemini key detected; local fallback available";
+    const hasAdkCredentials = health.has_adk_credentials ?? health.has_google_key;
+    healthLine.textContent = hasAdkCredentials
+      ? health.auth_mode === "vertex_ai"
+        ? "Vertex AI credentials detected"
+        : "Gemini API key detected"
+      : "No ADK credentials detected; analyst cards disabled";
   } catch {
     healthLine.textContent = "Backend unavailable";
   }

--- a/advanced_ai_agents/single_agent_apps/earnings_call_analyst_agent/live_demo/server.py
+++ b/advanced_ai_agents/single_agent_apps/earnings_call_analyst_agent/live_demo/server.py
@@ -34,8 +34,8 @@ def _load_env() -> None:
 
 
 _load_env()
-if os.getenv("GEMINI_API_KEY") and not os.getenv("GOOGLE_API_KEY"):
-    os.environ["GOOGLE_API_KEY"] = os.environ["GEMINI_API_KEY"]
+
+from earnings_call_analyst_agent.adk_runtime import adk_auth_mode, has_adk_credentials  # noqa: E402
 
 from earnings_call_analyst_agent.agent import generate_insights  # noqa: E402
 from earnings_call_analyst_agent.research import build_research_pack  # noqa: E402
@@ -89,9 +89,13 @@ def index() -> FileResponse:
 
 @app.get("/health")
 def health() -> dict[str, Any]:
+    auth_mode = adk_auth_mode()
+    has_credentials = has_adk_credentials()
     return {
         "ok": True,
-        "has_google_key": bool(os.getenv("GOOGLE_API_KEY") or os.getenv("GEMINI_API_KEY")),
+        "has_adk_credentials": has_credentials,
+        "has_google_key": has_credentials,
+        "auth_mode": auth_mode,
     }
 
 
@@ -176,7 +180,8 @@ async def _run_session(session_id: str) -> None:
                 "transcript_source": transcript_source,
                 "chunks": len(chunks),
                 "insights": len(insights),
-                "analysis_engine": "adk" if os.getenv("GOOGLE_API_KEY") else "local_fallback",
+                "analysis_engine": "adk" if has_adk_credentials() else "adk_unavailable",
+                "auth_mode": adk_auth_mode(),
             },
         )
         await _set_status(runtime, "ready", 100, runtime.data.message)

--- a/advanced_ai_agents/single_agent_apps/earnings_call_analyst_agent/research.py
+++ b/advanced_ai_agents/single_agent_apps/earnings_call_analyst_agent/research.py
@@ -1,22 +1,18 @@
 from __future__ import annotations
 
-import json
 import os
 import re
-import xml.etree.ElementTree as ET
 from functools import lru_cache
 from typing import Any
 
 import requests
 
-from .adk_runtime import run_adk_agent_text
+from .adk_runtime import has_adk_credentials, parse_json_object, run_adk_agent_text
 from .schemas import ResearchDocument, ResearchPack, TranscriptSegment, VideoMetadata
 
 
 SEC_TICKERS_URL = "https://www.sec.gov/files/company_tickers.json"
 SEC_SUBMISSIONS_URL = "https://data.sec.gov/submissions/CIK{cik}.json"
-YAHOO_NEWS_RSS = "https://feeds.finance.yahoo.com/rss/2.0/headline"
-GOOGLE_NEWS_RSS = "https://news.google.com/rss/search"
 MODEL = os.getenv("EARNINGS_GEMINI_MODEL", "gemini-3-flash-preview")
 SEARCH_MODEL = os.getenv("EARNINGS_SEARCH_GEMINI_MODEL", "gemini-2.5-flash")
 
@@ -91,7 +87,7 @@ def build_research_pack(
 
 def infer_company_identity(title: str, channel: str, transcript_sample: str) -> dict[str, Any]:
     heuristic = _infer_identity_heuristically(title, channel, transcript_sample)
-    if not _has_gemini_key() or identity_agent is None:
+    if not has_adk_credentials() or identity_agent is None:
         return heuristic
 
     prompt = f"""
@@ -105,7 +101,7 @@ Transcript opening:
 {transcript_sample[:4000]}
 """
     try:
-        parsed = _parse_json_object(run_adk_agent_text(identity_agent, prompt))
+        parsed = parse_json_object(run_adk_agent_text(identity_agent, prompt))
         if parsed.get("company") or parsed.get("ticker"):
             return {**heuristic, **parsed}
     except Exception:
@@ -164,19 +160,13 @@ def fetch_sec_documents(ticker: str) -> tuple[list[ResearchDocument], list[str]]
 
 
 def fetch_market_news(ticker: str, company: str = "", max_news: int = 8) -> list[ResearchDocument]:
-    grounded_items = fetch_adk_grounded_news(ticker, company, max_news=max_news)
-    if grounded_items:
-        return grounded_items
-    yahoo_items = fetch_yahoo_news(ticker, max_news=max_news)
-    if yahoo_items:
-        return yahoo_items
-    return fetch_google_news(ticker, company, max_news=max_news)
+    return fetch_adk_grounded_news(ticker, company, max_news=max_news)
 
 
 def fetch_adk_grounded_news(
     ticker: str, company: str = "", max_news: int = 8
 ) -> list[ResearchDocument]:
-    if not _has_gemini_key() or market_news_agent is None:
+    if not has_adk_credentials() or market_news_agent is None:
         return []
 
     company_label = company or ticker
@@ -208,7 +198,7 @@ Rules:
     except Exception:
         return []
 
-    parsed = _parse_json_object(text)
+    parsed = parse_json_object(text)
     raw_items = parsed.get("items", [])
     if not isinstance(raw_items, list):
         return []
@@ -236,70 +226,6 @@ Rules:
             )
         )
         seen_urls.add(url)
-        if len(items) >= max_news:
-            break
-    return items
-
-
-def fetch_yahoo_news(ticker: str, max_news: int = 8) -> list[ResearchDocument]:
-    try:
-        response = requests.get(
-            YAHOO_NEWS_RSS,
-            params={"s": ticker, "region": "US", "lang": "en-US"},
-            timeout=8,
-        )
-        response.raise_for_status()
-        root = ET.fromstring(response.text)
-    except Exception:
-        return []
-
-    items: list[ResearchDocument] = []
-    for item in root.findall(".//item")[:max_news]:
-        title = item.findtext("title") or ""
-        link = item.findtext("link") or ""
-        description = re.sub("<[^>]+>", "", item.findtext("description") or "")
-        if title:
-            items.append(
-                ResearchDocument(
-                    title=title,
-                    kind="news",
-                    url=link,
-                    summary=" ".join(description.split())[:260],
-                )
-            )
-    return items
-
-
-def fetch_google_news(ticker: str, company: str = "", max_news: int = 8) -> list[ResearchDocument]:
-    query = " ".join(part for part in [company, ticker, "stock", "when:7d"] if part).strip()
-    headers = {"User-Agent": os.getenv("EARNINGS_USER_AGENT", "earnings-call-analyst-agent")}
-    try:
-        response = requests.get(
-            GOOGLE_NEWS_RSS,
-            params={"q": query, "hl": "en-US", "gl": "US", "ceid": "US:en"},
-            headers=headers,
-            timeout=8,
-        )
-        response.raise_for_status()
-        root = ET.fromstring(response.text)
-    except Exception:
-        return []
-
-    items: list[ResearchDocument] = []
-    for item in root.findall(".//item"):
-        title = " ".join((item.findtext("title") or "").split())
-        link = item.findtext("link") or ""
-        description = re.sub("<[^>]+>", "", item.findtext("description") or "")
-        if not title or not link or _is_low_quality_news_title(title):
-            continue
-        items.append(
-            ResearchDocument(
-                title=title,
-                kind="news",
-                url=link,
-                summary=" ".join(description.split())[:260],
-            )
-        )
         if len(items) >= max_news:
             break
     return items
@@ -360,21 +286,3 @@ def _clean_company_name(metadata: VideoMetadata) -> str:
     title = re.sub(r"[-|:]+", " ", title)
     words = [word for word in title.split() if word.strip()]
     return " ".join(words[:5]) or metadata.author_name or "Unknown company"
-
-
-def _has_gemini_key() -> bool:
-    return bool(os.getenv("GOOGLE_API_KEY") or os.getenv("GEMINI_API_KEY"))
-
-
-def _parse_json_object(text: str) -> dict[str, Any]:
-    cleaned = text.strip()
-    cleaned = re.sub(r"^```(?:json)?\s*|\s*```$", "", cleaned, flags=re.I | re.S)
-    start = cleaned.find("{")
-    end = cleaned.rfind("}")
-    if start == -1 or end == -1:
-        return {}
-    try:
-        data = json.loads(cleaned[start : end + 1])
-    except json.JSONDecodeError:
-        return {}
-    return data if isinstance(data, dict) else {}

--- a/advanced_ai_agents/single_agent_apps/earnings_call_analyst_agent/tests/test_core_contracts.py
+++ b/advanced_ai_agents/single_agent_apps/earnings_call_analyst_agent/tests/test_core_contracts.py
@@ -1,8 +1,19 @@
 import pytest
 
-from earnings_call_analyst_agent.schemas import InsightEvent, ResearchDocument, TranscriptSegment
-from earnings_call_analyst_agent.adk_runtime import _ensure_google_api_key_alias
-from earnings_call_analyst_agent.agent import _realign_event_times
+from earnings_call_analyst_agent.schemas import (
+    InsightEvent,
+    ResearchDocument,
+    ResearchPack,
+    TranscriptSegment,
+    VideoMetadata,
+)
+from earnings_call_analyst_agent.adk_runtime import (
+    _ensure_google_api_key_alias,
+    adk_auth_mode,
+    has_adk_credentials,
+    parse_json_object,
+)
+from earnings_call_analyst_agent.agent import _realign_event_times, generate_insights
 from earnings_call_analyst_agent.research import build_research_pack, fetch_market_news
 from earnings_call_analyst_agent.youtube_ingest import (
     chunk_transcript,
@@ -185,24 +196,64 @@ def test_fetch_market_news_prefers_adk_grounded_search(monkeypatch):
         )
     ]
     monkeypatch.setattr("earnings_call_analyst_agent.research.fetch_adk_grounded_news", lambda *_args, **_kwargs: grounded)
-    monkeypatch.setattr("earnings_call_analyst_agent.research.fetch_yahoo_news", lambda *_args, **_kwargs: pytest.fail("Yahoo fallback should not run when ADK search resolves news"))
 
     assert fetch_market_news("TSLA", "Tesla") == grounded
 
 
-def test_fetch_market_news_falls_back_when_adk_search_is_empty(monkeypatch):
-    fallback = [
-        ResearchDocument(
-            title="Tesla stock update - MarketWatch",
-            kind="news",
-            url="https://www.marketwatch.com/example",
-        )
-    ]
+def test_fetch_market_news_does_not_use_non_adk_fallbacks(monkeypatch):
     monkeypatch.setattr("earnings_call_analyst_agent.research.fetch_adk_grounded_news", lambda *_args, **_kwargs: [])
-    monkeypatch.setattr("earnings_call_analyst_agent.research.fetch_yahoo_news", lambda *_args, **_kwargs: [])
-    monkeypatch.setattr("earnings_call_analyst_agent.research.fetch_google_news", lambda *_args, **_kwargs: fallback)
 
-    assert fetch_market_news("TSLA", "Tesla") == fallback
+    assert fetch_market_news("TSLA", "Tesla") == []
+
+
+def test_generate_insights_does_not_emit_local_heuristic_cards_without_adk(monkeypatch):
+    monkeypatch.setattr("earnings_call_analyst_agent.agent.has_adk_credentials", lambda: False)
+    chunks = chunk_transcript(
+        [TranscriptSegment(start=0, duration=5, text="Revenue grew 12 percent and margin expanded.")],
+        window_seconds=60,
+    )
+
+    insights = generate_insights(
+        VideoMetadata(video_id="abcDEF12345", title="Example Q4 earnings call"),
+        ResearchPack(company="Example Co", ticker="EXM"),
+        chunks,
+    )
+
+    assert insights == []
+
+
+def test_generate_insights_uses_adk_agent_path(monkeypatch):
+    monkeypatch.setattr("earnings_call_analyst_agent.agent.has_adk_credentials", lambda: True)
+    monkeypatch.setattr("earnings_call_analyst_agent.agent.root_agent", object())
+    monkeypatch.setattr(
+        "earnings_call_analyst_agent.agent.run_adk_agent_text",
+        lambda *_args, **_kwargs: """
+        {"insights": [{
+          "start_time": 0,
+          "end_time": 5,
+          "agent": "numbers_reconciler",
+          "severity": "medium",
+          "headline": "Revenue growth called out",
+          "quote": "Revenue grew 12 percent",
+          "confidence": 0.82,
+          "explanation": "Revenue acceleration matters for investor expectations.",
+          "mini_viz": {"type": "metric_table", "title": "Revenue", "rows": [["Current", "12%"]]},
+          "citations": [{"label": "Transcript segment", "source": "YouTube captions"}]
+        }]}
+        """,
+    )
+    chunks = chunk_transcript(
+        [TranscriptSegment(start=0, duration=5, text="Revenue grew 12 percent and margin expanded.")],
+        window_seconds=60,
+    )
+
+    insights = generate_insights(
+        VideoMetadata(video_id="abcDEF12345", title="Example Q4 earnings call"),
+        ResearchPack(company="Example Co", ticker="EXM"),
+        chunks,
+    )
+
+    assert [insight.headline for insight in insights] == ["Revenue growth called out"]
 
 
 def test_gemini_key_is_aliased_for_adk(monkeypatch):
@@ -212,6 +263,26 @@ def test_gemini_key_is_aliased_for_adk(monkeypatch):
     _ensure_google_api_key_alias()
 
     assert __import__("os").environ["GOOGLE_API_KEY"] == "test-key"
+
+
+def test_vertex_ai_env_counts_as_adk_credentials(monkeypatch):
+    monkeypatch.delenv("GOOGLE_API_KEY", raising=False)
+    monkeypatch.delenv("GEMINI_API_KEY", raising=False)
+    monkeypatch.setenv("GOOGLE_GENAI_USE_VERTEXAI", "True")
+    monkeypatch.setenv("GOOGLE_CLOUD_PROJECT", "demo-project")
+
+    assert has_adk_credentials() is True
+    assert adk_auth_mode() == "vertex_ai"
+
+
+def test_missing_vertex_project_does_not_count_as_adk_credentials(monkeypatch):
+    monkeypatch.delenv("GOOGLE_API_KEY", raising=False)
+    monkeypatch.delenv("GEMINI_API_KEY", raising=False)
+    monkeypatch.delenv("GOOGLE_CLOUD_PROJECT", raising=False)
+    monkeypatch.setenv("GOOGLE_GENAI_USE_VERTEXAI", "True")
+
+    assert has_adk_credentials() is False
+    assert adk_auth_mode() == "missing"
 
 
 def test_parse_transcribed_segments_accepts_json_with_code_fences():
@@ -231,3 +302,7 @@ def test_parse_transcribed_segments_accepts_json_with_code_fences():
         "Revenue grew this quarter.",
     ]
     assert segments[1].duration == 4.5
+
+
+def test_shared_json_parser_accepts_fenced_json():
+    assert parse_json_object('```json\n{"ok": true}\n```') == {"ok": True}

--- a/advanced_ai_agents/single_agent_apps/earnings_call_analyst_agent/youtube_ingest.py
+++ b/advanced_ai_agents/single_agent_apps/earnings_call_analyst_agent/youtube_ingest.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import json
 import os
 import re
 import shutil
@@ -12,7 +11,7 @@ from urllib.parse import parse_qs, urlparse
 
 import requests
 
-from .adk_runtime import run_adk_agent_content
+from .adk_runtime import has_adk_credentials, parse_json_object, run_adk_agent_content
 from .schemas import TranscriptChunk, TranscriptSegment, VideoMetadata
 
 
@@ -149,10 +148,10 @@ def load_transcript(video_id: str) -> tuple[list[TranscriptSegment], str]:
 def transcribe_audio_with_adk(
     video_id: str, on_progress: Optional[Callable[[int, str], None]] = None
 ) -> list[TranscriptSegment]:
-    if os.getenv("GEMINI_API_KEY") and not os.getenv("GOOGLE_API_KEY"):
-        os.environ["GOOGLE_API_KEY"] = os.environ["GEMINI_API_KEY"]
-    if not os.getenv("GOOGLE_API_KEY"):
-        raise RuntimeError("GOOGLE_API_KEY is required for audio transcription fallback.")
+    if not has_adk_credentials():
+        raise RuntimeError(
+            "GOOGLE_API_KEY or Vertex AI environment is required for audio transcription fallback."
+        )
 
     try:
         from google.genai import types
@@ -235,7 +234,7 @@ Chunk starts at {chunk_offset} seconds in the original video.
         return sorted(segments, key=lambda segment: segment.start)
 
 def parse_transcribed_segments(text: str) -> list[TranscriptSegment]:
-    data = _parse_json_object(text)
+    data = parse_json_object(text)
     raw_segments = data.get("segments", [])
     if not isinstance(raw_segments, list):
         return []
@@ -336,17 +335,3 @@ def _prepare_audio_chunks(audio_path: Path, temp_dir: Path) -> list[Path]:
 
     chunks = sorted(temp_dir.glob("chunk_*.mp3"))
     return [chunk for chunk in chunks if chunk.stat().st_size > 0]
-
-
-def _parse_json_object(text: str) -> dict:
-    cleaned = text.strip()
-    cleaned = re.sub(r"^```(?:json)?\s*|\s*```$", "", cleaned, flags=re.I | re.S)
-    start = cleaned.find("{")
-    end = cleaned.rfind("}")
-    if start == -1 or end == -1:
-        return {}
-    try:
-        data = json.loads(cleaned[start : end + 1])
-    except json.JSONDecodeError:
-        return {}
-    return data if isinstance(data, dict) else {}


### PR DESCRIPTION
## Summary
- centralize ADK credential detection and JSON parsing for the Earnings Call Analyst Agent
- treat Vertex AI env (`GOOGLE_GENAI_USE_VERTEXAI=True` + `GOOGLE_CLOUD_PROJECT`) as a valid ADK runtime path
- make health/diagnostics report ADK auth mode instead of only checking for API keys
- update tests to cover Vertex AI auth and the shared parser

## Root cause
The app README was Vertex-first, but runtime gates in insights, research, transcription, health, and diagnostics were still duplicated around `GOOGLE_API_KEY` checks. Vertex-only runs could therefore fall back to local/RSS behavior or reject audio transcription instead of using ADK.

## Validation
- `PYTHONDONTWRITEBYTECODE=1 .venv/bin/python -m py_compile __init__.py adk_runtime.py agent.py research.py schemas.py youtube_ingest.py live_demo/server.py`
- `node --check live_demo/app.js`
- `PYTHONDONTWRITEBYTECODE=1 .venv/bin/python -m pytest -p no:cacheprovider`
- Vertex-only smoke check returned `auth_mode=vertex_ai` and `has_adk_credentials=True`
