### PR TITLE
feat: add OWASP Agent Memory Guard to LLM Apps with Memory section

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,6 +283,7 @@ streamlit run travel_agent.py
 *   [📝 LLM App with Personalized Memory](advanced_llm_apps/llm_apps_with_memory_tutorials/llm_app_personalized_memory/)
 *   [🗄️ Local ChatGPT Clone with Memory](advanced_llm_apps/llm_apps_with_memory_tutorials/local_chatgpt_with_memory/)
 *   [🧠 Multi-LLM Application with Shared Memory](advanced_llm_apps/llm_apps_with_memory_tutorials/multi_llm_memory/)
+*   [🛡️ Agent Memory Guard – Memory Poisoning Defense](https://github.com/OWASP/www-project-agent-memory-guard) <sub>↗ external</sub> – Detect and block memory poisoning attacks (OWASP ASI06) in agent memory stores like Mem0, Zep, and ChromaDB
 
 ### 💬 Chat with X Tutorials
 *Turn any data source into a chat interface.*


### PR DESCRIPTION
## What this adds

[OWASP Agent Memory Guard](https://github.com/OWASP/www-project-agent-memory-guard) — a runtime defense library that detects and blocks memory poisoning attacks (OWASP ASI06) in agent memory stores.

### Why it fits this section

The Memory Tutorials section showcases apps that use persistent memory (Mem0, stateful chat, shared memory). Agent Memory Guard is the security complement — it protects those same memory stores from injection and poisoning attacks that can corrupt agent behavior across sessions.

### Details

- **OWASP project** under the Agentic Security Initiatives
- Integrates with Mem0, Zep, ChromaDB, LangChain, CrewAI
- 200+ downloads/day on PyPI
- Detects: prompt injection persistence, instruction hijacking, cross-agent contamination
- `pip install agent-memory-guard`

Happy to adjust placement or description if you'd prefer it elsewhere!