### PR TITLE
fix: replace hardcoded API key placeholders in llm_router_app

### DIFF
--- a/advanced_llm_apps/cursor_ai_experiments/llm_router_app/.env.example
+++ b/advanced_llm_apps/cursor_ai_experiments/llm_router_app/.env.example
@@ -1,0 +1,2 @@
+OPENAI_API_KEY=your-openai-api-key
+TOGETHERAI_API_KEY=your-together-ai-api-key

--- a/advanced_llm_apps/cursor_ai_experiments/llm_router_app/llm_router.py
+++ b/advanced_llm_apps/cursor_ai_experiments/llm_router_app/llm_router.py
@@ -1,10 +1,20 @@
-import os
-
-os.environ["OPENAI_API_KEY"] = "your_openai_api_key"
-os.environ['TOGETHERAI_API_KEY'] = "your_togetherai_api_key"
-
 import streamlit as st
 from routellm.controller import Controller
+
+# Set up Streamlit app
+st.title("RouteLLM Chat App")
+
+# API key input via sidebar
+openai_key = st.sidebar.text_input("OpenAI API Key", type="password")
+together_key = st.sidebar.text_input("Together AI API Key", type="password")
+
+if not openai_key or not together_key:
+    st.info("Enter your OpenAI and Together AI API keys in the sidebar to get started.")
+    st.stop()
+
+import os
+os.environ["OPENAI_API_KEY"] = openai_key
+os.environ["TOGETHERAI_API_KEY"] = together_key
 
 # Initialize RouteLLM client
 client = Controller(
@@ -12,9 +22,6 @@ client = Controller(
     strong_model="gpt-4o-mini",
     weak_model="together_ai/meta-llama/Meta-Llama-3.1-70B-Instruct-Turbo",
 )
-
-# Set up Streamlit app
-st.title("RouteLLM Chat App")
 
 # Initialize chat history
 if "messages" not in st.session_state:


### PR DESCRIPTION
## Summary

Replaces hardcoded API key placeholder strings in `advanced_llm_apps/cursor_ai_experiments/llm_router_app/llm_router.py` with Streamlit sidebar text input, consistent with the rest of the repo.

## Problem

The file had literal strings as API key values:

```python
os.environ[OPENAI_API_KEY] = your_openai_api_key
os.environ[TOGETHERAI_API_KEY] = your_togetherai_api_key
```

This pattern:
1. **Fails silently at runtime** - the app starts but API calls fail with auth errors
2. **Risk of credential leaks** - users may edit the strings in-place and accidentally commit real keys
3. **Inconsistent with repo conventions** - most other templates use `st.sidebar.text_input` for key collection

## Changes

- Replaced hardcoded strings with `st.sidebar.text_input` (password-masked)
- Added `st.stop()` guard when keys are not provided
- Added `.env.example` documenting required keys
- Moved `import os` below Streamlit setup (only needed after keys are collected)

## Test plan

- [ ] Verify the app starts and shows the sidebar key inputs
- [ ] Verify `st.stop()` fires when keys are empty
- [ ] Verify the app works end-to-end when valid keys are provided