### PR TITLE
Add Remio personal knowledge agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,6 +283,7 @@ streamlit run travel_agent.py
 *   [📝 LLM App with Personalized Memory](advanced_llm_apps/llm_apps_with_memory_tutorials/llm_app_personalized_memory/)
 *   [🗄️ Local ChatGPT Clone with Memory](advanced_llm_apps/llm_apps_with_memory_tutorials/local_chatgpt_with_memory/)
 *   [🧠 Multi-LLM Application with Shared Memory](advanced_llm_apps/llm_apps_with_memory_tutorials/multi_llm_memory/)
+*   [🔎 Remio Personal Knowledge Agent](advanced_llm_apps/llm_apps_with_memory_tutorials/remio_personal_knowledge_agent/)
 
 ### 💬 Chat with X Tutorials
 *Turn any data source into a chat interface.*

--- a/advanced_llm_apps/llm_apps_with_memory_tutorials/remio_personal_knowledge_agent/README.md
+++ b/advanced_llm_apps/llm_apps_with_memory_tutorials/remio_personal_knowledge_agent/README.md
@@ -1,0 +1,51 @@
+## Remio Personal Knowledge Agent
+
+This Streamlit app turns the Remio CLI into a local-first personal knowledge agent. It searches and answers questions over Remio's indexed notes, files, webpages, recordings, emails, messages, images, and other local knowledge sources.
+
+### Features
+
+- Uses Remio's local index and vector retrieval instead of repeatedly scanning raw files
+- Supports semantic note search and RAG-style Q&A
+- Works with Remio's pre-parsed files, webpages, recordings, notes, emails, messages, and images
+- Keeps context prompts smaller by retrieving relevant indexed chunks first
+- Detects missing Remio CLI or desktop app and points users to https://remio.ai/
+
+### How to get Started?
+
+1. Clone the GitHub repository
+
+```bash
+git clone https://github.com/Shubhamsaboo/awesome-llm-apps.git
+cd awesome-llm-apps/advanced_llm_apps/llm_apps_with_memory_tutorials/remio_personal_knowledge_agent
+```
+
+2. Install the required dependencies:
+
+```bash
+pip install -r requirements.txt
+```
+
+3. Install and open the Remio desktop app
+
+Remio CLI depends on the desktop app. Download or open Remio from:
+
+```text
+https://remio.ai/
+```
+
+Then verify:
+
+```bash
+remio doctor
+```
+
+4. Run the Streamlit app
+
+```bash
+streamlit run remio_personal_knowledge_agent.py
+```
+
+### Why Remio for agent memory?
+
+General-purpose agents often waste tokens by reading whole files or repeatedly using shell search over personal folders. Remio pre-parses and indexes personal knowledge locally, then exposes targeted retrieval through the CLI. This lets an agent retrieve only the relevant context before synthesizing an answer.
+

--- a/advanced_llm_apps/llm_apps_with_memory_tutorials/remio_personal_knowledge_agent/README.md
+++ b/advanced_llm_apps/llm_apps_with_memory_tutorials/remio_personal_knowledge_agent/README.md
@@ -1,6 +1,6 @@
 ## Remio Personal Knowledge Agent
 
-This Streamlit app turns the Remio CLI into a local-first personal knowledge agent. It searches and answers questions over Remio's indexed notes, files, webpages, recordings, emails, messages, images, and other local knowledge sources.
+This Streamlit app is a Remio-powered personal knowledge agent. It uses the Remio desktop app as the local-first knowledge base and calls the Remio CLI to search and answer questions over indexed notes, files, webpages, recordings, emails, messages, images, and other local knowledge sources.
 
 ### Features
 
@@ -8,7 +8,7 @@ This Streamlit app turns the Remio CLI into a local-first personal knowledge age
 - Supports semantic note search and RAG-style Q&A
 - Works with Remio's pre-parsed files, webpages, recordings, notes, emails, messages, and images
 - Keeps context prompts smaller by retrieving relevant indexed chunks first
-- Detects missing Remio CLI or desktop app and points users to https://remio.ai/
+- Detects missing Remio desktop app or CLI access and points users to https://remio.ai/
 
 ### How to get Started?
 
@@ -27,7 +27,7 @@ pip install -r requirements.txt
 
 3. Install and open the Remio desktop app
 
