### PR TITLE
Add Boardroom

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,7 @@ streamlit run travel_agent.py
 *   [✈️ MCP Apps Generative UI Showcase](generative_ui_agents/mcp-apps-generative-ui-showcase/)
 *   [🎛️ AI Shadcn Component Generator](generative_ui_agents/ai-shadcn-component-generator/)
 *   [🔍 AI Deep Research Agent](generative_ui_agents/ai-deep-research-agent/)
+*   [🏛️ Boardroom](https://github.com/jamiejhouston-commits/boardroom) <sub>↗ external</sub> - Local-first iPhone + Mac command center for running Hermes Agent as an autonomous company with boardroom debates, human greenlights, Demo Day, voice/chat, and multi-agent workflows.
 
 ### 🎮 Autonomous Game-Playing Agents
 *Agents that play games end-to-end - reasoning, strategy, and action.*


### PR DESCRIPTION
Adds Boardroom as an external agentic frontend / multi-agent command center.

Fit checked before submission:
- The list covers AI Agents, Multi-agent Teams, Voice AI Agents, and Generative UI / Agentic Frontends.
- Boardroom is a public, source-available iOS + Mac relay app for running Hermes Agent organization workflows: boardroom debates, human greenlight, Demo Day, voice/chat, and multi-agent company operation.
- This PR only edits the third-party awesome list README; it does not edit the Boardroom repo.
