### PR TITLE
Add OpenAcme to Multi-agent Teams

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ streamlit run travel_agent.py
 *   [✨ Multimodal Design Agent Team](advanced_ai_agents/multi_agent_apps/agent_teams/multimodal_design_agent_team/)
 *   [🎨 🍌 Multimodal UI/UX Feedback Agent Team with Nano Banana](advanced_ai_agents/multi_agent_apps/agent_teams/multimodal_uiux_feedback_agent_team/)
 *   [🌏 AI Travel Planner Agent Team](/advanced_ai_agents/multi_agent_apps/agent_teams/ai_travel_planner_agent_team/)
-*   [🤖 OpenAcme — Local-first AI Workforce Platform](https://github.com/sandydasari/openacme) <sub>↗ external</sub>
+*   [🤖 OpenAcme — AI Workforce Platform](https://github.com/sandydasari/openacme) — Named agents with roles, tools, memory, and MCP servers that delegate tasks to each other. Local-first, BYO model, no telemetry. <sub>↗ external</sub>
 
 ### 🗣️ Voice AI Agents
 *Speech-in, speech-out agents using real-time voice APIs.*

--- a/README.md
+++ b/README.md
@@ -181,6 +181,7 @@ streamlit run travel_agent.py
 *   [✨ Multimodal Design Agent Team](advanced_ai_agents/multi_agent_apps/agent_teams/multimodal_design_agent_team/)
 *   [🎨 🍌 Multimodal UI/UX Feedback Agent Team with Nano Banana](advanced_ai_agents/multi_agent_apps/agent_teams/multimodal_uiux_feedback_agent_team/)
 *   [🌏 AI Travel Planner Agent Team](/advanced_ai_agents/multi_agent_apps/agent_teams/ai_travel_planner_agent_team/)
+*   [🤖 OpenAcme — Local-first AI Workforce Platform](https://github.com/sandydasari/openacme) <sub>↗ external</sub>
 
 ### 🗣️ Voice AI Agents
 *Speech-in, speech-out agents using real-time voice APIs.*


### PR DESCRIPTION
## Description

Adds [OpenAcme](https://github.com/sandydasari/openacme) to the **Multi-agent Teams** section as an external project.

OpenAcme is a local-first AI workforce platform where you define named agents with roles, personas, tools, memory, and per-agent MCP servers. Agents collaborate via a shared task board — any agent can assign work to another, dependencies are tracked, and the scheduler wakes agents when their work is ready. Supports Anthropic, OpenAI, Google, OpenRouter, and Ollama, with BYO Claude Pro or ChatGPT Plus subscription support. MIT licensed, no telemetry.

## Why Multi-agent Teams

It fits the section description exactly: *"Multiple agents collaborating to accomplish complex, cross-domain tasks."* Each agent in the workforce is a distinct persona with its own model and tools; they delegate to each other autonomously rather than being orchestrated by a single controller.

## Checklist

- [x] Marked `<sub>↗ external</sub>` following the pattern used by other external entries in the list
- [x] MIT licensed open-source project
- [x] Runnable — `npm install -g @openacme/cli && openacme setup && openacme`