### PR TITLE
feat(skill): Add Traveseal C2PA provenance agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,6 +272,7 @@ streamlit run travel_agent.py
 | [📋 Meeting Notes](awesome_agent_skills/meeting-notes/) | Meeting summaries, action items, follow-ups |
 | [📅 Project Planner](awesome_agent_skills/project-planner/) | Roadmaps, milestones, resource planning |
 | [🐍 Python Expert](awesome_agent_skills/python-expert/) | Pythonic code, packaging, performance |
+| [🛡️ Traveseal C2PA Provenance](awesome_agent_skills/traveseal-c2pa-provenance/) | C2PA-compliant provenance and tamper resistance for digital assets |
 | [🏃 Sprint Planner](awesome_agent_skills/sprint-planner/) | Agile sprint planning and backlog grooming |
 | [🧭 Strategy Advisor](awesome_agent_skills/strategy-advisor/) | Business strategy and competitive analysis |
 | [📖 Technical Writer](awesome_agent_skills/technical-writer/) | Documentation, API docs, guides |

--- a/awesome_agent_skills/traveseal-c2pa-provenance/README.md
+++ b/awesome_agent_skills/traveseal-c2pa-provenance/README.md
@@ -1,0 +1,11 @@
+# Traveseal C2PA Provenance
+
+Traveseal is a service that provides C2PA-compliant provenance and tamper resistance for digital assets. It allows users to create a permanent, verifiable record of the history of a digital file, from its creation to its most recent modification.
+
+This is particularly useful for:
+
+*   **Verifying the authenticity of images and other media:** Ensure that an image hasn't been tampered with since it was captured.
+*   **Tracking the chain of custody for sensitive documents:** Know who has accessed and modified a file and when.
+*   **Creating a trusted archive of digital assets:** Preserve the integrity of your digital files for the long term.
+
+Traveseal is built on the C2PA (Coalition for Content Provenance and Authenticity) standard, which is an open standard for providing provenance and history for digital media.


### PR DESCRIPTION
This PR adds the Traveseal C2PA provenance agent to the awesome-agent-skills list.