### PR TITLE
Add Comply (skills_library) — open-source product compliance skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,6 +234,7 @@ streamlit run travel_agent.py
 *Ready-to-use agent skill files you can plug into any AI agent or LLM workflow.*
 
 *   [♾️ Self-Improving Agent Skills](awesome_agent_skills/self-improving-agent-skills/) - Automatically optimize agent skills using Gemini and ADK
+*   [🛂 Comply - Product Compliance Skills](https://github.com/Cleo-Labs-IA/skills_library) <sub>↗ external</sub> - 40+ production-grade skills + 2 MCP servers for physical-product compliance (REACH, FDA, CE, RoHS, customs, marketplace rules) across cosmetics, food, electronics, toys, textiles. MIT licensed.
 
 <details>
 <summary><strong>📋 Browse all 19 skills</strong></summary>


### PR DESCRIPTION
## What
Adds **Comply (skills_library)** under the *Awesome Agent Skills* section as an external resource.

[Cleo-Labs-IA/skills_library](https://github.com/Cleo-Labs-IA/skills_library) is an open-source library of **40+ production-grade skills + 2 MCP servers** for physical-product compliance — REACH, FDA, CE, RoHS, customs, marketplace rules — across cosmetics, food, electronics, toys, textiles, and 13 other verticals.

## Why this fits
- Drop-in skill files for Claude Code / Cursor / Codex (`~/.claude/skills/`)
- MIT licensed
- Production-grade (40+ skills, zero vague language, evidence-based outputs)
- Native MCP integration (2 bundled MCP servers)
- Active development

## Entry added
\`\`\`
*   [🛂 Comply - Product Compliance Skills](https://github.com/Cleo-Labs-IA/skills_library) <sub>↗ external</sub> - 40+ production-grade skills + 2 MCP servers for physical-product compliance (REACH, FDA, CE, RoHS, customs, marketplace rules) across cosmetics, food, electronics, toys, textiles. MIT licensed.
\`\`\`

Followed the existing \`<sub>↗ external</sub>\` convention used elsewhere in the section. Happy to adjust placement, emoji, or wording to match your style guide.