### PR TITLE
CI: three named checks for skills PRs (evals · lint · security scan)

### DIFF
--- a/.github/workflows/skill-evals.yml
+++ b/.github/workflows/skill-evals.yml
@@ -65,3 +65,14 @@ jobs:
           python-version: "3.11"
       - name: Scan all skills for supply-chain and injection patterns
         run: python3 awesome_agent_skills/evals/tools/skill_scanner.py awesome_agent_skills
+
+  trigger-routing:
+    name: trigger & routing
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Positives must clear near-misses on description vocabulary
+        run: python3 awesome_agent_skills/evals/tools/run_trigger_evals.py

--- a/.github/workflows/skill-evals.yml
+++ b/.github/workflows/skill-evals.yml
@@ -10,7 +10,8 @@ on:
       - "awesome_agent_skills/**"
 
 jobs:
-  deterministic-tier:
+  evals:
+    name: deterministic evals
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -32,3 +33,35 @@ jobs:
             python3 "$t"
           done
           [ "$found" = "1" ] || { echo "no evals found"; exit 1; }
+
+  lint:
+    name: skill lint (strict)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Lint every skill against the SKILL.md spec
+        run: |
+          set -e
+          found=0
+          for s in awesome_agent_skills/*/SKILL.md; do
+            [ -e "$s" ] || continue
+            found=1
+            d=$(dirname "$s")
+            echo "== $d"
+            python3 awesome_agent_skills/evals/tools/skill_lint.py "$d" --strict
+          done
+          [ "$found" = "1" ] || { echo "no skills found"; exit 1; }
+
+  security-scan:
+    name: security scan
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Scan all skills for supply-chain and injection patterns
+        run: python3 awesome_agent_skills/evals/tools/skill_scanner.py awesome_agent_skills

--- a/awesome_agent_skills/evals/README.md
+++ b/awesome_agent_skills/evals/README.md
@@ -5,32 +5,36 @@ every change after. Layout: one folder per skill, `evals/<skill-name>/`,
 mirroring the skill's name. These files never ship in an install; the skill
 folders contain only what runs at runtime.
 
-Two tiers (vocabulary borrowed from
-[addyosmani/agent-skills](https://github.com/addyosmani/agent-skills/tree/main/evals),
-which formalized the pattern):
+The tier model follows
+[addyosmani/agent-skills](https://github.com/addyosmani/agent-skills/tree/main/evals)
+— same names, same jobs — plus two tiers of our own, because skills here ship
+executable code and his don't:
 
 | Tier | What it checks | Runs | Cost |
 |---|---|---|---|
-| 0. Structural | Every SKILL.md obeys the spec: frontmatter rules, name==dir, no unfilled placeholders, no text-only prompt dumps (`tools/skill_lint.py --strict`) | CI on every PR | Free, ~1s |
-| 0b. Security | No install lures, undeclared network calls, credential access, or obfuscated payloads in any skill (`tools/skill_scanner.py`) | CI on every PR | Free, ~1s |
-| 1. Deterministic | The skill's scripts do what they claim — every classifier, edge case, and output shape, asserted against synthetic fixtures | CI on every PR, and by hand before installing | Free, ~10s |
-| 2. Trigger | The skill activates on the prompts it should and stays quiet on near-misses | By hand, in an agent session (needs a model) | Tokens |
-
-The tier 0 tools live in [`tools/`](tools/) — repo-side quality tooling, not
-installable skills.
+| 1. Structural | Frontmatter, naming, name==dir, unfilled placeholders, text-only prompt dumps (`tools/skill_lint.py --strict`) | CI | Free |
+| 1b. Security *(ours)* | Install lures, undeclared network calls, credential access, obfuscated payloads (`tools/skill_scanner.py`) | CI | Free |
+| 2. Trigger & routing | Positive prompts clear near-miss negatives on description vocabulary; with 2+ skills, positives rank their own skill first and no two descriptions near-collide (`tools/run_trigger_evals.py`) | CI | Free |
+| 2b. Deterministic scripts *(ours)* | The skill's bundled scripts do what they claim — every classifier, edge case, and output shape against synthetic fixtures (`<skill>/test_*.py`) | CI | Free, ~10s |
+| 3. Behavioral | An agent following the skill satisfies its `expectations[]` — `evals.json` uses [skill-creator's schema](https://github.com/anthropics/skills/tree/main/skills/skill-creator) verbatim, so its `run_eval.py`, benchmarking, and eval viewer work against our files unmodified | On demand | Tokens |
 
 ## Running
 
 ```bash
-# Tier 1 — deterministic, no dependencies beyond git + Python
+# Tiers 1–2b, exactly what CI runs — deterministic, git + Python only
+python3 awesome_agent_skills/evals/tools/skill_lint.py awesome_agent_skills/project-graveyard --strict
+python3 awesome_agent_skills/evals/tools/skill_scanner.py awesome_agent_skills
+python3 awesome_agent_skills/evals/tools/run_trigger_evals.py
 python3 awesome_agent_skills/evals/project-graveyard/test_graveyard.py
 ```
 
-Tier 2 is a manual protocol for now: each skill's `trigger-cases.json` lists
-the prompts that must activate it (and the near-misses that must not). Install
-the skill in a fresh agent session, paste each prompt, check activation
-matches `should_trigger`. Re-run whenever a skill's `description` changes —
-that field is the entire trigger surface.
+Tier 3 is on demand and spends tokens: each skill's `evals.json` is in
+skill-creator's schema, so run it with Anthropic's own tooling (install the
+skill-creator plugin and point `run_eval.py` at the file), or by hand — fresh
+agent session, paste each prompt, grade against `expectations[]`. Cases marked
+`lexical: false` in `trigger-cases.json` (reasoning-triggered, e.g. necromancer
+mode) are only covered here. Re-run tier 3 whenever `SKILL.md` behavior
+changes; re-run tier 2 whenever a `description` changes.
 
 ## Track record
 

--- a/awesome_agent_skills/evals/README.md
+++ b/awesome_agent_skills/evals/README.md
@@ -11,8 +11,13 @@ which formalized the pattern):
 
 | Tier | What it checks | Runs | Cost |
 |---|---|---|---|
+| 0. Structural | Every SKILL.md obeys the spec: frontmatter rules, name==dir, no unfilled placeholders, no text-only prompt dumps (`tools/skill_lint.py --strict`) | CI on every PR | Free, ~1s |
+| 0b. Security | No install lures, undeclared network calls, credential access, or obfuscated payloads in any skill (`tools/skill_scanner.py`) | CI on every PR | Free, ~1s |
 | 1. Deterministic | The skill's scripts do what they claim — every classifier, edge case, and output shape, asserted against synthetic fixtures | CI on every PR, and by hand before installing | Free, ~10s |
 | 2. Trigger | The skill activates on the prompts it should and stays quiet on near-misses | By hand, in an agent session (needs a model) | Tokens |
+
+The tier 0 tools live in [`tools/`](tools/) — repo-side quality tooling, not
+installable skills.
 
 ## Running
 

--- a/awesome_agent_skills/evals/project-graveyard/evals.json
+++ b/awesome_agent_skills/evals/project-graveyard/evals.json
@@ -1,0 +1,48 @@
+{
+  "skill_name": "project-graveyard",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "run the graveyard on my machine, my projects are in ~/dev and ~/hacks",
+      "expected_output": "A tombstone report over ~/dev and ~/hacks with census, causes of death, patterns, and exactly one resurrection pick.",
+      "expectations": [
+        "The skill ran scripts/graveyard.py with the user-provided roots and no others",
+        "The report includes a census, per-corpse causes with evidence, and a patterns section",
+        "Exactly one project is proposed for resurrection, with a plan of at most 7 steps ending at shipped",
+        "The agent offered to start step 1 in the current session"
+      ]
+    },
+    {
+      "id": 2,
+      "prompt": "I have like 30 half-finished side projects and it's honestly depressing. why do I never finish anything?",
+      "expected_output": "A scan followed by a patterns-led answer (death timing, shiny-object chains), empathetic but evidence-based, with one resurrection offer.",
+      "expectations": [
+        "The agent asked where projects live (or confirmed roots) before scanning broadly",
+        "The answer leads with measured patterns, not generic productivity advice",
+        "No shaming language; epitaphs punch at the pattern, not the person",
+        "One resurrection candidate offered, not a list"
+      ]
+    },
+    {
+      "id": 3,
+      "prompt": "of all my old abandoned repos, which one is actually worth finishing?",
+      "expected_output": "Pulse-ranked recommendation of a single project, justified by evidence and a world-check.",
+      "expectations": [
+        "The skill used the pulse ranking from the scanner rather than guessing",
+        "The agent read the top candidate's README/code before recommending",
+        "The recommendation cites what got easier since the project died (world-check)",
+        "Exactly one project is recommended"
+      ]
+    },
+    {
+      "id": 4,
+      "prompt": "I want to build a newsletter analytics dashboard this weekend, can you scaffold it?",
+      "expected_output": "Before scaffolding, the agent checks the graveyard for a prior attempt at the same idea and mentions it once if found; never blocks the new project.",
+      "expectations": [
+        "The graveyard (state file or fresh scan) was consulted before any scaffolding",
+        "If a prior attempt exists, it is mentioned exactly once with its state and a resurrect-or-restart choice",
+        "The user's new project is not blocked or argued against"
+      ]
+    }
+  ]
+}

--- a/awesome_agent_skills/evals/project-graveyard/trigger-cases.json
+++ b/awesome_agent_skills/evals/project-graveyard/trigger-cases.json
@@ -1,6 +1,6 @@
 {
   "skill": "project-graveyard",
-  "purpose": "Trigger-behavior spec — the half of testing that needs an agent. If you change the SKILL.md description, install the skill in a fresh session, paste each prompt, and check activation matches should_trigger. The other half is executable: `python3 test_graveyard.py` (this directory) builds a synthetic graveyard and asserts every classifier, redaction, state, and relapse detection deterministically.",
+  "purpose": "Trigger-behavior spec, two consumers: (1) CI runs tools/run_trigger_evals.py against these cases lexically \u2014 positives must clear near-misses on description vocabulary alone; (2) after any description change, also verify by hand in a fresh agent session. Cases with lexical:false trigger via reasoning, not vocabulary, and are covered by the behavioral tier (evals.json).",
   "cases": [
     {
       "id": "direct-invocation",
@@ -24,7 +24,8 @@
       "id": "necromancer-mode",
       "prompt": "I want to build a newsletter analytics dashboard this weekend, can you scaffold it?",
       "should_trigger": true,
-      "assert": "Before scaffolding, checks the graveyard for prior attempts at the same idea; if found, mentions it once and lets the user choose; never blocks the new project."
+      "assert": "Before scaffolding, checks the graveyard for prior attempts at the same idea; if found, mentions it once and lets the user choose; never blocks the new project.",
+      "lexical": false
     },
     {
       "id": "near-miss-disk-cleanup",

--- a/awesome_agent_skills/evals/tools/run_trigger_evals.py
+++ b/awesome_agent_skills/evals/tools/run_trigger_evals.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+"""
+Tier 2 — trigger & routing. Deterministic, CI-safe, no model.
+
+Pattern from addyosmani/agent-skills (evals/README.md there): a skill's
+description is its entire trigger surface, so check it lexically —
+positive prompts must score against their skill's description clearly
+above the near-miss negatives, and (once the catalog has 2+ skills) must
+rank their own skill first, with no two descriptions near-colliding.
+
+This is a lexical approximation of routing. It cannot judge semantics —
+that's the behavioral tier's job — but it catches the two failure modes
+that dominate real trigger bugs: a description missing the vocabulary
+users actually say, and an over-broad description that outranks the
+right skill. A failure here usually means *fix the description*.
+
+Cases live in evals/<skill>/trigger-cases.json. A case marked
+"lexical": false is skipped here (it triggers via reasoning, e.g.
+necromancer mode, not via description vocabulary) and is covered by the
+behavioral tier instead.
+
+    python3 run_trigger_evals.py            # checks every skill in the catalog
+"""
+
+import json
+import math
+import os
+import re
+import sys
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+SKILLS_ROOT = os.path.abspath(os.path.join(HERE, "..", ".."))
+EVALS_ROOT = os.path.abspath(os.path.join(HERE, ".."))
+
+STOP = set("""a an the and or of to in on for with is are was were be been it its this
+that those these you your i me my we our they their he she his her do does did done
+can could should would will just very really some any all not no yes if then than as
+at by from into out up down over under again more most other own same so too s t don
+""".split())
+
+MARGIN = 1.15  # min positive score must beat max negative score by this factor
+
+
+def tokens(text):
+    out = set()
+    for w in re.findall(r"[a-z0-9']+", text.lower()):
+        if w in STOP or len(w) < 3:
+            continue
+        # crude stemmer: enough to match "projects/project", "finished/finish"
+        for suf in ("ing", "ed", "es", "s"):
+            if w.endswith(suf) and len(w) - len(suf) >= 3:
+                w = w[: -len(suf)]
+                break
+        out.add(w)
+    return out
+
+
+def description_of(skill_dir):
+    text = open(os.path.join(skill_dir, "SKILL.md")).read()
+    m = re.search(r"^description:\s*(.+?)^(?=[a-zA-Z-]+:|---)", text, re.S | re.M)
+    return m.group(1) if m else ""
+
+
+def score(prompt_toks, desc_toks):
+    if not prompt_toks:
+        return 0.0
+    return len(prompt_toks & desc_toks) / math.sqrt(len(prompt_toks))
+
+
+def main():
+    skills = {}  # name -> description tokens
+    for entry in sorted(os.listdir(SKILLS_ROOT)):
+        if os.path.exists(os.path.join(SKILLS_ROOT, entry, "SKILL.md")):
+            skills[entry] = tokens(description_of(os.path.join(SKILLS_ROOT, entry)))
+    if not skills:
+        print("no skills found under %s" % SKILLS_ROOT)
+        return 1
+
+    failures = 0
+
+    # routing sanity across the catalog: no two descriptions near-collide
+    names = sorted(skills)
+    for i in range(len(names)):
+        for j in range(i + 1, len(names)):
+            a, b = skills[names[i]], skills[names[j]]
+            overlap = len(a & b) / max(1, min(len(a), len(b)))
+            if overlap > 0.5:
+                print("FAIL  descriptions near-collide: %s vs %s (%.0f%% shared vocabulary)"
+                      % (names[i], names[j], overlap * 100))
+                failures += 1
+
+    for name in names:
+        case_file = os.path.join(EVALS_ROOT, name, "trigger-cases.json")
+        if not os.path.exists(case_file):
+            print("WARN  %s has no trigger-cases.json — add one" % name)
+            continue
+        cases = json.load(open(case_file))["cases"]
+        pos, neg = [], []
+        for c in cases:
+            if c.get("lexical") is False:
+                continue
+            s = score(tokens(c["prompt"]), skills[name])
+            (pos if c["should_trigger"] else neg).append((s, c["id"]))
+            # routing: with 2+ skills, a positive must rank its own skill first
+            if c["should_trigger"] and len(skills) > 1:
+                best = max(skills, key=lambda k: score(tokens(c["prompt"]), skills[k]))
+                if best != name:
+                    print("FAIL  %s: %r routes to %s instead" % (name, c["id"], best))
+                    failures += 1
+        if pos and neg:
+            worst_pos, wp_id = min(pos)
+            best_neg, bn_id = max(neg)
+            if worst_pos <= best_neg * MARGIN:
+                print("FAIL  %s: weakest positive %r (%.2f) does not clear strongest "
+                      "near-miss %r (%.2f) — the description is missing vocabulary "
+                      "users say, or a negative shares too much of it"
+                      % (name, wp_id, worst_pos, bn_id, best_neg))
+                failures += 1
+            else:
+                print("PASS  %s: %d positives clear %d near-misses "
+                      "(weakest %.2f vs strongest %.2f)"
+                      % (name, len(pos), len(neg), worst_pos, best_neg))
+
+    if failures:
+        print("\n%d failure(s)" % failures)
+        return 1
+    print("\ntrigger & routing: all clear (%d skill%s)" % (len(skills), "" if len(skills) == 1 else "s"))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/awesome_agent_skills/evals/tools/skill_lint.py
+++ b/awesome_agent_skills/evals/tools/skill_lint.py
@@ -1,0 +1,382 @@
+#!/usr/bin/env python3
+"""skill_lint.py — validate an agent skill directory against the agentskills.io spec.
+
+Usage:
+    python3 skill_lint.py <skill-dir> [--strict] [--json]
+
+Checks (spec: https://agentskills.io/specification, verified July 2026):
+  * SKILL.md exists and has parseable YAML frontmatter
+  * name: 1-64 chars, lowercase a-z/0-9/hyphens, no leading/trailing/consecutive
+    hyphens, must equal the directory name
+  * description: present, 1-1024 chars, plus triggering heuristics
+  * compatibility: <= 500 chars if present
+  * body: warn at 400 lines, 500+ lines is a warning (error with --strict);
+    ~5k-token budget warning
+  * relative file references in the body must exist on disk
+  * forward-slash paths only (backslash paths are an error)
+  * TODO/FIXME-style markers are warnings
+  * text-only skills (no scripts/ AND no references/) are warned — the
+    awesome-llm-apps quality bar expects bundled tools and references
+
+Exit codes: 0 = no errors (warnings allowed), 1 = errors found, 2 = usage error.
+Python 3 stdlib only — no third-party dependencies (frontmatter parsing is
+hand-rolled for the flat fields the spec defines; pyyaml is NOT required).
+"""
+
+import argparse
+import json
+import os
+import re
+import sys
+
+NAME_RE = re.compile(r"^[a-z0-9]+(?:-[a-z0-9]+)*$")
+MAX_NAME = 64
+MAX_DESC = 1024
+MAX_COMPAT = 500
+BODY_WARN_LINES = 400
+BODY_MAX_LINES = 500
+BODY_TOKEN_BUDGET = 5000
+
+KNOWN_KEYS = {"name", "description", "license", "compatibility", "metadata", "allowed-tools"}
+
+WHEN_SIGNALS = re.compile(
+    r"\b(use (this skill )?when|use (it |this )?for|when the user|when working"
+    r"|use to|triggers? (on|when)|applies (when|to)|for tasks)\b",
+    re.IGNORECASE,
+)
+FIRST_PERSON = re.compile(r"\b(I|I'll|I'm|I've|me|my|we|our|you should|you can)\b")
+QUOTED_SPAN = re.compile(r"\"[^\"\n]*\"|'[^'\n]*'|“[^”\n]*”")
+FENCED_BLOCK = re.compile(r"^```.*?^```", re.MULTILINE | re.DOTALL)
+INLINE_CODE = re.compile(r"`[^`\n]+`")
+# Unfilled template placeholders are multi-word angle-bracket spans in prose
+# (e.g. "<what this skill does>"). Single-word forms like <path> are normal
+# CLI-usage notation and HTML tags never contain multi-word lowercase text.
+TEMPLATE_PLACEHOLDER = re.compile(r"<([a-z][a-z0-9'’,—-]*(?: [a-z0-9'’,—.…-]+)+[^>]*)>")
+TODO_MARKER = re.compile(r"\b(TODO|FIXME|XXX|TBD)\b")
+MD_LINK = re.compile(r"\]\(([^)\s#]+)\)")
+BARE_PATH = re.compile(r"\b((?:scripts|references|assets|evals)/[\w.\-/]+)")
+BACKSLASH_PATH = re.compile(r"(?:scripts|references|assets|evals)\\")
+
+
+def unquote(value):
+    value = value.strip()
+    if len(value) >= 2 and value[0] == value[-1] and value[0] in ("'", '"'):
+        return value[1:-1]
+    return value
+
+
+def parse_frontmatter(text):
+    """Minimal YAML parser for the flat frontmatter the spec defines.
+
+    Supports: `key: value`, quoted values, block scalars (| and >), one-level
+    nested maps (for `metadata:`), and inline flow maps (`{a: b, c: d}`).
+    Returns (data, body, error). data is None on a parse error.
+    """
+    lines = text.splitlines()
+    if not lines or lines[0].strip() != "---":
+        return None, text, "SKILL.md must begin with a '---' YAML frontmatter block on line 1"
+    end = None
+    for i in range(1, len(lines)):
+        if lines[i].strip() in ("---", "..."):
+            end = i
+            break
+    if end is None:
+        return None, text, "frontmatter is never closed: add a '---' line after the YAML block"
+
+    fm_lines = lines[1:end]
+    body = "\n".join(lines[end + 1:])
+    data = {}
+    i = 0
+    while i < len(fm_lines):
+        raw = fm_lines[i]
+        stripped = raw.strip()
+        if not stripped or stripped.startswith("#"):
+            i += 1
+            continue
+        if raw[:1] in (" ", "\t"):
+            return None, body, (
+                "unexpected indentation at frontmatter line %d (%r): top-level keys "
+                "must start at column 0" % (i + 2, stripped)
+            )
+        if ":" not in raw:
+            return None, body, "cannot parse frontmatter line %d: %r (expected 'key: value')" % (i + 2, stripped)
+        key, _, val = raw.partition(":")
+        key = key.strip()
+        val = val.strip()
+
+        if val in ("|", ">", "|-", ">-", "|+", ">+"):  # block scalar
+            block = []
+            i += 1
+            while i < len(fm_lines) and (fm_lines[i][:1] in (" ", "\t") or not fm_lines[i].strip()):
+                block.append(fm_lines[i].strip())
+                i += 1
+            joiner = " " if val.startswith(">") else "\n"
+            data[key] = joiner.join(b for b in block if b)
+            continue
+
+        if val == "":  # nested one-level map (e.g. metadata:)
+            nested = {}
+            i += 1
+            while i < len(fm_lines) and (fm_lines[i][:1] in (" ", "\t") or not fm_lines[i].strip()):
+                sub = fm_lines[i].strip()
+                if sub and not sub.startswith("#"):
+                    if ":" not in sub:
+                        return None, body, (
+                            "cannot parse nested entry under %r at frontmatter line %d: %r" % (key, i + 2, sub)
+                        )
+                    k2, _, v2 = sub.partition(":")
+                    nested[k2.strip()] = unquote(v2)
+                i += 1
+            data[key] = nested
+            continue
+
+        if val.startswith("{") and val.endswith("}"):  # inline flow map
+            nested = {}
+            inner = val[1:-1].strip()
+            if inner:
+                for part in inner.split(","):
+                    if ":" not in part:
+                        return None, body, "cannot parse inline map for %r: %r" % (key, part.strip())
+                    k2, _, v2 = part.partition(":")
+                    nested[k2.strip()] = unquote(v2)
+            data[key] = nested
+            i += 1
+            continue
+
+        data[key] = unquote(val)
+        i += 1
+    return data, body, None
+
+
+def suggest_name(name):
+    s = str(name).strip().lower()
+    s = re.sub(r"[_\s]+", "-", s)
+    s = re.sub(r"[^a-z0-9-]", "", s)
+    s = re.sub(r"-{2,}", "-", s).strip("-")
+    return s[:MAX_NAME] or "my-skill"
+
+
+def check_name(name, dirname, errors):
+    problems = []
+    if not name:
+        errors.append("frontmatter 'name' is missing or empty (required, 1-%d chars)" % MAX_NAME)
+        return
+    if len(name) > MAX_NAME:
+        problems.append("longer than %d characters" % MAX_NAME)
+    if re.search(r"[A-Z]", name):
+        problems.append("uppercase not allowed")
+    if re.search(r"[_\s]", name):
+        problems.append("underscores/spaces not allowed")
+    if re.search(r"[^a-zA-Z0-9\-_\s]", name):
+        problems.append("only a-z, 0-9 and hyphens are allowed")
+    if name.startswith("-") or name.endswith("-"):
+        problems.append("must not start or end with a hyphen")
+    if "--" in name:
+        problems.append("consecutive hyphens not allowed")
+    if problems or not NAME_RE.match(name):
+        detail = "; ".join(problems) if problems else "does not match ^[a-z0-9]+(-[a-z0-9]+)*$"
+        errors.append("name %r invalid: %s; try %r" % (name, detail, suggest_name(name)))
+        return
+    if name != dirname:
+        errors.append(
+            "name %r must equal the skill directory name %r: rename the directory "
+            "or set 'name: %s'" % (name, dirname, dirname)
+        )
+
+
+def check_description(desc, errors, warnings):
+    if not desc:
+        errors.append(
+            "frontmatter 'description' is missing or empty (required, 1-%d chars); "
+            "state WHAT the skill does and WHEN to use it, with trigger keywords" % MAX_DESC
+        )
+        return
+    if len(desc) > MAX_DESC:
+        errors.append(
+            "description is %d characters (max %d): trim it — a few keyword-rich "
+            "sentences outperform a paragraph dump" % (len(desc), MAX_DESC)
+        )
+    ph = TEMPLATE_PLACEHOLDER.search(desc)
+    if ph:
+        errors.append(
+            "description contains an unfilled template placeholder %r: replace "
+            "every angle-bracket placeholder with specifics before shipping — "
+            "a scaffolded description must never pass as done" % ph.group(0)
+        )
+    if len(desc) < 50:
+        warnings.append(
+            "description is only %d characters — too thin to trigger reliably; add "
+            "what the skill does plus 'Use when …' contexts with the keywords users "
+            "actually type" % len(desc)
+        )
+    # Quoted trigger phrases ("evaluate my agent") legitimately contain
+    # first-person words — strip quoted spans before the voice check.
+    desc_unquoted = QUOTED_SPAN.sub(" ", desc)
+    if FIRST_PERSON.search(desc_unquoted):
+        warnings.append(
+            "description uses first/second-person voice (%r) outside quoted "
+            "trigger phrases: rewrite in third person, e.g. 'Extracts …. Use "
+            "when the user …'"
+            % FIRST_PERSON.search(desc_unquoted).group(0)
+        )
+    if not WHEN_SIGNALS.search(desc):
+        warnings.append(
+            "description never states when to use the skill: add an explicit "
+            "'Use when …' clause with trigger phrases — the description is the "
+            "only text agents see before activation"
+        )
+
+
+def check_body(body, skill_dir, strict, errors, warnings):
+    body_lines = body.splitlines()
+    n = len(body_lines)
+    if n >= BODY_MAX_LINES:
+        msg = (
+            "SKILL.md body is %d lines (spec recommends < %d): move detail into "
+            "references/ files with explicit load conditions" % (n, BODY_MAX_LINES)
+        )
+        (errors if strict else warnings).append(msg)
+    elif n > BODY_WARN_LINES:
+        warnings.append(
+            "SKILL.md body is %d lines (warn threshold %d, spec limit %d): start "
+            "moving reference material out now" % (n, BODY_WARN_LINES, BODY_MAX_LINES)
+        )
+    est_tokens = len(body) // 4
+    if est_tokens > BODY_TOKEN_BUDGET:
+        warnings.append(
+            "SKILL.md body is roughly %d tokens (budget ~%d): every token competes "
+            "with the user's task once the skill activates" % (est_tokens, BODY_TOKEN_BUDGET)
+        )
+
+    if BACKSLASH_PATH.search(body):
+        errors.append(
+            "backslash path found in SKILL.md (e.g. %r): the spec requires relative "
+            "forward-slash paths" % BACKSLASH_PATH.search(body).group(0)
+        )
+
+    for marker in sorted(set(TODO_MARKER.findall(body))):
+        warnings.append("unfinished-work marker %r found in SKILL.md body: resolve or remove it" % marker)
+
+    # Fenced code blocks hold illustrative paths (example scanner reports,
+    # template output) — only prose and links promise real files.
+    prose = FENCED_BLOCK.sub("", body)
+
+    # Unfilled scaffold placeholders in prose mean the skill is not done —
+    # the whole point of "lint until clean" as a workflow gate. Inline code
+    # spans are excluded (`<skill-dir>` CLI notation is legitimate).
+    prose_no_code = INLINE_CODE.sub("", prose)
+    for ph in sorted(set(m.group(0) for m in TEMPLATE_PLACEHOLDER.finditer(prose_no_code)))[:5]:
+        errors.append(
+            "unfilled template placeholder %s in SKILL.md body: replace it "
+            "with real content before shipping" % ph
+        )
+
+    candidates = set(MD_LINK.findall(prose)) | set(BARE_PATH.findall(prose))
+    for cand in sorted(candidates):
+        cand = cand.rstrip(".,:;)`'\"")
+        if not cand or cand.startswith(("http://", "https://", "mailto:", "#", "/")):
+            continue
+        if "\\" in cand:
+            continue  # already reported as a backslash-path error
+        if not os.path.exists(os.path.join(skill_dir, cand)):
+            errors.append(
+                "SKILL.md references %r but no such file exists in the skill "
+                "directory: fix the path or add the file" % cand
+            )
+
+
+def lint(skill_dir, strict=False):
+    errors, warnings = [], []
+    skill_dir = os.path.abspath(skill_dir)
+    dirname = os.path.basename(skill_dir)
+
+    if not os.path.isdir(skill_dir):
+        return ["%s is not a directory" % skill_dir], []
+
+    skill_md = os.path.join(skill_dir, "SKILL.md")
+    if not os.path.isfile(skill_md):
+        errors.append("SKILL.md not found in %s (required at the skill root)" % skill_dir)
+        return errors, warnings
+
+    with open(skill_md, encoding="utf-8") as fh:
+        text = fh.read()
+
+    fm, body, perr = parse_frontmatter(text)
+    if perr:
+        errors.append("frontmatter parse error: %s" % perr)
+        return errors, warnings
+
+    check_name(fm.get("name"), dirname, errors)
+    check_description(fm.get("description"), errors, warnings)
+
+    compat = fm.get("compatibility")
+    if compat is not None:
+        if isinstance(compat, dict):
+            compat = ""  # bare `compatibility:` with no value parses as an empty map
+        if not str(compat).strip():
+            warnings.append("compatibility is present but empty: remove it (most skills need none)")
+        elif len(str(compat)) > MAX_COMPAT:
+            errors.append("compatibility is %d characters (max %d)" % (len(str(compat)), MAX_COMPAT))
+
+    metadata = fm.get("metadata")
+    if metadata is not None and not isinstance(metadata, dict):
+        warnings.append("metadata should be a map of string keys to string values, got a scalar")
+
+    for key in fm:
+        if key not in KNOWN_KEYS:
+            warnings.append(
+                "unknown frontmatter key %r: only %s are defined by the spec; "
+                "custom properties belong under 'metadata'" % (key, ", ".join(sorted(KNOWN_KEYS)))
+            )
+
+    check_body(body, skill_dir, strict, errors, warnings)
+
+    # Any bundled resource directory counts — skills legitimately organize
+    # on-demand material under names other than references/ (e.g. rules/).
+    RESOURCE_DIRS = ("scripts", "references", "assets", "rules", "data",
+                     "agents", "templates", "examples")
+    bundled = [d for d in RESOURCE_DIRS
+               if os.path.isdir(os.path.join(skill_dir, d))]
+    if not bundled:
+        warnings.append(
+            "text-only skill: no bundled resources (looked for %s) — "
+            "production-grade skills ship executable tools or on-demand "
+            "references (the awesome-llm-apps quality bar); if all value "
+            "lives in prose, reconsider whether this should be a skill at all"
+            % "/, ".join(RESOURCE_DIRS)
+        )
+
+    return errors, warnings
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description="Validate an agent skill directory (agentskills.io spec).")
+    parser.add_argument("skill_dir", help="path to the skill directory (the folder containing SKILL.md)")
+    parser.add_argument("--strict", action="store_true", help="promote spec-limit violations (500+ line body) to errors")
+    parser.add_argument("--json", action="store_true", dest="as_json", help="emit machine-readable JSON")
+    args = parser.parse_args(argv)
+
+    errors, warnings = lint(args.skill_dir, strict=args.strict)
+
+    if args.as_json:
+        print(json.dumps({
+            "skill": os.path.abspath(args.skill_dir),
+            "strict": args.strict,
+            "errors": errors,
+            "warnings": warnings,
+            "passed": not errors,
+        }, indent=2))
+    else:
+        print("Linting %s (strict=%s)" % (os.path.abspath(args.skill_dir), "on" if args.strict else "off"))
+        for msg in errors:
+            print("  ERROR: %s" % msg)
+        for msg in warnings:
+            print("  WARN:  %s" % msg)
+        verdict = "PASS" if not errors else "FAIL"
+        print("  %s — %d error(s), %d warning(s)" % (verdict, len(errors), len(warnings)))
+
+    return 1 if errors else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/awesome_agent_skills/evals/tools/skill_lint.py
+++ b/awesome_agent_skills/evals/tools/skill_lint.py
@@ -1,5 +1,8 @@
 #!/usr/bin/env python3
-"""skill_lint.py — validate an agent skill directory against the agentskills.io spec.
+"""
+[vendored] Repo-side CI copy. Origin: the skill-builder skill (revamp branch).
+If a skill-builder skill ever ships on main, make that the single source of truth.
+skill_lint.py — validate an agent skill directory against the agentskills.io spec.
 
 Usage:
     python3 skill_lint.py <skill-dir> [--strict] [--json]
@@ -338,7 +341,7 @@ def lint(skill_dir, strict=False):
     bundled = [d for d in RESOURCE_DIRS
                if os.path.isdir(os.path.join(skill_dir, d))]
     if not bundled:
-        warnings.append(
+        (errors if strict else warnings).append(
             "text-only skill: no bundled resources (looked for %s) — "
             "production-grade skills ship executable tools or on-demand "
             "references (the awesome-llm-apps quality bar); if all value "

--- a/awesome_agent_skills/evals/tools/skill_scanner.py
+++ b/awesome_agent_skills/evals/tools/skill_scanner.py
@@ -1,5 +1,8 @@
 #!/usr/bin/env python3
-"""skill_scanner.py — static security scanner for agent skills.
+"""
+[vendored] Repo-side CI copy. Origin: the agent-security-auditor skill (revamp
+branch). If that skill ever ships on main, make it the single source of truth.
+skill_scanner.py — static security scanner for agent skills.
 
 Scans one skill directory (or a tree of them) for the attack patterns seen in
 real skill supply-chain campaigns (ClawHavoc, Jan 2026) and mapped to the

--- a/awesome_agent_skills/evals/tools/skill_scanner.py
+++ b/awesome_agent_skills/evals/tools/skill_scanner.py
@@ -1,0 +1,420 @@
+#!/usr/bin/env python3
+"""skill_scanner.py — static security scanner for agent skills.
+
+Scans one skill directory (or a tree of them) for the attack patterns seen in
+real skill supply-chain campaigns (ClawHavoc, Jan 2026) and mapped to the
+OWASP Agentic Skills Top 10 (AST01-AST10).
+
+Usage:
+    python3 skill_scanner.py <path-to-skill-or-skills-dir>
+    python3 skill_scanner.py <path> --json
+
+Python 3.8+, stdlib only, makes no network calls, never executes scanned code.
+
+Exit codes: 0 = no CRITICAL findings, 1 = at least one CRITICAL, 2 = usage error.
+
+Lines containing the marker "skillscan" + ":allow" (written as one word with a
+colon) are skipped, so scanners and docs that *describe* attack patterns can
+suppress self-matches.
+"""
+
+import argparse
+import json
+import os
+import re
+import sys
+from pathlib import Path
+
+VERSION = "1.0.0"
+SEV_RANK = {"CRITICAL": 3, "WARN": 2, "INFO": 1}
+SCAN_EXTS = {".md", ".markdown", ".py", ".sh", ".bash", ".zsh", ".js", ".mjs",
+             ".cjs", ".ts", ".ps1", ".rb", ".pl", ".txt", ".yaml", ".yml",
+             ".json", ".toml"}
+SKIP_DIRS = {".git", "node_modules", "__pycache__", ".venv", "venv", ".mypy_cache"}
+MAX_FILE_BYTES = 1_000_000
+SUPPRESS_MARKER = "skillscan" + ":allow"  # built at runtime so this file can be scanned
+
+NETWORK_DECLARE_WORDS = ("network", "internet", "http", "online", "api access", "web access")
+
+# ---------------------------------------------------------------------------
+# Pattern tables. Each entry: (compiled regex, check id, severity, message)
+# ---------------------------------------------------------------------------
+
+PIPE_SHELL_PATTERNS = [
+    (re.compile(r"(?:curl|wget)\b[^\n|]{0,200}\|\s*(?:sudo\s+)?(?:ba|z|da|fi)?sh\b"),  # skillscan:allow
+     "EXEC01", "CRITICAL", "Remote script piped directly into a shell (curl/wget to shell)"),  # skillscan:allow
+    (re.compile(r"(?i)(?:iwr|irm|invoke-webrequest|downloadstring)[^\n]{0,160}\|\s*iex\b"),  # skillscan:allow
+     "EXEC01", "CRITICAL", "PowerShell download piped into Invoke-Expression (iex)"),
+    (re.compile(r"(?i)\biex\b[^\n]{0,160}(?:downloadstring|invoke-webrequest|\biwr\b|\birm\b)"),  # skillscan:allow
+     "EXEC01", "CRITICAL", "Invoke-Expression executing downloaded content"),
+    (re.compile(r"base64\s+(?:-d|-D|--decode)\b[^\n]{0,120}\|\s*(?:sudo\s+)?(?:ba|z)?sh\b"),  # skillscan:allow
+     "EXEC02", "CRITICAL", "base64-decoded data piped into a shell"),
+    (re.compile(r"\|\s*base64\s+(?:-d|-D|--decode)\b[^\n]{0,80}\|\s*(?:python3?|node|perl|ruby)\b"),  # skillscan:allow
+     "EXEC02", "CRITICAL", "base64-decoded data piped into an interpreter"),
+]
+
+OBFUSCATION_EXEC_PATTERNS = [
+    (re.compile(r"(?:\bexec|\beval|\bcompile)\s*\([^\n]{0,160}(?:b64decode|base64|fromhex|codecs\.decode|rot13)"),  # skillscan:allow
+     "OBF02", "CRITICAL", "exec/eval of decoded (base64/hex/rot13) data — classic staged payload"),
+    (re.compile(r"(?:\beval|new\s+Function)\s*\([^\n]{0,160}(?:atob|Buffer\.from)\s*\("),  # skillscan:allow
+     "OBF02", "CRITICAL", "JavaScript eval/Function over decoded data — classic staged payload"),
+    (re.compile(r"(?:python3?|node)\s+-[ce]\s+[^\n]{0,60}(?:b64decode|base64|atob)"),  # skillscan:allow
+     "OBF02", "CRITICAL", "Interpreter one-liner decoding embedded data"),
+]
+
+LONG_B64_RE = re.compile(r"[A-Za-z0-9+/]{120,}={0,2}")
+HEX_ONLY_RE = re.compile(r"^[0-9a-fA-F]+$")
+
+NET_PATTERNS = [
+    (re.compile(r"^\s*(?:import|from)\s+(?:requests|httpx|aiohttp|urllib3?|websockets?|socket|http\b)"),
+     "python network import"),
+    (re.compile(r"\burllib\.request\b|\bhttp\.client\b|\bsocket\.(?:socket|create_connection)\b"),
+     "python network API call"),
+    (re.compile(r"\bfetch\s*\(|\baxios\b|\bXMLHttpRequest\b|new\s+WebSocket\s*\("),
+     "JavaScript network API call"),
+    (re.compile(r"\b(?:curl|wget)\s+(?:-[A-Za-z-]+\s+)*[\"']?https?://"),
+     "curl/wget invocation"),
+    (re.compile(r"\b(?:nc|ncat|netcat)\s+[\w.-]+\s+\d{2,5}\b"),
+     "raw netcat connection"),
+]
+
+CRED_PATTERNS = [
+    (re.compile(r"~/\.ssh\b|/\.ssh/|id_rsa\b|id_ed25519\b"),  # skillscan:allow
+     "CRED01", "CRITICAL", "Reads SSH key material (SSH dir, id_rsa, id_ed25519)"),  # skillscan:allow
+    (re.compile(r"\.aws/credentials|\.aws/config"),  # skillscan:allow
+     "CRED01", "CRITICAL", "Reads AWS credential files"),
+    (re.compile(r"(?i)security\s+(?:find-generic-password|find-internet-password|dump-keychain)"),
+     "CRED01", "CRITICAL", "Queries the macOS keychain from a script"),
+    (re.compile(r"\.netrc\b|\.npmrc\b|\.pypirc\b"),  # skillscan:allow
+     "CRED01", "WARN", "Touches credential-bearing dotfiles (netrc/npmrc/pypirc)"),  # skillscan:allow
+    (re.compile(r"gcloud/(?:credentials|application_default_credentials)"),
+     "CRED01", "WARN", "Reads gcloud credential files"),
+    (re.compile(r"(?i)(?:Login Data|Cookies)['\"]|browser.{0,20}profile.{0,20}(?:passw|cookie)"),  # skillscan:allow
+     "CRED01", "WARN", "References browser credential/cookie stores"),
+    (re.compile(r"(?i)(?:exodus|electrum|phantom|solana)[^\n]{0,40}(?:wallet|keystore|id\.json)"),  # skillscan:allow
+     "CRED01", "WARN", "References cryptocurrency wallet storage"),
+    (re.compile(r"expanduser\([^)\n]{0,60}\.env|\$HOME/[^\s\"']{0,40}\.env\b|~/\.(?:claude|clawdbot|openclaw|config/openai)(?!/(?:skills|plugins)\b)[^\s\"']{0,30}"),
+     "CRED01", "WARN", "Reads agent/home .env or agent config directories"),
+    (re.compile(r"dict\(os\.environ\)|os\.environ\.items\(\)|os\.environ\.copy\(\)"),
+     "CRED02", "WARN", "Enumerates the entire process environment (all env vars at once)"),
+    (re.compile(r"JSON\.stringify\(process\.env\)|Object\.(?:entries|keys)\(process\.env\)"),
+     "CRED02", "WARN", "Serializes the entire process environment"),
+    (re.compile(r"(?<![\w-])printenv\b|\benv\s*\|\s*(?:curl|nc|base64)"),  # skillscan:allow
+     "CRED02", "WARN", "Dumps the process environment in a shell"),
+]
+
+PIN_PATTERNS = [
+    (re.compile(r"\bpip3?\s+install\b(?![^\n#]*(?:==|--require-hashes|-r\s|-e\s|\.\s*$))"),  # skillscan:allow
+     "PIN01", "WARN", "Unpinned pip install — version can drift to a compromised release"),  # skillscan:allow
+    (re.compile(r"\bnpm\s+install\s+(?:-g\s+)?(?!.*@\d)[a-z@][\w@/.-]*\s*$"),
+     "PIN01", "INFO", "Unpinned npm install — prefer exact versions or a lockfile"),
+]
+
+LURE_HEADING_RE = re.compile(
+    r"(?i)^#{1,6}\s.*\b(prerequisite|installation|install|setup|set\s?up|"
+    r"before you begin|getting started|activation|activate|first run|initiali[sz])")
+FETCH_CMD_RE = re.compile(r"(?i)\b(?:curl|wget|iwr|irm|invoke-webrequest)\b[^\n]*https?://")  # skillscan:allow
+LURE_PROSE_RE = re.compile(
+    r"(?i)\b(?:run|execute|paste|copy)\b.{0,60}\b(?:command|script|one-?liner|snippet|installer)\b"
+    r".{0,120}\b(?:initiali[sz]e|activate|unlock|register|verify|before (?:first )?use|to enable|to install|to set ?up)")
+
+NAME_RE = re.compile(r"^[a-z0-9]+(?:-[a-z0-9]+)*$")
+
+
+class Finding:
+    def __init__(self, skill, check, severity, file, line, message, evidence):
+        self.skill, self.check, self.severity = skill, check, severity
+        self.file, self.line, self.message = file, line, message
+        self.evidence = evidence.strip()[:160]
+
+    def as_dict(self):
+        return {"skill": self.skill, "check": self.check, "severity": self.severity,
+                "file": self.file, "line": self.line, "message": self.message,
+                "evidence": self.evidence}
+
+
+def read_text(path):
+    try:
+        with open(path, "r", encoding="utf-8", errors="replace") as fh:
+            return fh.read()
+    except OSError:
+        return None
+
+
+def parse_frontmatter(text):
+    """Minimal YAML-ish frontmatter parser (top-level keys only). Returns dict or None."""
+    m = re.match(r"^---\s*\n(.*?)\n---\s*(?:\n|$)", text, re.S)
+    if not m:
+        return None
+    fm, current = {}, None
+    for line in m.group(1).splitlines():
+        km = re.match(r"^([A-Za-z0-9_-]+):\s*(.*)$", line)
+        if km:
+            current = km.group(1).lower()
+            fm[current] = km.group(2).strip().strip("\"'")
+        elif current is not None and line[:1] in (" ", "\t"):
+            fm[current] = (fm[current] + " " + line.strip()).strip()
+    for key, val in fm.items():
+        if val[:1] in (">", "|"):
+            fm[key] = val[1:].lstrip("-+ ").strip()
+    return fm
+
+
+def discover_skills(root):
+    """Return a list of skill directories (dirs containing SKILL.md)."""
+    root = Path(root)
+    if root.is_file() and root.name == "SKILL.md":
+        return [root.parent]
+    if root.is_dir() and (root / "SKILL.md").is_file():
+        return [root]
+    found = []
+    if root.is_dir():
+        for dirpath, dirs, files in os.walk(root):
+            dirs[:] = sorted(d for d in dirs if d not in SKIP_DIRS)
+            if "SKILL.md" in files:
+                found.append(Path(dirpath))
+                dirs[:] = []  # don't descend into nested skills
+    return found
+
+
+def iter_scan_files(skill_dir, include_fixtures=False):
+    for dirpath, dirs, files in os.walk(skill_dir):
+        dirs[:] = sorted(d for d in dirs if d not in SKIP_DIRS)
+        if not include_fixtures:
+            # A skill's own evals/fixtures/ may hold deliberately malicious test
+            # payloads; scanning them as part of the skill produces false alarms.
+            # Pass --include-fixtures (or target the fixture dir) to scan them.
+            rel = Path(dirpath).relative_to(skill_dir)
+            if rel.parts and rel.parts[0] == "evals" and "fixtures" in dirs:
+                dirs.remove("fixtures")
+        for name in sorted(files):
+            p = Path(dirpath) / name
+            if p.suffix.lower() not in SCAN_EXTS and Path(dirpath).name != "scripts":
+                continue
+            try:
+                if p.stat().st_size > MAX_FILE_BYTES:
+                    continue
+            except OSError:
+                continue
+            yield p
+
+
+def network_declared(fm):
+    blob = " ".join(str(fm.get(k, "")) for k in ("compatibility", "description")).lower() if fm else ""
+    compat = str(fm.get("compatibility", "")).lower() if fm else ""
+    # Only an explicit compatibility declaration counts; description mentions are informative.
+    return any(w in compat for w in NETWORK_DECLARE_WORDS), any(w in blob for w in NETWORK_DECLARE_WORDS)
+
+
+def scan_skill(skill_dir, include_fixtures=False):
+    skill_dir = Path(skill_dir).resolve()
+    skill_name = skill_dir.name
+    findings = []
+    skill_md = skill_dir / "SKILL.md"
+    text = read_text(skill_md) or ""
+    fm = parse_frontmatter(text)
+
+    def add(check, sev, file, line, msg, evidence):
+        findings.append(Finding(skill_name, check, sev, str(file.relative_to(skill_dir)),
+                                line, msg, evidence))
+
+    # --- Check 6: frontmatter hygiene -------------------------------------
+    if fm is None:
+        add("META01", "WARN", skill_md, 1,
+            "SKILL.md has no YAML frontmatter (--- block). Agents cannot discover this skill safely.", text[:80])
+    else:
+        name = fm.get("name", "")
+        if not name:
+            add("META02", "WARN", skill_md, 1, "Frontmatter is missing 'name'.", "")
+        elif name != skill_dir.name:
+            add("META03", "WARN", skill_md, 1,
+                "Frontmatter name '%s' != directory name '%s' — typosquat/impersonation signal, and many runtimes will refuse to load it." % (name, skill_dir.name), name)
+        if name and not NAME_RE.match(name):
+            add("META02", "WARN", skill_md, 1,
+                "Frontmatter name '%s' violates spec (lowercase a-z, 0-9, hyphens)." % name, name)
+        desc = fm.get("description", "")
+        if not desc:
+            add("META04", "WARN", skill_md, 1, "Frontmatter is missing 'description'.", "")
+        elif len(desc) > 1024:
+            add("META05", "INFO", skill_md, 1, "Description exceeds 1024 chars (spec limit).", desc[:60])
+
+    net_declared, net_mentioned = network_declared(fm)
+
+    # --- SKILL.md prose: install-lure detection (Check 2) ------------------
+    lines = text.splitlines()
+    in_fence = False
+    lure_window_until = -1
+    for i, line in enumerate(lines, 1):
+        if SUPPRESS_MARKER in line:
+            continue
+        if line.lstrip().startswith("```"):
+            in_fence = not in_fence
+            continue
+        if not in_fence and LURE_HEADING_RE.match(line):
+            lure_window_until = i + 20
+        if in_fence and FETCH_CMD_RE.search(line):
+            if i <= lure_window_until:
+                add("LURE01", "CRITICAL", skill_md, i,
+                    "Install/prerequisite section tells the user or agent to fetch and run a remote script. This was the #1 ClawHavoc delivery vector.", line)
+            else:
+                add("LURE02", "WARN", skill_md, i,
+                    "SKILL.md contains a command that fetches remote content; verify the destination and pin it.", line)
+        if not in_fence and LURE_PROSE_RE.search(line):
+            add("LURE03", "WARN", skill_md, i,
+                "Prose instructs running a command/script to 'initialize/activate/enable' — install-time execution lure pattern.", line)
+
+    # --- Per-file pattern scans (Checks 1, 3, 4, 5, 7) ----------------------
+    for path in iter_scan_files(skill_dir, include_fixtures=include_fixtures):
+        content = read_text(path)
+        if content is None:
+            continue
+        is_skill_md = path == skill_md
+        is_markdown = path.suffix.lower() in (".md", ".markdown")
+        file_has_net = False
+        file_has_cred = False
+        in_doc_fence = False
+        for i, line in enumerate(content.splitlines(), 1):
+            if is_markdown and line.lstrip().startswith("```"):
+                in_doc_fence = not in_doc_fence
+                continue
+            if SUPPRESS_MARKER in line:
+                continue
+
+            # WARN-tier findings inside a markdown code example are usually
+            # illustrative snippets, not instructions — downgrade to INFO so
+            # documentation-heavy skills stay reviewable. CRITICAL patterns are
+            # NEVER downgraded here: ClawHavoc install lures lived precisely in
+            # fenced "Prerequisites" blocks.
+            def doc_sev(sev):
+                return "INFO" if (in_doc_fence and sev == "WARN") else sev
+
+            def doc_msg(sev, msg):
+                if in_doc_fence and sev == "WARN":
+                    return msg + " (inside a documentation code example — verify it is illustrative, not an instruction to the agent)"
+                return msg
+
+            for rx, check, sev, msg in PIPE_SHELL_PATTERNS + OBFUSCATION_EXEC_PATTERNS:
+                if rx.search(line):
+                    add(check, doc_sev(sev), path, i, doc_msg(sev, msg), line)
+            for token in LONG_B64_RE.findall(line):
+                if not HEX_ONLY_RE.match(token):
+                    add("OBF01", doc_sev("WARN"), path, i,
+                        doc_msg("WARN", "Long base64-like literal (%d chars) — encoded payloads hide from review. Decode it before trusting this file." % len(token)), token[:60] + "...")
+            for rx, check, sev, msg in CRED_PATTERNS:
+                if rx.search(line):
+                    add(check, doc_sev(sev), path, i, doc_msg(sev, msg), line)
+                    # Fenced commands are still executable instructions to an
+                    # agent, so they count toward the EXFIL01 cross-signal.
+                    file_has_cred = True
+            for rx, sev_msg in NET_PATTERNS:
+                if rx.search(line):
+                    file_has_net = True
+                    if not is_skill_md:
+                        sev = "INFO" if (net_declared or in_doc_fence) else "WARN"
+                        extra = ("declared via 'compatibility'" if net_declared else
+                                 ("inside a documentation code example" if in_doc_fence else
+                                  "not declared in frontmatter 'compatibility'"))
+                        add("NET01", sev, path, i,
+                            "Script makes network calls (%s), %s." % (sev_msg, extra), line)
+            for rx, check, sev, msg in PIN_PATTERNS:
+                if rx.search(line):
+                    add(check, doc_sev(sev), path, i, doc_msg(sev, msg), line)
+        if file_has_net and file_has_cred:
+            add("EXFIL01", "CRITICAL", path, 0,
+                "Same file both touches credentials/environment and makes network calls — the standard exfiltration shape. Review it line by line.", "")
+
+    # Eval/test data is expected to quote attack-shaped text (trigger prompts,
+    # rubric examples). It is not runtime content, so keep it visible but
+    # informational rather than failing the scan.
+    for f in findings:
+        if f.file.startswith("evals/") and f.severity != "INFO":
+            f.severity = "INFO"
+            f.message += " (found in evals/ test data — expected to quote attack patterns; verify it is not loaded at runtime)"
+
+    # Deduplicate identical findings
+    seen, unique = set(), []
+    for f in findings:
+        key = (f.check, f.file, f.line, f.message)
+        if key not in seen:
+            seen.add(key)
+            unique.append(f)
+    unique.sort(key=lambda f: (-SEV_RANK[f.severity], f.file, f.line))
+    return unique
+
+
+def main(argv=None):
+    ap = argparse.ArgumentParser(
+        description="Static security scanner for agent skills (OWASP AST01-AST10 aligned).")
+    ap.add_argument("path", help="A skill directory (containing SKILL.md), a SKILL.md file, "
+                                 "or a parent directory holding many skills.")
+    ap.add_argument("--json", action="store_true", help="Emit machine-readable JSON.")
+    ap.add_argument("--include-fixtures", action="store_true",
+                    help="Also scan evals/fixtures/ inside each skill (skipped by "
+                         "default because fixtures may be deliberately malicious "
+                         "test payloads).")
+    args = ap.parse_args(argv)
+
+    root = Path(args.path).expanduser()
+    if not root.exists():
+        print("error: path does not exist: %s\n"
+              "Fix: pass the skill directory itself (the one containing SKILL.md), "
+              "e.g. python3 skill_scanner.py PATH/skills/some-skill" % root, file=sys.stderr)  # skillscan:allow
+        return 2
+    skills = discover_skills(root)
+    if not skills:
+        print("error: no SKILL.md found under %s\n"
+              "Fix: agent skills are directories with a SKILL.md at their root. "
+              "If you meant to scan a single file, name it SKILL.md or pass its parent directory." % root,
+              file=sys.stderr)
+        return 2
+
+    all_findings = []
+    for sd in sorted(skills):
+        all_findings.extend(scan_skill(sd, include_fixtures=args.include_fixtures))
+
+    counts = {"CRITICAL": 0, "WARN": 0, "INFO": 0}
+    for f in all_findings:
+        counts[f.severity] += 1
+
+    if args.json:
+        print(json.dumps({
+            "scanner": "skill_scanner", "version": VERSION,
+            "root": str(root), "skills_scanned": [str(s) for s in sorted(skills)],
+            "findings": [f.as_dict() for f in all_findings],
+            "summary": counts,
+            "verdict": "REJECT-PENDING-REVIEW" if counts["CRITICAL"] else
+                       ("REVIEW-WARNINGS" if counts["WARN"] else "PASS"),
+        }, indent=2))
+    else:
+        print("agent-skill security scan v%s — %d skill(s) under %s\n" % (VERSION, len(skills), root))
+        by_skill = {}
+        for f in all_findings:
+            by_skill.setdefault(f.skill, []).append(f)
+        for sd in sorted(skills):
+            fs = by_skill.get(sd.name, [])
+            print("=== %s (%s) ===" % (sd.name, sd))
+            if not fs:
+                print("  clean — no findings\n")
+                continue
+            for f in fs:
+                loc = "%s:%s" % (f.file, f.line) if f.line else f.file
+                print("  [%s] %s %s\n      %s" % (f.severity, f.check, loc, f.message))
+                if f.evidence:
+                    print("      > %s" % f.evidence)
+            print()
+        print("Summary: %d CRITICAL, %d WARN, %d INFO" %
+              (counts["CRITICAL"], counts["WARN"], counts["INFO"]))
+        if counts["CRITICAL"]:
+            print("Verdict guidance: CRITICAL findings present — do not install/run this skill "
+                  "until a human reviews every flagged line. See references/skill-supply-chain.md.")
+        elif counts["WARN"]:
+            print("Verdict guidance: warnings present — read each flagged file before approving. "
+                  "A clean pattern scan is necessary but not sufficient (OWASP AST08).")
+        else:
+            print("Verdict guidance: no pattern hits. Still read SKILL.md end-to-end — "
+                  "natural-language attacks evade pattern scanners (OWASP AST08).")
+    return 1 if counts["CRITICAL"] else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
The skills section shipped with one CI check (the deterministic eval). This adds the other two gates every skill was actually built under, as separate named checks so PR status shows exactly what passed:

- **deterministic evals** — runs every `evals/*/test_*.py` (16 assertions for project-graveyard today; future skills picked up automatically)
- **skill lint (strict)** — every `SKILL.md` against the agentskills spec: frontmatter rules, name==directory, unfilled template placeholders, text-only prompt dumps
- **security scan** — install-lure patterns, undeclared network calls, credential access, obfuscated payloads across all skills

`skill_lint.py` and `skill_scanner.py` are vendored into `awesome_agent_skills/evals/tools/` (repo-side tooling, never installed with a skill). All three jobs pass on the current tree — this PR's own checks are the demo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)