### PR TITLE
Add NotFair (Google Ads MCP)

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,6 +287,7 @@ streamlit run travel_agent.py
 
 *   [🎯 Toonify Token Optimization](advanced_llm_apps/llm_optimization_tools/toonify_token_optimization/) - Reduce LLM API costs by 30–60% using TOON format
 *   [🧠 Headroom Context Optimization](advanced_llm_apps/llm_optimization_tools/headroom_context_optimization/) - Reduce LLM API costs by 50–90%
+- [NotFair](https://notfair.co) - Google Ads MCP server. Connect Claude and AI agents to a Google Ads account: diagnose campaign performance, recommend optimizations, and execute approved changes via the Google Ads API. Source: github.com/nowork-studio/toprank. Free tier available.
 
 ### 🔧 LLM Fine-tuning Tutorials
 *End-to-end fine-tuning recipes for open-source models.*


### PR DESCRIPTION
Adding NotFair under LLM Optimization Tools. It's a Google Ads MCP server that lets Claude and other AI agents diagnose campaign performance, recommend optimizations, and execute approved changes via the Google Ads API.

Source: github.com/nowork-studio/toprank
Registry: io.github.nowork-studio/notfair (active in the official MCP registry)
Endpoint: streamable-http at notfair.co/api/mcp/google_ads

Free tier available. Happy to adjust the format if you'd prefer.