### PR TITLE
Add h5i to Multi-agent Teams

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,7 @@ streamlit run travel_agent.py
 *   [✨ Multimodal Design Agent Team](advanced_ai_agents/multi_agent_apps/agent_teams/multimodal_design_agent_team/)
 *   [🎨 🍌 Multimodal UI/UX Feedback Agent Team with Nano Banana](advanced_ai_agents/multi_agent_apps/agent_teams/multimodal_uiux_feedback_agent_team/)
 *   [🌏 AI Travel Planner Agent Team](/advanced_ai_agents/multi_agent_apps/agent_teams/ai_travel_planner_agent_team/)
+*   [🦀 h5i - Multi-Agent Coding CLI](https://github.com/h5i-dev/h5i) <sub>↗ external</sub>
 
 ### 🗣️ Voice AI Agents
 *Speech-in, speech-out agents using real-time voice APIs.*


### PR DESCRIPTION
This adds [h5i](https://github.com/h5i-dev/h5i) to the **Multi-agent Teams** section.

h5i is an open-source Rust CLI that runs several coding agents (Claude Code, Codex) on the same task in isolated sandboxes, has them peer-review each other, then a neutral verifier replays and tests each candidate and merges the one that passes. Run metadata is versioned in the repo under refs/h5i/*.

The entry follows the existing format and ordering of the list.