### PR TITLE
Add Human Browser (cloud residential browser MCP for AI agents)

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ AI Agents · Multi-agent Teams · MCP Agents · RAG · Voice Agents · Agent Ski
 
 ---
 
+- [Human Browser](https://github.com/VirixLabs/humanbrowser) - Cloud-hosted residential browser MCP for AI agents. Real residential IP per session, automated captcha solving (reCAPTCHA, hCaptcha, Turnstile, PerimeterX), live viewer URL for human-in-the-loop, MCP + A2A endpoints, $1 free trial.
 ## 💡 Why this exists
 
 You shouldn't have to rebuild the same RAG pipeline, agent loop, or MCP integration from scratch every time you start a new LLM project.


### PR DESCRIPTION
## What

Add [Human Browser](https://github.com/VirixLabs/humanbrowser) to the list.

## Why this fits

Human Browser fits in this list because it gives LLM agents real-web capabilities — residential IPs, captcha solving, MCP endpoint — without separate proxy/captcha vendor contracts.

- Hosted MCP endpoint at `agent.humanbrowser.cloud/mcp` (Streamable HTTP, Bearer token).
- Real residential IP per session (geo-selectable, not datacenter).
- Automated captcha solving: reCAPTCHA v2/v3, hCaptcha, Turnstile, PerimeterX.
- Live viewer URL with every task for HITL (CAPTCHA, 2FA, OTP).
- Sticky profile/cookies across sessions.
- Pay-as-you-go pricing, no subscription, $1 free trial.
- Open-source npm: `@virixlabs/humanbrowser` (Apache-2.0).

Happy to adjust placement/format. Thanks for maintaining the list!