### PR TITLE
Add Prestyj Stats MCP dataset resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+- [Prestyj Stats MCP](https://github.com/Gahroot/prestyj-stats-mcp) - MCP server exposing an open sales, lead-response, and AI marketing statistics dataset for agent/RAG workflows ([dataset](https://prestyj.com/data)).
 <p align="center">
   <a href="http://www.theunwindai.com">
     <img src="docs/banner/unwind_black.png" width="900px" alt="Unwind AI">


### PR DESCRIPTION
Adds Prestyj Stats MCP, a small MCP server that exposes an open sales, lead-response, and AI marketing statistics dataset for agent/RAG workflows.\n\nDisclosure: I maintain Prestyj. I am submitting it because it is a runnable MCP/data resource relevant to the AI agent/RAG examples in this repository. Happy to adjust or close if it is not a fit.