### PR TITLE
Add Nexo - external MCP workspace reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,6 +223,7 @@ streamlit run travel_agent.py
 *   [📑 Notion MCP Agent](mcp_ai_agents/notion_mcp_agent)
 *   [🌍 AI Travel Planner MCP Agent](mcp_ai_agents/ai_travel_planner_mcp_agent_team)
 *   [🔀 Multi-MCP Agent Router](mcp_ai_agents/multi_mcp_agent_router/)
+*   [🖥️ Nexo - All-in-One Workspace AI](https://github.com/Nexo-Agent/nexo) <sub>↗ external</sub>
 
 ### 📀 RAG (Retrieval Augmented Generation)
 *Retrieval pipelines - from simple chains to agentic and multi-source.*


### PR DESCRIPTION
## Summary
- Adds [Nexo](https://github.com/Nexo-Agent/nexo) as an external reference in the **MCP AI Agents** section
- Nexo is a cross-platform desktop AI workspace (Tauri + React + Rust) with multi-provider LLM support, MCP integration, workspace management, and local SQLite storage

## Placement
Follows the existing external link pattern (`↗ external`) used for other third-party projects in this repo.

## Test plan
- [x] Link points to https://github.com/Nexo-Agent/nexo
- [x] Entry placed at the bottom of the MCP AI Agents section


Made with [Cursor](https://cursor.com)