### PR TITLE
Add emem to MCP AI Agents section

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,7 @@ streamlit run travel_agent.py
 *   [📑 Notion MCP Agent](mcp_ai_agents/notion_mcp_agent)
 *   [🌍 AI Travel Planner MCP Agent](mcp_ai_agents/ai_travel_planner_mcp_agent_team)
 *   [🔀 Multi-MCP Agent Router](mcp_ai_agents/multi_mcp_agent_router/)
+*   [🌍 emem - Earth Memory MCP Server](https://github.com/Vortx-AI/emem) <sub>↗ external</sub>
 
 ### 📀 RAG (Retrieval Augmented Generation)
 *Retrieval pipelines - from simple chains to agentic and multi-source.*


### PR DESCRIPTION
Adds emem as an external link in the MCP AI Agents section.

emem is an open source MCP server that gives AI agents signed geospatial facts and cite-able receipts for place-based questions.

- https://github.com/Vortx-AI/emem
- Public MCP endpoint: https://emem.dev/mcp