-Remio CLI depends on the desktop app. Download or open Remio from:
+This app depends on the Remio desktop app. Download or open Remio from:
 
 ```text
 https://remio.ai/
@@ -47,5 +47,4 @@ streamlit run remio_personal_knowledge_agent.py
 
 ### Why Remio for agent memory?
 
-General-purpose agents often waste tokens by reading whole files or repeatedly using shell search over personal folders. Remio pre-parses and indexes personal knowledge locally, then exposes targeted retrieval through the CLI. This lets an agent retrieve only the relevant context before synthesizing an answer.
-
+General-purpose agents often waste tokens by reading whole files or repeatedly using shell search over personal folders. Remio pre-parses and indexes personal knowledge locally, then exposes targeted retrieval to this app through its CLI. This lets an agent retrieve only the relevant context before synthesizing an answer.

--- a/advanced_llm_apps/llm_apps_with_memory_tutorials/remio_personal_knowledge_agent/remio_personal_knowledge_agent.py
+++ b/advanced_llm_apps/llm_apps_with_memory_tutorials/remio_personal_knowledge_agent/remio_personal_knowledge_agent.py
@@ -1,0 +1,96 @@
+import json
+import shutil
+import subprocess
+
+import streamlit as st
+
+
+def run_remio(args):
+    if not shutil.which("remio"):
+        return {
+            "ok": False,
+            "error": "Remio CLI was not found. Install or open Remio from https://remio.ai/.",
+        }
+
+    try:
+        completed = subprocess.run(
+            ["remio", *args],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )
+    except subprocess.TimeoutExpired:
+        return {"ok": False, "error": "Remio command timed out."}
+
+    output = completed.stdout.strip() or completed.stderr.strip()
+    if not output:
+        return {"ok": completed.returncode == 0, "data": None}
+
+    try:
+        parsed = json.loads(output)
+    except json.JSONDecodeError:
+        parsed = {"ok": completed.returncode == 0, "data": output}
+
+    if completed.returncode != 0 and parsed.get("ok", True):
+        parsed["ok"] = False
+        parsed["error"] = parsed.get("error") or output
+
+    return parsed
+
+
+st.title("Remio Personal Knowledge Agent")
+st.caption("Search and ask questions over your local-first Remio knowledge base.")
+
+with st.sidebar:
+    st.header("Remio Status")
+    if st.button("Check Remio"):
+        status = run_remio(["doctor"])
+        if status.get("ok"):
+            st.success("Remio is available.")
+        else:
+            st.error(status.get("error", "Remio is unavailable."))
+            st.link_button("Download Remio", "https://remio.ai/")
+
+    mode = st.radio("Mode", ["RAG answer", "Search notes"])
+    limit = st.slider("Result limit", min_value=3, max_value=20, value=8)
+
+query = st.text_area(
+    "Ask about your notes, files, recordings, emails, messages, or saved webpages",
+    placeholder="What did we decide about the product launch timeline?",
+)
+
+if st.button("Run") and query.strip():
+    if mode == "RAG answer":
+        result = run_remio(["rag", query.strip(), "--limit", str(limit)])
+        if result.get("ok"):
+            data = result.get("data") or {}
+            st.markdown(data.get("content", "No answer returned."))
+            citations = data.get("citations") or []
+            if citations:
+                st.subheader("Citations")
+                for citation in citations:
+                    title = citation.get("title", "Untitled")
+                    note_id = citation.get("noteId", "")
+                    st.write(f"- {title} ({note_id})")
+        else:
+            st.error(result.get("error", "Remio RAG failed."))
+            st.link_button("Download Remio", "https://remio.ai/")
+    else:
+        result = run_remio(["search_notes", "--query", query.strip(), "--limit", str(limit)])
+        if result.get("ok"):
+            data = result.get("data") or {}
+            results = data.get("results") or []
+            if not results:
+                st.info("No matching notes found.")
+            for item in results:
+                st.subheader(item.get("title", "Untitled"))
+                st.caption(item.get("noteType", "note"))
+                if item.get("preview"):
+                    st.write(item["preview"])
+                if item.get("noteId"):
+                    st.code(item["noteId"], language="text")
+        else:
+            st.error(result.get("error", "Remio search failed."))
+            st.link_button("Download Remio", "https://remio.ai/")
+

--- a/advanced_llm_apps/llm_apps_with_memory_tutorials/remio_personal_knowledge_agent/remio_personal_knowledge_agent.py
+++ b/advanced_llm_apps/llm_apps_with_memory_tutorials/remio_personal_knowledge_agent/remio_personal_knowledge_agent.py
@@ -30,13 +30,20 @@ def run_remio(args):
     try:
         parsed = json.loads(output)
     except json.JSONDecodeError:
-        parsed = {"ok": completed.returncode == 0, "data": output}
+        parsed = output
 
-    if completed.returncode != 0 and parsed.get("ok", True):
-        parsed["ok"] = False
-        parsed["error"] = parsed.get("error") or output
+    if completed.returncode != 0:
+        error = parsed.get("error") if isinstance(parsed, dict) else None
+        return {"ok": False, "data": parsed, "error": error or output}
 
-    return parsed
+    if isinstance(parsed, dict) and "ok" in parsed:
+        return {
+            "ok": bool(parsed.get("ok")),
+            "data": parsed.get("data", parsed),
+            "error": parsed.get("error"),
+        }
+
+    return {"ok": True, "data": parsed, "error": None}
 
 
 st.title("Remio Personal Knowledge Agent")
@@ -93,4 +100,3 @@ if st.button("Run") and query.strip():
         else:
             st.error(result.get("error", "Remio search failed."))
             st.link_button("Download Remio", "https://remio.ai/")
-

--- a/advanced_llm_apps/llm_apps_with_memory_tutorials/remio_personal_knowledge_agent/requirements.txt
+++ b/advanced_llm_apps/llm_apps_with_memory_tutorials/remio_personal_knowledge_agent/requirements.txt
@@ -1,0 +1,1 @@
+streamlit

--- a/advanced_llm_apps/llm_apps_with_memory_tutorials/remio_personal_knowledge_agent/requirements.txt
+++ b/advanced_llm_apps/llm_apps_with_memory_tutorials/remio_personal_knowledge_agent/requirements.txt
@@ -1,1 +1,1 @@
-streamlit
+streamlit>=1.28.0


### PR DESCRIPTION
## Summary
- Add a Remio-powered Streamlit personal knowledge agent tutorial under LLM apps with memory
- Use the Remio desktop app as the local-first knowledge base, with the Remio CLI as the app interface for semantic search and RAG
- Detect missing Remio desktop app/CLI access and point users to https://remio.ai/ before running queries

## Why
Remio pre-parses and indexes local notes, files, webpages, recordings, emails, messages, images, and other personal knowledge sources. This gives agents targeted retrieval instead of repeatedly scanning raw files with shell search or loading full documents into prompts, which can reduce token usage and latency for personal knowledge workflows.

## Test
- python3 -m py_compile advanced_llm_apps/llm_apps_with_memory_tutorials/remio_personal_knowledge_agent/remio_personal_knowledge_agent.py