### PR TITLE
Add flik2002/openclaw-monitor - free open-source monitoring dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ streamlit run travel_agent.py
 *   [🎧 AI Social Media News and Podcast Agent](advanced_ai_agents/multi_agent_apps/ai_news_and_podcast_agents/)
 *   [🌐 Openwork - Open Browser Automation Agent](https://github.com/accomplish-ai/openwork) <sub>↗ external</sub>
 *   [🛡️ Trust-Gated Multi-Agent Research Team](advanced_ai_agents/multi_agent_apps/trust_gated_agent_team/)
+*   [📊 OpenClaw Monitor - Token Usage & Session Tracking Dashboard](https://github.com/flik2002/openclaw-monitor) <sub>↗ external</sub>
 
 ### 🎮 Autonomous Game-Playing Agents
 *Agents that play games end-to-end - reasoning, strategy, and action.*

--- a/README.md
+++ b/README.md
@@ -34,6 +34,9 @@
 <p><strong>100+ AI Agent & RAG apps you can actually run — clone, customize, ship.</strong><br/>
 AI Agents · Multi-agent Teams · MCP Agents · RAG · Voice Agents · Agent Skills · Fine-tuning</p>
 
+- [flik2002/openclaw-monitor](https://github.com/flik2002/openclaw-monitor) ![GitHub Repo stars](https://img.shields.io/github/stars/flik2002/openclaw-monitor?style=social) - Free open-source monitoring dashboard for OpenClaw AI agents — token usage, session tracking, 7-day trends, multi-model support. Vue 3 + ECharts.
+
+
 <p>
 <strong>Free step-by-step tutorials on <a href="https://www.theunwindai.com">Unwind AI</a></strong><br/>
 <strong>Works with Claude · Gemini · OpenAI · xAI · Qwen · Llama</strong>


### PR DESCRIPTION
## flik2002/openclaw-monitor

> Free open-source monitoring dashboard for OpenClaw AI agents — token usage, session tracking, 7-day trends, multi-model support. Vue 3 + ECharts.

### Resources
- 🌐 Live Demo: https://flik2002.github.io/openclaw-monitor/
- 📦 GitHub: https://github.com/flik2002/openclaw-monitor
- 📷 Screenshot: https://raw.githubusercontent.com/flik2002/openclaw-monitor/main/Openclaw%20Monitor.jpg

### Why This Fits
OpenClaw Monitor is a free, self-hosted dashboard for monitoring OpenClaw AI agents — tracking token usage, session activity, 7-day trends, and multi-model support. Built with Vue 3 + ECharts.
