### PR TITLE
Add AEGIS — reliability middleware for LLM agents (exactly-once + HITL + billing)

### DIFF
--- a/README.md
+++ b/README.md
@@ -341,3 +341,4 @@ streamlit run travel_agent.py
 ## 📜 License
 
 Apache-2.0. See [LICENSE](LICENSE). Fork it, ship it, sell it.
+- [AEGIS](https://github.com/cstamigo-droid/aegis-idempotency) - Production reliability layer for LLM-powered agents: exactly-once execution, human approval gates, and per-event billing. MIT, self-hostable, hosted API available.


### PR DESCRIPTION
## AEGIS

A reliability middleware for teams shipping LLM-powered agents to production.

**What it solves:**
- Duplicate actions when agents retry on failure
- No human checkpoint before consequential actions (send email, move money, deploy code)
- No cost visibility per tenant or per agent run

**Validated:** 500 concurrent requests on real PostgreSQL (Testcontainers, not mocks), 41 tests, MIT license.

- SDK: `pip install aegis-idempotency`
- GitHub: https://github.com/cstamigo-droid/aegis-idempotency
- Hosted API: https://aegis-idempotency-production.up.railway.app/docs