### PR TITLE
feat: add Aegis DQ MCP Agent — agentic data quality validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,7 @@ streamlit run travel_agent.py
 *   [📑 Notion MCP Agent](mcp_ai_agents/notion_mcp_agent)
 *   [🌍 AI Travel Planner MCP Agent](mcp_ai_agents/ai_travel_planner_mcp_agent_team)
 *   [🔀 Multi-MCP Agent Router](mcp_ai_agents/multi_mcp_agent_router/)
+*   [🛡️ Aegis DQ MCP Agent](mcp_ai_agents/aegis_dq_mcp_agent/)
 
 ### 📀 RAG (Retrieval Augmented Generation)
 *Retrieval pipelines - from simple chains to agentic and multi-source.*

--- a/mcp_ai_agents/aegis_dq_mcp_agent/README.md
+++ b/mcp_ai_agents/aegis_dq_mcp_agent/README.md
@@ -1,0 +1,104 @@
+# 🛡️ Aegis DQ MCP Agent
+
+A Streamlit app that uses [Aegis DQ](https://github.com/aegis-dq/aegis-dq) as an MCP server to run agentic data quality validation — diagnosing failures, tracing root causes, and proposing SQL fixes through natural language.
+
+## Features
+
+- **Natural language interface** — ask the agent to validate data, search past runs, or compare results
+- **LLM-powered diagnosis** — Aegis DQ explains *why* a check failed, not just *that* it failed
+- **Full audit trail** — every validation run is logged to SQLite with FTS5 search
+- **Demo dataset** — pre-loaded `orders` table with intentional data quality issues to explore
+- **5 rule types** — null checks, range validation, accepted values, uniqueness, custom SQL
+
+## Demo Dataset
+
+The app seeds a local DuckDB database with an `orders` table containing **5 intentional data quality issues**:
+
+| Issue | Rule | Severity |
+|---|---|---|
+| Negative `amount` (-50.00) | range check | HIGH |
+| NULL `customer_id` | not_null | CRITICAL |
+| Invalid `status` ("refunded") | accepted_values | HIGH |
+| Duplicate `order_id` (ORD-001) | unique | HIGH |
+| NULL `amount` | not_null | MEDIUM |
+
+## Setup
+
+### Prerequisites
+
+- Python 3.10+
+- OpenAI API key
+
+### Installation
+
+1. Clone the repository:
+   ```bash
+   git clone https://github.com/Shubhamsaboo/awesome-llm-apps.git
+   cd awesome-llm-apps/mcp_ai_agents/aegis_dq_mcp_agent
+   ```
+
+2. Install dependencies:
+   ```bash
+   pip install -r requirements.txt
+   ```
+
+3. Set your OpenAI API key:
+   ```bash
+   export OPENAI_API_KEY=your-openai-api-key
+   ```
+   Or copy the secrets example:
+   ```bash
+   cp mcp_agent.secrets.yaml.example mcp_agent.secrets.yaml
+   # edit mcp_agent.secrets.yaml and add your key
+   ```
+
+4. Run the app:
+   ```bash
+   streamlit run main.py
+   ```
+
+## Example Prompts
+
+**Run validation (fast, no LLM):**
+```
+Run the rules at /path/to/sample_rules.yaml against DuckDB with no_llm=true and tell me what failed.
+```
+
+**Check audit trail:**
+```
+Show me the last 5 validation runs.
+```
+
+**Search decisions:**
+```
+Search the audit trail for anything about null customer IDs.
+```
+
+**Compare runs:**
+```
+Compare the last two runs — what newly failed?
+```
+
+## How It Works
+
+1. The app seeds a DuckDB database with sample orders data containing data quality issues
+2. The MCP-Agent framework connects to the Aegis DQ MCP server (`aegis mcp`)
+3. You ask questions in natural language
+4. The agent calls Aegis DQ tools (`run_validation`, `list_runs`, `search_decisions`, etc.)
+5. Results are displayed as structured markdown with severity grouping
+
+## Aegis DQ MCP Tools Used
+
+| Tool | What it does |
+|---|---|
+| `run_validation` | Run rules YAML against a warehouse |
+| `list_runs` | List recent run IDs from the audit trail |
+| `get_run_report` | Get the full report for a past run |
+| `search_decisions` | Full-text search across all LLM decisions |
+| `compare_reports` | Diff two runs — regressions and fixes |
+
+## Links
+
+- [Aegis DQ GitHub](https://github.com/aegis-dq/aegis-dq)
+- [Aegis DQ Docs](https://aegis-dq.dev)
+- [MCP-Agent Framework](https://github.com/lastmile-ai/mcp-agent)

--- a/mcp_ai_agents/aegis_dq_mcp_agent/main.py
+++ b/mcp_ai_agents/aegis_dq_mcp_agent/main.py
@@ -1,0 +1,166 @@
+"""Aegis DQ MCP Agent — agentic data quality validation with LLM diagnosis."""
+
+import asyncio
+import os
+from pathlib import Path
+
+import streamlit as st
+from mcp_agent.agents.agent import Agent
+from mcp_agent.app import MCPApp
+from mcp_agent.workflows.llm.augmented_llm import RequestParams
+from mcp_agent.workflows.llm.augmented_llm_openai import OpenAIAugmentedLLM
+
+from setup_demo_db import setup_demo_db
+
+RULES_PATH = str(Path(__file__).parent / "sample_rules.yaml")
+DB_PATH = "/tmp/aegis_demo.duckdb"
+
+st.set_page_config(page_title="Aegis DQ Agent", page_icon="🛡️", layout="wide")
+
+st.markdown("<h1>🛡️ Aegis DQ MCP Agent</h1>", unsafe_allow_html=True)
+st.markdown(
+    "Ask the agent to validate your data, diagnose failures, and propose SQL fixes — "
+    "powered by [Aegis DQ](https://github.com/aegis-dq/aegis-dq) via MCP."
+)
+
+with st.sidebar:
+    st.markdown("### 🗄️ Demo Dataset")
+    st.markdown("A sample `orders` table is pre-loaded with **intentional data quality issues**:")
+    st.markdown("- ❌ Negative order amount")
+    st.markdown("- ❌ NULL customer_id")
+    st.markdown("- ❌ Invalid status (`refunded`)")
+    st.markdown("- ❌ Duplicate order_id")
+    st.markdown("- ❌ NULL amount")
+    st.markdown("---")
+    st.markdown("### 💬 Example Prompts")
+    st.markdown("**Run validation**")
+    st.code(f"Run the rules at {RULES_PATH} against DuckDB with no LLM and tell me what failed.", language=None)
+    st.markdown("**Audit trail**")
+    st.code("Show me the last 5 validation runs.", language=None)
+    st.markdown("**Search decisions**")
+    st.code("Search the audit trail for anything about null customer IDs.", language=None)
+    st.markdown("---")
+    st.caption("Built with [Aegis DQ](https://aegis-dq.dev) + [MCP-Agent](https://github.com/lastmile-ai/mcp-agent)")
+
+# Seed the demo database on first load
+if "db_ready" not in st.session_state:
+    setup_demo_db(DB_PATH)
+    st.session_state.db_ready = True
+
+query = st.text_area(
+    "Your Question",
+    placeholder=f"Run the rules at {RULES_PATH} against DuckDB with no LLM and tell me what failed.",
+    height=100,
+)
+
+# Session state init
+if "initialized" not in st.session_state:
+    st.session_state.initialized = False
+    st.session_state.mcp_app = MCPApp(name="aegis_dq_agent")
+    st.session_state.mcp_context = None
+    st.session_state.mcp_agent_app = None
+    st.session_state.agent = None
+    st.session_state.llm = None
+    st.session_state.loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(st.session_state.loop)
+    st.session_state.is_processing = False
+    st.session_state.last_result = None
+
+
+async def setup_agent():
+    if not st.session_state.initialized:
+        try:
+            st.session_state.mcp_context = st.session_state.mcp_app.run()
+            st.session_state.mcp_agent_app = await st.session_state.mcp_context.__aenter__()
+
+            st.session_state.agent = Agent(
+                name="aegis-dq-agent",
+                instruction="""You are a data quality expert powered by Aegis DQ tools.
+
+Your job is to help users validate their data, understand failures, and propose fixes.
+
+When asked to run validation:
+1. Call run_validation with the provided rules_path, warehouse="duckdb", no_llm=True for fast checks
+2. Parse the JSON result and present failures clearly — group by severity
+3. For each failure explain: what rule failed, which table/column, and what the issue means
+
+When asked about past runs:
+1. Call list_runs to get recent run IDs
+2. Use get_run_report to retrieve full details
+
+When asked to search:
+1. Use search_decisions with relevant keywords
+
+Always present results in clear markdown with tables where appropriate.
+Highlight CRITICAL and HIGH severity failures prominently.""",
+                server_names=["aegis-dq"],
+            )
+
+            await st.session_state.agent.initialize()
+            st.session_state.llm = await st.session_state.agent.attach_llm(OpenAIAugmentedLLM)
+            st.session_state.initialized = True
+        except Exception as e:
+            return f"Error during initialization: {str(e)}"
+    return None
+
+
+async def run_agent(message: str) -> str:
+    if not os.getenv("OPENAI_API_KEY") and not os.path.exists(
+        os.path.join(os.path.dirname(__file__), "mcp_agent.secrets.yaml")
+    ):
+        return (
+            "⚠️ No LLM credentials found. Either set `OPENAI_API_KEY` in your environment, "
+            "or copy `mcp_agent.secrets.yaml.example` to `mcp_agent.secrets.yaml` and add your key."
+        )
+    try:
+        error = await setup_agent()
+        if error:
+            return error
+        result = await st.session_state.llm.generate_str(
+            message=message,
+            request_params=RequestParams(use_history=True, maxTokens=8000),
+        )
+        return result
+    except Exception as e:
+        return f"Error: {str(e)}"
+
+
+def start_run():
+    st.session_state.is_processing = True
+
+
+col1, col2 = st.columns([1, 4])
+with col1:
+    st.button(
+        "🚀 Run",
+        type="primary",
+        use_container_width=True,
+        disabled=st.session_state.is_processing or not query.strip(),
+        on_click=start_run,
+    )
+with col2:
+    if st.session_state.is_processing:
+        st.info("Agent is working…")
+
+if st.session_state.is_processing:
+    with st.spinner("Running Aegis DQ agent…"):
+        result = st.session_state.loop.run_until_complete(run_agent(query))
+    st.session_state.last_result = result
+    st.session_state.is_processing = False
+    st.rerun()
+
+if st.session_state.last_result:
+    st.markdown("### Results")
+    st.markdown(st.session_state.last_result)
+else:
+    st.info(
+        "👆 Enter a prompt above to get started. "
+        f"The demo database is ready at `{DB_PATH}` with 10 orders rows including data quality issues."
+    )
+
+st.markdown("---")
+st.markdown(
+    "Built with [Aegis DQ](https://aegis-dq.dev) · "
+    "[MCP-Agent](https://github.com/lastmile-ai/mcp-agent) · "
+    "[Streamlit](https://streamlit.io)"
+)

--- a/mcp_ai_agents/aegis_dq_mcp_agent/mcp_agent.config.yaml
+++ b/mcp_ai_agents/aegis_dq_mcp_agent/mcp_agent.config.yaml
@@ -1,0 +1,20 @@
+execution_engine: asyncio
+logger:
+  transports: [console, file]
+  level: info
+  progress_display: true
+  path_settings:
+    path_pattern: "logs/aegis-dq-agent-{unique_id}.jsonl"
+    unique_id: "timestamp"
+    timestamp_format: "%Y%m%d_%H%M%S"
+
+mcp:
+  servers:
+    aegis-dq:
+      command: "aegis"
+      args: ["mcp"]
+      env:
+        DUCKDB_PATH: "/tmp/aegis_demo.duckdb"
+
+openai:
+  default_model: "gpt-4o-mini"

--- a/mcp_ai_agents/aegis_dq_mcp_agent/mcp_agent.secrets.yaml.example
+++ b/mcp_ai_agents/aegis_dq_mcp_agent/mcp_agent.secrets.yaml.example
@@ -1,0 +1,2 @@
+openai:
+  api_key: "your-openai-api-key"

--- a/mcp_ai_agents/aegis_dq_mcp_agent/requirements.txt
+++ b/mcp_ai_agents/aegis_dq_mcp_agent/requirements.txt
@@ -1,0 +1,6 @@
+streamlit>=1.28.0
+mcp-agent>=0.0.14
+openai>=1.0.0
+aegis-dq[mcp]>=0.7.0
+duckdb>=1.0.0
+asyncio>=3.4.3

--- a/mcp_ai_agents/aegis_dq_mcp_agent/sample_rules.yaml
+++ b/mcp_ai_agents/aegis_dq_mcp_agent/sample_rules.yaml
@@ -1,0 +1,41 @@
+apiVersion: aegis.dev/v1
+rules:
+  - id: orders_amount_positive
+    table: orders
+    column: amount
+    type: range
+    logic:
+      min: 0
+      max: 100000
+    severity: high
+    description: Order amounts must be positive and within a realistic range
+
+  - id: orders_status_valid
+    table: orders
+    column: status
+    type: accepted_values
+    logic:
+      values: [pending, confirmed, shipped, delivered, cancelled]
+    severity: high
+    description: Order status must be one of the allowed values
+
+  - id: orders_customer_id_not_null
+    table: orders
+    column: customer_id
+    type: not_null
+    severity: critical
+    description: Every order must have a customer ID
+
+  - id: orders_no_duplicates
+    table: orders
+    column: order_id
+    type: unique
+    severity: high
+    description: Order IDs must be unique
+
+  - id: orders_amount_not_null
+    table: orders
+    column: amount
+    type: not_null
+    severity: medium
+    description: Order amount should not be null

--- a/mcp_ai_agents/aegis_dq_mcp_agent/setup_demo_db.py
+++ b/mcp_ai_agents/aegis_dq_mcp_agent/setup_demo_db.py
@@ -1,0 +1,31 @@
+"""Creates a sample DuckDB database with intentional data quality issues for the demo."""
+
+import duckdb
+
+
+def setup_demo_db(db_path: str = "/tmp/aegis_demo.duckdb") -> str:
+    con = duckdb.connect(db_path)
+    con.execute("DROP TABLE IF EXISTS orders")
+    con.execute("""
+        CREATE TABLE orders (
+            order_id    VARCHAR,
+            customer_id VARCHAR,
+            amount      DOUBLE,
+            status      VARCHAR
+        )
+    """)
+    con.execute("""
+        INSERT INTO orders VALUES
+        ('ORD-001', 'CUST-1', 250.00,  'delivered'),
+        ('ORD-002', 'CUST-2', 89.99,   'shipped'),
+        ('ORD-003', NULL,     150.00,  'pending'),
+        ('ORD-004', 'CUST-4', -50.00,  'confirmed'),
+        ('ORD-005', 'CUST-5', 999.50,  'refunded'),
+        ('ORD-006', 'CUST-6', 320.00,  'delivered'),
+        ('ORD-001', 'CUST-7', 75.00,   'pending'),
+        ('ORD-008', 'CUST-8', NULL,    'shipped'),
+        ('ORD-009', 'CUST-9', 410.00,  'cancelled'),
+        ('ORD-010', 'CUST-10', 88.00,  'delivered')
+    """)
+    con.close()
+    return db_path

--- a/mcp_ai_agents/aegis_dq_mcp_agent/setup_demo_db.py
+++ b/mcp_ai_agents/aegis_dq_mcp_agent/setup_demo_db.py
@@ -1,9 +1,13 @@
 """Creates a sample DuckDB database with intentional data quality issues for the demo."""
 
+import os
 import duckdb
 
 
 def setup_demo_db(db_path: str = "/tmp/aegis_demo.duckdb") -> str:
+    # Always start fresh to avoid schema conflicts from prior runs
+    if os.path.exists(db_path):
+        os.remove(db_path)
     con = duckdb.connect(db_path)
     con.execute("DROP TABLE IF EXISTS orders")
     con.execute("""
@@ -29,3 +33,8 @@ def setup_demo_db(db_path: str = "/tmp/aegis_demo.duckdb") -> str:
     """)
     con.close()
     return db_path
+
+
+if __name__ == "__main__":
+    path = setup_demo_db()
+    print(f"Demo database created at {path}")


### PR DESCRIPTION
## What

Adds a new MCP AI Agent demo: **Aegis DQ MCP Agent** (`mcp_ai_agents/aegis_dq_mcp_agent/`).

## About

[Aegis DQ](https://github.com/aegis-dq/aegis-dq) is an open-source agentic data quality framework. This demo connects to it as an MCP server and lets users validate data, diagnose failures, and explore the audit trail — all through natural language.

## What the demo does

- Seeds a local DuckDB `orders` table with **5 intentional data quality issues** (null IDs, negative amounts, invalid status, duplicates)
- Connects to the Aegis DQ MCP server via `mcp-agent`
- Users ask questions in natural language — the agent calls `run_validation`, `list_runs`, `search_decisions`, `compare_reports`
- Results are shown as structured markdown with severity grouping

## Files

```
mcp_ai_agents/aegis_dq_mcp_agent/
├── main.py                        # Streamlit app
├── setup_demo_db.py               # Seeds DuckDB with sample data
├── sample_rules.yaml              # 5 data quality rules to validate
├── mcp_agent.config.yaml          # MCP server config
├── mcp_agent.secrets.yaml.example # API key template
├── requirements.txt               # Dependencies
└── README.md                      # Setup + usage guide
```

## How to run

```bash
cd mcp_ai_agents/aegis_dq_mcp_agent
pip install -r requirements.txt
export OPENAI_API_KEY=your-key
streamlit run main.py
```

## Example prompts

- "Run the rules at sample_rules.yaml against DuckDB with no_llm=true"
- "Show me the last 5 validation runs"
- "Search the audit trail for null customer IDs"