### PR TITLE
Add ForgeDock — autonomous dev pipeline for Claude Code

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,7 @@ streamlit run travel_agent.py
 *   [🎧 AI Social Media News and Podcast Agent](advanced_ai_agents/multi_agent_apps/ai_news_and_podcast_agents/)
 *   [🌐 Openwork - Open Browser Automation Agent](https://github.com/accomplish-ai/openwork) <sub>↗ external</sub>
 *   [🛡️ Trust-Gated Multi-Agent Research Team](advanced_ai_agents/multi_agent_apps/trust_gated_agent_team/)
+*   [🔧 ForgeDock — Autonomous Dev Pipeline for Claude Code](https://github.com/RapierCraftStudios/ForgeDock) <sub>↗ external</sub>
 
 ### 🛰️ Always-on Agents
 *Background agents that run on schedules or events, monitor changing context, decide what needs attention, and proactively deliver updates, artifacts, or actions.*


### PR DESCRIPTION
## Summary

- Adds [ForgeDock](https://github.com/RapierCraftStudios/ForgeDock) to the **Advanced AI Agents** section as an external link.
- ForgeDock is an autonomous AI development pipeline for Claude Code that uses GitHub as a persistent knowledge graph. 20+ slash commands orchestrate investigate → architect → build → review → merge workflows with structured context annotations.
- Follows the existing external-link format (`↗ external` marker) already used by other entries in the section.

## Changes

Single line added to `README.md` in the Advanced AI Agents section.