### PR TITLE
Add financial disclaimer for the earnings call agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,8 @@ streamlit run travel_agent.py
 
 > 📬 [Subscribe on Unwind AI](https://www.theunwindai.com) to get new template drops + tutorials in your inbox.
 
+> **⚠️ Disclaimer:** just a heads up, conditions apply to these financial tools. the signals this agent pulls dont guarantee any specific market direction. every investor takes on their own risk, so do your own research before making any trades. this code just extracts data, it isnt financial advice.
+
 ## 📑 Table of Contents
 
 <details open>


### PR DESCRIPTION
you built a great tool here. the earnings call analyst is one of the best parts of the repo. but users can be unpredictable. they might see the data and think it is a hot stock tip.

i opened this pr to add a quick disclaimer. it draws a line between the software and investment advice. it covers your back as the maintainer and keeps the users grounded in reality. better to have it in there now before someone loses their shirt on a trade and looks for someone to blame.