### PR TITLE
Add Octomind to Advanced AI Agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,7 @@ streamlit run travel_agent.py
 *   [🎧 AI Social Media News and Podcast Agent](advanced_ai_agents/multi_agent_apps/ai_news_and_podcast_agents/)
 *   [🌐 Openwork - Open Browser Automation Agent](https://github.com/accomplish-ai/openwork) <sub>↗ external</sub>
 *   [🛡️ Trust-Gated Multi-Agent Research Team](advanced_ai_agents/multi_agent_apps/trust_gated_agent_team/)
+*   [🐙 Octomind - Open-source AI Agent Runtime](https://github.com/muvon/octomind) <sub>↗ external</sub>
 
 ### 🎮 Autonomous Game-Playing Agents
 *Agents that play games end-to-end - reasoning, strategy, and action.*


### PR DESCRIPTION
## Octomind — Open-source AI Agent Runtime

[Octomind](https://github.com/muvon/octomind) is an open-source AI agent runtime (Apache 2.0, written in Rust).

**Why it fits Advanced AI Agents:**
- Production-style: 48+ specialist agents across 12 domains (developer, lawyer, doctor, devops, security, finance)
- Tools, memory, multi-step reasoning via built-in plan tool, agent spawning, and tap registry
- Multi-provider (13+ LLMs — OpenAI, Anthropic, Google, AWS Bedrock, DeepSeek, Groq, Ollama, etc.)
- Adaptive context compression for 4+ hour sessions without quality degradation
- Hard spending caps (per-request + per-session) — no surprise bills

**Links:**
- GitHub: https://github.com/muvon/octomind
- Website: https://octomind.run
- License: Apache 2.0

Happy to adjust the format if needed.