### PR TITLE
feat: add Rolecraft to Awesome Agent Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,6 +252,7 @@ streamlit run travel_agent.py
 *Ready-to-use agent skill files you can plug into any AI agent or LLM workflow.*
 
 *   [♾️ Self-Improving Agent Skills](awesome_agent_skills/self-improving-agent-skills/) - Automatically optimize agent skills using Gemini and ADK
+*   [🛠️ Rolecraft](https://github.com/sametcelikbicak/rolecraft) - Zero-dependency CLI tool for managing SKILL.md files for 66+ AI coding agents
 
 <details>
 <summary><strong>📋 Browse all 19 skills</strong></summary>


### PR DESCRIPTION
Add [Rolecraft](https://github.com/sametcelikbicak/rolecraft) — zero-dependency CLI tool for managing SKILL.md files for 66+ AI coding agents. Works with opencode, claude-code, cursor, and all spec-compliant agents.