### PR TITLE
Add TWZRD Agent Intel — Solana x402 trust MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,6 +217,7 @@ streamlit run travel_agent.py
 *   [📑 Notion MCP Agent](mcp_ai_agents/notion_mcp_agent)
 *   [🌍 AI Travel Planner MCP Agent](mcp_ai_agents/ai_travel_planner_mcp_agent_team)
 *   [🔀 Multi-MCP Agent Router](mcp_ai_agents/multi_mcp_agent_router/)
+*   [🔐 TWZRD Agent Intel](https://intel.twzrd.xyz) — Solana x402 trust-scoring MCP server. Free preflight + paid Ed25519-signed trust receipts via <1s USDC settlement. [MCP](https://intel.twzrd.xyz/mcp)
 
 ### 📀 RAG (Retrieval Augmented Generation)
 *Retrieval pipelines - from simple chains to agentic and multi-source.*


### PR DESCRIPTION
## Summary

Adds [TWZRD Agent Intel](https://intel.twzrd.xyz) to the **MCP AI Agents** section.

**TWZRD Agent Intel** is a production MCP server for agent trust verification on Solana:
- 4 free preflight tools score any Solana wallet (on-chain activity, tx patterns, network age, recurring behavior)
- 4 paid tools return Ed25519-signed `twzrd.receipt.v5` trust tokens
- Streamable-HTTP MCP at `https://intel.twzrd.xyz/mcp` — works with Claude, LangChain, and any MCP-compatible agent
- <1s USDC settlement via x402 protocol on Solana mainnet
- MCP Registry: `xyz.twzrd.intel/twzrd-agent-intel`

Fits the MCP AI Agents section as a ready-to-use MCP server that agents can call to verify trust before transacting.

**Links:** [Website](https://intel.twzrd.xyz) | [MCP](https://intel.twzrd.xyz/mcp) | [OpenAPI](https://intel.twzrd.xyz/openapi.json) | [GitHub](https://github.com/twzrd-sol/wzrd-final)