### PR TITLE
Add Financial News MCP Agent (AlphaAI)

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,6 +223,7 @@ streamlit run travel_agent.py
 *   [📑 Notion MCP Agent](mcp_ai_agents/notion_mcp_agent)
 *   [🌍 AI Travel Planner MCP Agent](mcp_ai_agents/ai_travel_planner_mcp_agent_team)
 *   [🔀 Multi-MCP Agent Router](mcp_ai_agents/multi_mcp_agent_router/)
+*   [📈 Financial News MCP Agent](mcp_ai_agents/financial_news_agent/)
 
 ### 📀 RAG (Retrieval Augmented Generation)
 *Retrieval pipelines - from simple chains to agentic and multi-source.*

--- a/mcp_ai_agents/financial_news_agent/README.md
+++ b/mcp_ai_agents/financial_news_agent/README.md
@@ -1,0 +1,75 @@
+# 📈 Financial News MCP Agent
+
+A Streamlit app that answers natural-language questions about the stock market using the [AlphaAI](https://alphai.io) MCP server through the Model Context Protocol (MCP). Every article AlphaAI returns is pre-analyzed at ingest with a **per-ticker relevance score (1-10)**, a category, and impact analysis, and SEC EDGAR **Form 4 insider filings** are surfaced as structured data.
+
+**✨ Uses AlphaAI's hosted [MCP server](https://alphai.io/mcp) — Streamable HTTP + OAuth 2.1 — with a real free tier (no credit card).**
+
+## Features
+
+- **Natural Language Interface**: Ask about tickers, sectors, trending stories, or insider activity in plain English
+- **Relevance-Scored News**: Results lead with the highest-relevance stories and surface the 1-10 score
+- **SEC Form 4 Insider Data**: Ask about insider buying/selling, scored as structured events
+- **MCP Integration**: Connects to a remote OAuth-protected MCP server via `mcp-remote`
+- **Interactive UI**: Streamlit interface with example queries and custom input
+
+## Setup
+
+### Requirements
+
+- Python 3.8+
+- Node.js (provides `npx`, used to run [`mcp-remote`](https://www.npmjs.com/package/mcp-remote))
+  - Install from [nodejs.org](https://nodejs.org/)
+- OpenAI API Key
+- A free AlphaAI account (created during the OAuth step — no credit card)
+
+### Installation
+
+1. Clone this repository:
+   ```bash
+   git clone https://github.com/Shubhamsaboo/awesome-llm-apps.git
+   cd awesome-llm-apps/mcp_ai_agents/financial_news_agent
+   ```
+
+2. Install the required Python packages:
+   ```bash
+   pip install -r requirements.txt
+   ```
+
+3. Verify Node.js is available (for `npx mcp-remote`):
+   ```bash
+   node --version
+   npx --version
+   ```
+
+4. Get your API key:
+   - **OpenAI API Key**: Get from [platform.openai.com/api-keys](https://platform.openai.com/api-keys)
+
+### Running the App
+
+1. Start the Streamlit app:
+   ```bash
+   streamlit run financial_news_agent.py
+   ```
+
+2. In the app:
+   - Enter your OpenAI API key in the sidebar
+   - Type a query (or pick an example) and click **Run Query**
+   - On the **first** run, a browser tab opens for AlphaAI OAuth — sign in or create a free account, and approve access. `mcp-remote` caches the token, so later runs skip this step.
+
+## Example Queries
+
+- "What's the latest news on NVDA?"
+- "Show me today's top trending market stories"
+- "Any recent SEC Form 4 insider buying in energy names?"
+- "Summarize high-relevance news about Tesla this week"
+
+## How It Works
+
+1. `mcp-remote` bridges AlphaAI's remote Streamable-HTTP MCP server to a local stdio transport and runs the OAuth 2.1 handshake on first connect.
+2. The [Agno](https://github.com/agno-agi/agno) agent (powered by OpenAI) loads the AlphaAI MCP tools — news search, trending, per-ticker feeds, single-article fetch, ticker discovery, and SEC Form 4 insider news.
+3. The agent picks the right tools for your question, and AlphaAI returns relevance-scored, ticker-linked results.
+4. Answers are rendered as markdown with the relevance signal surfaced.
+
+## About AlphaAI
+
+[AlphaAI](https://alphai.io) turns the financial-news firehose (GDELT + SEC EDGAR) into machine-readable signal for AI agents and trading bots. It's available as a REST API and an MCP server, with a free tier of 20 requests/min and 100/day on both. See the [MCP docs](https://alphai.io/mcp) and [developer guide](https://alphai.io/developers).

--- a/mcp_ai_agents/financial_news_agent/financial_news_agent.py
+++ b/mcp_ai_agents/financial_news_agent/financial_news_agent.py
@@ -1,0 +1,135 @@
+import asyncio
+import os
+from textwrap import dedent
+
+import streamlit as st
+from agno.agent import Agent
+from agno.run.agent import RunOutput
+from agno.tools.mcp import MCPTools
+from mcp import StdioServerParameters
+
+# AlphaAI's hosted MCP server — relevance-scored, ticker-linked financial news
+# (GDELT + SEC EDGAR) exposed over Streamable HTTP with OAuth 2.1. We reach it
+# through `mcp-remote`, the stdio<->remote bridge that also drives the one-time
+# OAuth browser handshake and caches the token locally.
+MCP_URL = "https://mcp.alphai.io/mcp"
+
+st.set_page_config(page_title="📈 Financial News MCP Agent", page_icon="📈", layout="wide")
+
+st.markdown("<h1 class='main-header'>📈 Financial News MCP Agent</h1>", unsafe_allow_html=True)
+st.markdown(
+    "Ask for market-moving news in plain English. Powered by the "
+    "[AlphaAI](https://alphai.io) MCP server — every article is pre-scored for "
+    "per-ticker relevance (1-10) and category, with SEC Form 4 insider filings as "
+    "structured data — all via the Model Context Protocol."
+)
+
+with st.sidebar:
+    st.header("🔑 Authentication")
+
+    openai_key = st.text_input(
+        "OpenAI API Key",
+        type="password",
+        help="Required for the AI agent to interpret queries and format results",
+    )
+    if openai_key:
+        os.environ["OPENAI_API_KEY"] = openai_key
+
+    st.markdown("---")
+    st.markdown("### 🔗 AlphaAI MCP server")
+    st.caption(
+        "No key to paste. On the first query a browser tab opens for AlphaAI "
+        "OAuth — sign in or create a **free** account (no credit card). "
+        "`mcp-remote` caches the token, so later runs skip the prompt."
+    )
+    st.markdown(
+        "Free tier: **20 requests/min · 100/day**. "
+        "Get an account at [alphai.io](https://alphai.io) · "
+        "[MCP docs](https://alphai.io/mcp)"
+    )
+
+    st.markdown("---")
+    st.markdown("### 💡 Example Queries")
+    st.markdown("- What's the latest news on NVDA?")
+    st.markdown("- Show me today's top trending market stories")
+    st.markdown("- Any recent SEC Form 4 insider buying in energy names?")
+    st.markdown("- Summarize high-relevance news about Tesla this week")
+
+    st.markdown("---")
+    st.caption("Tip: mention a ticker (e.g. AAPL, MSFT) for the sharpest results.")
+
+query = st.text_area(
+    "Your Query",
+    value="What are the most relevant news stories on NVDA right now?",
+    placeholder="What would you like to know about the market?",
+)
+
+
+async def run_financial_news_agent(message: str) -> str:
+    if not os.getenv("OPENAI_API_KEY"):
+        return "Error: OpenAI API key not provided"
+
+    # `mcp-remote` (npx) bridges the remote OAuth-protected MCP server to a local
+    # stdio transport and handles the OAuth 2.1 flow on first connect.
+    server_params = StdioServerParameters(
+        command="npx",
+        args=["-y", "mcp-remote", MCP_URL],
+        env={**os.environ},
+    )
+
+    try:
+        async with MCPTools(server_params=server_params) as mcp_tools:
+            agent = Agent(
+                tools=[mcp_tools],
+                instructions=dedent("""\
+                    You are a financial-news analyst assistant backed by the AlphaAI MCP server.
+                    - Use the AlphaAI tools to fetch relevance-scored, ticker-linked news.
+                    - Lead with the highest-relevance stories; mention the 1-10 relevance score.
+                    - Group by ticker or category when it aids clarity.
+                    - For insider questions, use the SEC Form 4 tools and report direction, role, and value.
+                    - Be concise and factual; use markdown, and tables for numeric data.
+                    - Do not invent tickers, prices, or figures beyond what the tools return.
+                """),
+                markdown=True,
+            )
+            response: RunOutput = await asyncio.wait_for(agent.arun(message), timeout=180.0)
+            return response.content
+
+    except asyncio.TimeoutError:
+        return "Error: Request timed out after 180 seconds"
+    except Exception as e:
+        return f"Error: {str(e)}"
+
+
+if st.button("🚀 Run Query", type="primary", use_container_width=True):
+    if not openai_key:
+        st.error("Please enter your OpenAI API key in the sidebar")
+    elif not query:
+        st.error("Please enter a query")
+    else:
+        with st.spinner("Fetching and analyzing financial news via the AlphaAI MCP server..."):
+            result = asyncio.run(run_financial_news_agent(query))
+
+        st.markdown("### Results")
+        st.markdown(result)
+
+if "result" not in locals():
+    st.markdown(
+        """<div class='info-box'>
+        <h4>How to use this app:</h4>
+        <ol>
+            <li>Enter your <strong>OpenAI API key</strong> in the sidebar (powers the AI agent)</li>
+            <li>Make sure <strong>Node.js</strong> is installed (needed for <code>npx mcp-remote</code>)</li>
+            <li>Type a question about the market, or pick an example query</li>
+            <li>Click 'Run Query' — on the first run a browser tab opens for AlphaAI OAuth (free account, no card)</li>
+        </ol>
+        <p><strong>How it works:</strong></p>
+        <ul>
+            <li>Connects to AlphaAI's hosted <strong>MCP server</strong> (Streamable HTTP + OAuth 2.1) via <code>mcp-remote</code></li>
+            <li>The AI agent (OpenAI) interprets your query and calls the right AlphaAI tools — news search, trending, per-ticker feeds, SEC Form 4 insider news</li>
+            <li>Every article is pre-analyzed at ingest with a 1-10 relevance score, a category, and per-ticker impact</li>
+            <li>Results come back as readable markdown with the relevance signal surfaced</li>
+        </ul>
+        </div>""",
+        unsafe_allow_html=True,
+    )

--- a/mcp_ai_agents/financial_news_agent/requirements.txt
+++ b/mcp_ai_agents/financial_news_agent/requirements.txt
@@ -1,0 +1,4 @@
+streamlit>=1.28.0
+agno>=2.2.10
+mcp>=0.1.0
+openai>=1.0.0


### PR DESCRIPTION
Adds a new app under **MCP AI Agents**: a Streamlit + Agno agent that answers natural-language market questions through the **AlphaAI MCP server** (Model Context Protocol).

### What it does
- Connects to AlphaAI's hosted MCP server (Streamable HTTP + OAuth 2.1) via `mcp-remote` — the same stdio-bridge pattern as the other MCP agents here.
- The Agno agent (OpenAI) calls AlphaAI's tools: news search, trending, per-ticker feeds, single-article fetch, ticker discovery, and SEC Form 4 insider news.
- Every article is pre-scored at ingest with a 1–10 relevance score, a category, and per-ticker impact.

### Why it fits
- Same stack as the existing MCP agents (`streamlit`, `agno`, `mcp`, `openai`); 3-file layout (`financial_news_agent.py`, `requirements.txt`, `README.md`).
- Real **free tier** (20 req/min · 100/day, no credit card) — the OAuth step creates a free account, so it's runnable by anyone.

### Files
- `mcp_ai_agents/financial_news_agent/` (new)
- README index entry under *MCP AI Agents*

Docs: https://alphai.io/mcp