### PR TITLE
fix: guard against empty choices and message=None in DeepSeek response

### DIFF
--- a/advanced_ai_agents/autonomous_game_playing_agent_apps/ai_3dpygame_r1/ai_3dpygame_r1.py
+++ b/advanced_ai_agents/autonomous_game_playing_agent_apps/ai_3dpygame_r1/ai_3dpygame_r1.py
@@ -83,6 +83,8 @@ if generate_code_btn and query:
                 max_tokens=1  
             )
 
+        if not deepseek_response.choices or deepseek_response.choices[0].message is None:
+            raise ValueError("LLM returned empty or filtered response")
         reasoning_content = deepseek_response.choices[0].message.reasoning_content
         print("\nDeepseek Reasoning:\n", reasoning_content)
         with st.expander("R1's Reasoning"):      


### PR DESCRIPTION
## Problem

In `ai_3dpygame_r1.py`, the DeepSeek API response is accessed without checking if `choices` is empty or `message` is `None`:

```python
reasoning_content = deepseek_response.choices[0].message.reasoning_content
```

This crashes with:
- `IndexError` when `choices` is `[]` (API returns no completions)
- `AttributeError` when `choices[0].message` is `None` (filtered/refused content)

## Fix

```python
if not deepseek_response.choices or deepseek_response.choices[0].message is None:
    raise ValueError("LLM returned empty or filtered response")
reasoning_content = deepseek_response.choices[0].message.reasoning_content
```

**2 lines added, 0 deleted.**

## Verification

Detected by [pact](https://github.com/qizwiz/pact) static analysis (`llm_response_unguarded` rule). Confirmed: Gemini 2.5 Flash returns HTTP 200 with `choices[0].message=None` on prohibited content.