### PR TITLE
fix: remove Python stdlib modules from requirements.txt

### DIFF
--- a/advanced_ai_agents/multi_agent_apps/ai_financial_coach_agent/requirements.txt
+++ b/advanced_ai_agents/multi_agent_apps/ai_financial_coach_agent/requirements.txt
@@ -5,4 +5,3 @@ matplotlib>=3.7.0
 numpy==1.26.4
 python-dotenv>=1.0.0
 plotly>=5.15.0
-asyncio>=3.4.3

--- a/ai_agent_framework_crash_course/google_adk_crash_course/5_memory_agent/5_1_in_memory_conversation_agent/requirements.txt
+++ b/ai_agent_framework_crash_course/google_adk_crash_course/5_memory_agent/5_1_in_memory_conversation_agent/requirements.txt
@@ -1,4 +1,3 @@
 google-adk>=1.9.0
 streamlit>=1.47.1
 python-dotenv>=1.1.1
-asyncio 

--- a/ai_agent_framework_crash_course/google_adk_crash_course/5_memory_agent/5_2_persistent_conversation_agent/requirements.txt
+++ b/ai_agent_framework_crash_course/google_adk_crash_course/5_memory_agent/5_2_persistent_conversation_agent/requirements.txt
@@ -2,4 +2,3 @@ google-adk>=1.9.0
 streamlit>=1.47.1
 python-dotenv>=1.1.1
 sqlalchemy>=2.0.0
-asyncio 

--- a/mcp_ai_agents/browser_mcp_agent/requirements.txt
+++ b/mcp_ai_agents/browser_mcp_agent/requirements.txt
@@ -1,4 +1,3 @@
 streamlit>=1.28.0
 mcp-agent>=0.0.14
 openai>=1.0.0
-asyncio>=3.4.3

--- a/mcp_ai_agents/github_mcp_agent/requirements.txt
+++ b/mcp_ai_agents/github_mcp_agent/requirements.txt
@@ -2,4 +2,3 @@ streamlit>=1.28.0
 agno>=2.2.10
 mcp>=0.1.0
 openai>=1.0.0
-asyncio>=3.4.3

--- a/starter_ai_agents/ai_meme_generator_agent_browseruse/requirements.txt
+++ b/starter_ai_agents/ai_meme_generator_agent_browseruse/requirements.txt
@@ -1,6 +1,5 @@
 streamlit
 browser-use==0.1.26
-playwright==1.49.1 
+playwright==1.49.1
 langchain-openai
 langchain-anthropic
-asyncio

--- a/starter_ai_agents/mixture_of_agents/requirements.txt
+++ b/starter_ai_agents/mixture_of_agents/requirements.txt
@@ -1,3 +1,2 @@
 streamlit
-asyncio
 together

--- a/starter_ai_agents/openai_research_agent/requirements.txt
+++ b/starter_ai_agents/openai_research_agent/requirements.txt
@@ -1,7 +1,5 @@
 openai-agents
 openai
 streamlit
-uuid
 pydantic
 python-dotenv
-asyncio


### PR DESCRIPTION
## Summary

Removes `asyncio` and `uuid` from 8 `requirements.txt` files across the repo. These are Python standard library modules (available since Python 3.4+) and should not be listed as pip dependencies.

## Problem

Listing stdlib modules in `requirements.txt` causes two issues:

1. **Wrong package installed**: There is a PyPI package named `asyncio` that is unrelated to the stdlib module. Installing it can cause import conflicts.
2. **Confusing for contributors**: New contributors see stdlib modules listed and assume all imports need to be in requirements.txt.

## Files changed (8)

- `starter_ai_agents/openai_research_agent/requirements.txt` (removed `asyncio`, `uuid`)
- `starter_ai_agents/mixture_of_agents/requirements.txt` (removed `asyncio`)
- `starter_ai_agents/ai_meme_generator_agent_browseruse/requirements.txt` (removed `asyncio`)
- `mcp_ai_agents/github_mcp_agent/requirements.txt` (removed `asyncio>=3.4.3`)
- `mcp_ai_agents/browser_mcp_agent/requirements.txt` (removed `asyncio>=3.4.3`)
- `ai_agent_framework_crash_course/.../5_1_in_memory_conversation_agent/requirements.txt` (removed `asyncio`)
- `ai_agent_framework_crash_course/.../5_2_persistent_conversation_agent/requirements.txt` (removed `asyncio`)
- `advanced_ai_agents/multi_agent_apps/ai_financial_coach_agent/requirements.txt` (removed `asyncio>=3.4.3`)

## Test plan

- [ ] Verify each affected template still installs and runs correctly without the stdlib entries
- [ ] Confirm no actual third-party package named `asyncio` is needed by any template