### PR TITLE
fix: guard against empty choices and None content in memory tutorial apps

### DIFF
--- a/advanced_llm_apps/llm_apps_with_memory_tutorials/ai_arxiv_agent_memory/ai_arxiv_agent_memory.py
+++ b/advanced_llm_apps/llm_apps_with_memory_tutorials/ai_arxiv_agent_memory/ai_arxiv_agent_memory.py
@@ -47,6 +47,8 @@ if all(api_keys.values()):
         Output Format: Table with the following columns: [{{"title": "Paper Title", "authors": "Author Names", "abstract": "Brief abstract", "link": "arXiv link"}}, ...]
         """
         response = openai_client.chat.completions.create(model="gpt-4o-mini", messages=[{"role": "user", "content": prompt}], temperature=0.2)
+        if not response.choices or response.choices[0].message.content is None:
+            raise ValueError("Received empty or null response from OpenAI API")
         return response.choices[0].message.content
 
     if st.button('Search for Papers'):

--- a/advanced_llm_apps/llm_apps_with_memory_tutorials/ai_travel_agent_memory/travel_agent_memory.py
+++ b/advanced_llm_apps/llm_apps_with_memory_tutorials/ai_travel_agent_memory/travel_agent_memory.py
@@ -85,6 +85,8 @@ if openai_api_key:
                 {"role": "user", "content": full_prompt}
             ]
         )
+        if not response.choices or response.choices[0].message.content is None:
+            raise ValueError("Received empty or null response from OpenAI API")
         answer = response.choices[0].message.content
 
         # Add assistant response to chat history

--- a/advanced_llm_apps/llm_apps_with_memory_tutorials/llm_app_personalized_memory/llm_app_memory.py
+++ b/advanced_llm_apps/llm_apps_with_memory_tutorials/llm_app_personalized_memory/llm_app_memory.py
@@ -52,6 +52,8 @@ if openai_api_key:
                 ]
             )
             
+            if not response.choices or response.choices[0].message.content is None:
+                raise ValueError("Received empty or null response from OpenAI API")
             answer = response.choices[0].message.content
 
             st.write("Answer: ", answer)

--- a/advanced_llm_apps/llm_apps_with_memory_tutorials/multi_llm_memory/multi_llm_memory.py
+++ b/advanced_llm_apps/llm_apps_with_memory_tutorials/multi_llm_memory/multi_llm_memory.py
@@ -65,6 +65,8 @@ if openai_api_key and anthropic_api_key:
                         {"role": "user", "content": full_prompt}
                     ]
                 )
+                if not response.choices or response.choices[0].message.content is None:
+                    raise ValueError("Received empty or null response from OpenAI API")
                 answer = response.choices[0].message.content
             elif llm_choice == 'Claude Sonnet 3.5':
                 messages=[
@@ -72,6 +74,8 @@ if openai_api_key and anthropic_api_key:
                         {"role": "user", "content": full_prompt}
                     ]
                 response = completion(model="claude-3-5-sonnet-20240620", messages=messages)
+                if not response.choices or response.choices[0].message.content is None:
+                    raise ValueError("Received empty or null response from LLM API")
                 answer = response.choices[0].message.content
             st.write("Answer: ", answer)
 


### PR DESCRIPTION
## Summary

Fixes #841

Four apps in `llm_apps_with_memory_tutorials` accessed `response.choices[0].message.content` without verifying that `choices` is non-empty and `content` is not `None`. This is the same class of bug fixed in PR #820 (DeepSeek) and PR #840 (beifong).

**Affected files:**
- `ai_arxiv_agent_memory/ai_arxiv_agent_memory.py` — arXiv paper search with GPT-4o-mini
- `ai_travel_agent_memory/travel_agent_memory.py` — travel agent with OpenAI
- `llm_app_personalized_memory/llm_app_memory.py` — personalized memory app
- `multi_llm_memory/multi_llm_memory.py` — multi-LLM app (OpenAI GPT-4o and Claude Sonnet)

**Root cause:** An empty `choices` list or `None` content can occur when a content filter is triggered, a quota is exceeded, or a transient API error occurs.

**Fix:** Add an explicit guard before each `choices[0]` access in all four files. The `ValueError` propagates cleanly to any surrounding error handling.

## Test plan

- [ ] Normal API responses continue to work correctly
- [ ] `ValueError` is raised when `choices` is empty or `content` is `None`