### PR TITLE
fix: guard against empty choices and None message in memory tutorial apps

### DIFF
--- a/advanced_llm_apps/llm_apps_with_memory_tutorials/ai_arxiv_agent_memory/ai_arxiv_agent_memory.py
+++ b/advanced_llm_apps/llm_apps_with_memory_tutorials/ai_arxiv_agent_memory/ai_arxiv_agent_memory.py
@@ -47,6 +47,8 @@ if all(api_keys.values()):
         Output Format: Table with the following columns: [{{"title": "Paper Title", "authors": "Author Names", "abstract": "Brief abstract", "link": "arXiv link"}}, ...]
         """
         response = openai_client.chat.completions.create(model="gpt-4o-mini", messages=[{"role": "user", "content": prompt}], temperature=0.2)
+        if not response.choices or response.choices[0].message.content is None:
+            raise ValueError("Received empty or null response from OpenAI API")
         return response.choices[0].message.content
 
     if st.button('Search for Papers'):

--- a/advanced_llm_apps/llm_apps_with_memory_tutorials/ai_travel_agent_memory/travel_agent_memory.py
+++ b/advanced_llm_apps/llm_apps_with_memory_tutorials/ai_travel_agent_memory/travel_agent_memory.py
@@ -85,6 +85,8 @@ if openai_api_key:
                 {"role": "user", "content": full_prompt}
             ]
         )
+        if not response.choices or response.choices[0].message.content is None:
+            raise ValueError("Received empty or null response from OpenAI API")
         answer = response.choices[0].message.content
 
         # Add assistant response to chat history

--- a/advanced_llm_apps/llm_apps_with_memory_tutorials/llm_app_personalized_memory/llm_app_memory.py
+++ b/advanced_llm_apps/llm_apps_with_memory_tutorials/llm_app_personalized_memory/llm_app_memory.py
@@ -51,7 +51,9 @@ if openai_api_key:
                     {"role": "user", "content": full_prompt}
                 ]
             )
-            
+
+            if not response.choices or response.choices[0].message.content is None:
+                raise ValueError("Received empty or null response from OpenAI API")
             answer = response.choices[0].message.content
 
             st.write("Answer: ", answer)

--- a/advanced_llm_apps/llm_apps_with_memory_tutorials/multi_llm_memory/multi_llm_memory.py
+++ b/advanced_llm_apps/llm_apps_with_memory_tutorials/multi_llm_memory/multi_llm_memory.py
@@ -65,6 +65,8 @@ if openai_api_key and anthropic_api_key:
                         {"role": "user", "content": full_prompt}
                     ]
                 )
+                if not response.choices or response.choices[0].message.content is None:
+                    raise ValueError("Received empty or null response from OpenAI API")
                 answer = response.choices[0].message.content
             elif llm_choice == 'Claude Sonnet 3.5':
                 messages=[
@@ -72,6 +74,8 @@ if openai_api_key and anthropic_api_key:
                         {"role": "user", "content": full_prompt}
                     ]
                 response = completion(model="claude-3-5-sonnet-20240620", messages=messages)
+                if not response.choices or response.choices[0].message.content is None:
+                    raise ValueError("Received empty or null response from Claude API")
                 answer = response.choices[0].message.content
             st.write("Answer: ", answer)
 


### PR DESCRIPTION
## Summary
- Four apps in `advanced_llm_apps/llm_apps_with_memory_tutorials/` accessed `response.choices[0].message.content` without checking that `choices` is non-empty or that `content` is not `None`.
- This can cause an `IndexError` when the API returns an empty `choices` list (content filter, quota exceeded, or transient error), or silently pass `None` into downstream memory/UI code.
- Applies the same guard pattern used in #820 (merged) for the same class of bug in DeepSeek API calls.

## Files changed
- `ai_arxiv_agent_memory/ai_arxiv_agent_memory.py`
- `ai_travel_agent_memory/travel_agent_memory.py`
- `llm_app_personalized_memory/llm_app_memory.py`
- `multi_llm_memory/multi_llm_memory.py` (both the OpenAI and Claude branches)

## Test plan
- [x] `python -m py_compile` passes on all 4 modified files
- [ ] Manual smoke test of each Streamlit app with a valid API key (not run in this environment — no API keys available)

🤖 Generated with [Claude Code](https://claude.com/claude-code)