### PR TITLE
Add Bilibili RAG to RAG apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,6 +230,7 @@ streamlit run travel_agent.py
 *   [🔥 Agentic RAG with Embedding Gemma](rag_tutorials/agentic_rag_embedding_gemma)
 *   [🧐 Agentic RAG with Reasoning](rag_tutorials/agentic_rag_with_reasoning/)
 *   [📰 AI Blog Search (RAG)](rag_tutorials/ai_blog_search/)
+*   [📺 Bilibili RAG](https://github.com/via007/bilibili-rag) <sub>↗ external</sub>
 *   [🔍 Autonomous RAG](rag_tutorials/autonomous_rag/)
 *   [🔄 Contextual AI RAG Agent](rag_tutorials/contextualai_rag_agent/)
 *   [🔄 Corrective RAG (CRAG)](rag_tutorials/corrective_rag/)


### PR DESCRIPTION
## Summary

- Adds Bilibili RAG as a self-contained runnable tutorial under `rag_tutorials/bilibili_rag/`.
- Includes FastAPI backend, Next.js frontend, Docker Compose setup, screenshots, example env config, and setup instructions.
- Updates the RAG section README entry to point to the local tutorial folder instead of an external repository link.

## Why

Bilibili RAG turns Bilibili favorites into a searchable, source-traceable personal knowledge base with ASR, vector retrieval, RAG chat, multi-part video ingestion, and Markdown export.

## Checks

- `git diff --cached --check`
- `python3 -m compileall -q app`
- backend import check: `from app.main import app`
- `pip install -r requirements.txt` in a temporary virtual environment
- `npm ci`
- `npm run lint`
- `npm run build`