### PR TITLE
fix: guard against empty choices and None message in DeepSeek API responses

### DIFF
--- a/advanced_ai_agents/autonomous_game_playing_agent_apps/ai_3dpygame_r1/ai_3dpygame_r1.py
+++ b/advanced_ai_agents/autonomous_game_playing_agent_apps/ai_3dpygame_r1/ai_3dpygame_r1.py
@@ -83,6 +83,8 @@ if generate_code_btn and query:
                 max_tokens=1  
             )
 
+        if not deepseek_response.choices or deepseek_response.choices[0].message is None:
+            raise ValueError("DeepSeek returned an empty or filtered response")
         reasoning_content = deepseek_response.choices[0].message.reasoning_content
         print("\nDeepseek Reasoning:\n", reasoning_content)
         with st.expander("R1's Reasoning"):      

--- a/advanced_ai_agents/single_agent_apps/ai_system_architect_r1/ai_system_architect_r1.py
+++ b/advanced_ai_agents/single_agent_apps/ai_system_architect_r1/ai_system_architect_r1.py
@@ -194,6 +194,8 @@ class ModelChain:
                 stream=False   
             )
 
+            if not deepseek_response.choices or deepseek_response.choices[0].message is None:
+                raise ValueError("DeepSeek returned an empty or filtered response")
             reasoning_content = deepseek_response.choices[0].message.reasoning_content
             normal_content = deepseek_response.choices[0].message.content
             


### PR DESCRIPTION
## Summary

Add safety checks before accessing `deepseek_response.choices[0].message` to prevent crashes when the DeepSeek API returns empty or filtered responses.

## Changes

- `ai_3dpygame_r1.py` — Guard `choices[0].message.reasoning_content` access
- `ai_system_architect_r1.py` — Guard both `reasoning_content` and `content` access

Both files now raise `ValueError("DeepSeek returned an empty or filtered response")` instead of crashing with `IndexError` or `AttributeError`.

Closes #817