### PR TITLE
Add Metis

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,7 @@ streamlit run travel_agent.py
 *Background agents that run on schedules or events, monitor changing context, decide what needs attention, and proactively deliver updates, artifacts, or actions.*
 
 *   [📰 Always-on Hacker News Briefing Agent](always_on_agents/always_on_hn_briefing_agent/)
+*   [💼 Metis - Local Job Search Triage Agent](https://github.com/chenlomis/metis) <sub>↗ external</sub>
 
 ### 🤝 Multi-agent Teams
 *Multiple agents collaborating to accomplish complex, cross-domain tasks.*


### PR DESCRIPTION
Adds Metis as an external always-on agent.\n\nMetis is an open-source local CLI for job-search triage. It monitors job alerts and company career pages, scores roles against a local profile with Claude, sends a ranked digest, and keeps local scoring traces for debugging/explainability.\n\nI placed it under Always-on Agents because it runs as a recurring local workflow that monitors changing job sources and delivers updates.