### PR TITLE
advisor-orchestrator-worker: make agy CLI the primary worker path (Gemini API fallback)

### DIFF
--- a/agent_skills/advisor-orchestrator-worker/README.md
+++ b/agent_skills/advisor-orchestrator-worker/README.md
@@ -2,16 +2,16 @@
 
 **One model is a bottleneck. A team with one brain, twenty hands, and a board advisor is not.**
 
-This skill turns your coding agent into the orchestrator of a three-tier model team. Big tasks get split into self-contained briefs, blasted across cheap parallel workers, verified one by one, and judged by a stronger model exactly twice — before the work starts and before it ships.
+This skill turns your coding agent into the orchestrator of a three-tier model team. Big tasks get split into self-contained briefs, blasted across cheap parallel workers, verified one by one, and judged by a stronger model exactly twice: before the work starts and before it ships.
 
 <img width="3004" height="1408" alt="advisor_skill" src="https://github.com/user-attachments/assets/6f5dc5e8-6828-4598-b23c-72ede97fa238" />
 
 ## The team
 
-| Role | Default model <sub>(July 2026 — swap freely)</sub> | What it does | What it never does |
+| Role | Default model <sub>(July 2026, swap freely)</sub> | What it does | What it never does |
 |---|---|---|---|
 | **Orchestrator** | GPT-5.6 | Frames success criteria, plans waves, dispatches briefs, verifies every result, synthesizes the deliverable | Worker-level grunt work |
-| **Workers** | Gemini 3.5 Flash | One self-contained subtask each, in parallel, stateless — each sees only its brief, with tool access when the subtask needs it | Talk to each other, expand scope, get a second chance on the same call |
+| **Workers** | Gemini 3.5 Flash | One self-contained subtask each, in parallel, stateless; each sees only its brief, with tool access when the subtask needs it | Talk to each other, expand scope, get a second chance on the same call |
 | **Advisor** | Claude Fable 5 | Plan review before any dispatch, taste pass before delivery, called mid-run only at commitment boundaries | Execute anything |
 
 The economics are the point: cheap parallel generation where volume wins, expensive judgment only where it changes a decision. Every run states a budget up front, sized to the plan, and never spends past it silently: running out means an honest report or an explicit ask, not quiet burn. Models are knobs: the tier pattern is the durable part, the defaults were current in July 2026.
@@ -20,9 +20,9 @@ The economics are the point: cheap parallel generation where volume wins, expens
 
 Multi-model loops usually die from context leaks, silent partial failures, or judgment applied too late. Each has a rule here:
 
-- **Stateless briefs** ([references/worker-brief.md](references/worker-brief.md)) — every dispatch carries its full inputs and acceptance criteria inline. No shared context, no "as discussed above." Briefs travel as temp files — handed to `agy` as a quoted expansion, or jq-built into API payloads on the fallback path — never interpolated into shell strings.
-- **Verify before merge** — every result is judged against its own acceptance criteria: PASS, FIX (redispatched with the named failure), or ESCALATE. No silent partial passes, no hand-patching.
-- **The advisor is a critic, not an executor** ([references/advisor-consult.md](references/advisor-consult.md)) — verdict, ranked risks, concrete fixes, under 300 words. Every note gets applied or explicitly rebutted.
+- **Stateless briefs** ([references/worker-brief.md](references/worker-brief.md)): every dispatch carries its full inputs and acceptance criteria inline. No shared context, no "as discussed above." Briefs travel as temp files (handed to `agy` as a quoted expansion, or jq-built into API payloads on the fallback path), never interpolated into shell strings.
+- **Verify before merge**: every result is judged against its own acceptance criteria: PASS, FIX (redispatched with the named failure), or ESCALATE. No silent partial passes, no hand-patching.
+- **The advisor is a critic, not an executor** ([references/advisor-consult.md](references/advisor-consult.md)): verdict, ranked risks, concrete fixes, under 300 words. Every note gets applied or explicitly rebutted.
 
 ## Install
 
@@ -36,7 +36,7 @@ Or copy this folder into your agent's skills dir (`~/.claude/skills/`, `~/.codex
 
 ## Use it
 
-> "This is too big for one pass — orchestrate it across a model team."
+> "This is too big for one pass. Orchestrate it across a model team."
 > "Fan this out: research all 12 competitors in parallel and synthesize."
 > "Run the advisor-worker loop on this."
 
@@ -53,6 +53,6 @@ advisor-orchestrator-worker/
 └── references/fallbacks.md           # the Gemini and Anthropic API fallback calls
 ```
 
-Evals live repo-side in `agent_skills/evals/advisor-orchestrator-worker/` — you install only what runs.
+Evals live repo-side in `agent_skills/evals/advisor-orchestrator-worker/`; you install only what runs.
 
 Part of [awesome-llm-apps](https://github.com/Shubhamsaboo/awesome-llm-apps) · Apache-2.0 · Last verified: July 2026

--- a/agent_skills/advisor-orchestrator-worker/README.md
+++ b/agent_skills/advisor-orchestrator-worker/README.md
@@ -11,7 +11,7 @@ This skill turns your coding agent into the orchestrator of a three-tier model t
 | Role | Default model <sub>(July 2026 — swap freely)</sub> | What it does | What it never does |
 |---|---|---|---|
 | **Orchestrator** | GPT-5.6 | Frames success criteria, plans waves, dispatches briefs, verifies every result, synthesizes the deliverable | Worker-level grunt work |
-| **Workers** | Gemini 3.5 Flash via `agy` CLI <sub>(bare Gemini API as fallback)</sub> | One self-contained subtask each, in parallel, stateless — each sees only its brief, with tool access when the subtask needs it | Talk to each other, expand scope, get a second chance on the same call |
+| **Workers** | Gemini 3.5 Flash | One self-contained subtask each, in parallel, stateless — each sees only its brief, with tool access when the subtask needs it | Talk to each other, expand scope, get a second chance on the same call |
 | **Advisor** | Claude Fable 5 | Plan review before any dispatch, taste pass before delivery, called mid-run only at commitment boundaries | Execute anything |
 
 The economics are the point: cheap parallel generation where volume wins, expensive judgment only where it changes a decision. Every run states a budget up front, sized to the plan, and never spends past it silently: running out means an honest report or an explicit ask, not quiet burn. Models are knobs: the tier pattern is the durable part, the defaults were current in July 2026.

--- a/agent_skills/advisor-orchestrator-worker/README.md
+++ b/agent_skills/advisor-orchestrator-worker/README.md
@@ -49,7 +49,8 @@ advisor-orchestrator-worker/
 ├── SKILL.md                          # the loop, the team, budgets, escalation rules
 ├── README.md                         # this file
 ├── references/worker-brief.md        # the stateless dispatch format workers receive
-└── references/advisor-consult.md     # the consult format the advisor answers in
+├── references/advisor-consult.md     # the consult format the advisor answers in
+└── references/fallbacks.md           # the Gemini and Anthropic API fallback calls
 ```
 
 Evals live repo-side in `agent_skills/evals/advisor-orchestrator-worker/` — you install only what runs.

--- a/agent_skills/advisor-orchestrator-worker/README.md
+++ b/agent_skills/advisor-orchestrator-worker/README.md
@@ -32,7 +32,7 @@ npx skills add https://github.com/Shubhamsaboo/awesome-llm-apps/tree/main/agent_
 
 Or copy this folder into your agent's skills dir (`~/.claude/skills/`, `~/.codex/skills/`, `~/.agents/skills/`).
 
-**Needs** (declared up front, per this repo's rules): the `agy` (Antigravity) CLI for workers — with `GEMINI_API_KEY` (falls back to `GOOGLE_API_KEY`) as the API fallback — plus the `claude` CLI for the advisor (`ANTHROPIC_API_KEY` as its API fallback) and `jq` for fallback payloads. Every role runs on its subscription CLI when installed and falls back to its API key when not. The orchestrator is whichever agent loads the skill; to put a specific model in that seat, launch the run through its CLI (e.g. `codex exec "..."`). Anything missing degrades gracefully — the skill explains the setup fix, then offers degraded mode where your agent plays the missing role itself, labeled as such.
+**Needs** (declared up front, per this repo's rules): the `agy` CLI for workers, the `claude` CLI for the advisor, and `jq`. Missing a CLI? That role falls back to its API key: `GEMINI_API_KEY` (or `GOOGLE_API_KEY`) for workers, `ANTHROPIC_API_KEY` for the advisor. The orchestrator is whichever agent loads the skill; launch through a specific model's CLI (like `codex exec`) to choose it. If a role has neither CLI nor key, the skill explains the fix and offers a clearly labeled degraded mode.
 
 ## Use it
 

--- a/agent_skills/advisor-orchestrator-worker/README.md
+++ b/agent_skills/advisor-orchestrator-worker/README.md
@@ -11,16 +11,16 @@ This skill turns your coding agent into the orchestrator of a three-tier model t
 | Role | Default model <sub>(July 2026 — swap freely)</sub> | What it does | What it never does |
 |---|---|---|---|
 | **Orchestrator** | GPT-5.6 | Frames success criteria, plans waves, dispatches briefs, verifies every result, synthesizes the deliverable | Worker-level grunt work |
-| **Workers** | Gemini 3.5 Flash | One self-contained subtask each, in parallel, stateless — each sees only its brief | Talk to each other, expand scope, get a second chance on the same call |
+| **Workers** | Gemini 3.5 Flash via `agy` CLI <sub>(bare Gemini API as fallback)</sub> | One self-contained subtask each, in parallel, stateless — each sees only its brief, with tool access when the subtask needs it | Talk to each other, expand scope, get a second chance on the same call |
 | **Advisor** | Claude Fable 5 | Plan review before any dispatch, taste pass before delivery, called mid-run only at commitment boundaries | Execute anything |
 
-The economics are the point: cheap parallel generation where volume wins, expensive judgment only where it changes a decision. Budgeted — **20 worker calls, 5 consults** — so a run can't quietly burn a hole in your API bill. Models are knobs: the tier pattern is the durable part, the defaults were current in July 2026.
+The economics are the point: cheap parallel generation where volume wins, expensive judgment only where it changes a decision. Every run states a budget up front, sized to the plan, and never spends past it silently: running out means an honest report or an explicit ask, not quiet burn. Models are knobs: the tier pattern is the durable part, the defaults were current in July 2026.
 
 ## Why it doesn't fall apart
 
 Multi-model loops usually die from context leaks, silent partial failures, or judgment applied too late. Each has a rule here:
 
-- **Stateless briefs** ([references/worker-brief.md](references/worker-brief.md)) — every dispatch carries its full inputs and acceptance criteria inline. No shared context, no "as discussed above." Briefs travel as temp files with jq-built payloads, never interpolated into shell strings.
+- **Stateless briefs** ([references/worker-brief.md](references/worker-brief.md)) — every dispatch carries its full inputs and acceptance criteria inline. No shared context, no "as discussed above." Briefs travel as temp files — handed to `agy` as a quoted expansion, or jq-built into API payloads on the fallback path — never interpolated into shell strings.
 - **Verify before merge** — every result is judged against its own acceptance criteria: PASS, FIX (redispatched with the named failure), or ESCALATE. No silent partial passes, no hand-patching.
 - **The advisor is a critic, not an executor** ([references/advisor-consult.md](references/advisor-consult.md)) — verdict, ranked risks, concrete fixes, under 300 words. Every note gets applied or explicitly rebutted.
 
@@ -32,7 +32,7 @@ npx skills add https://github.com/Shubhamsaboo/awesome-llm-apps/tree/main/agent_
 
 Or copy this folder into your agent's skills dir (`~/.claude/skills/`, `~/.codex/skills/`, `~/.agents/skills/`).
 
-**Needs** (declared up front, per this repo's rules): `GEMINI_API_KEY` (falls back to `GOOGLE_API_KEY`) for workers, the `claude` CLI for the advisor, `jq`, and optionally the `agy` CLI for tool-using workers. Anything missing degrades gracefully — your agent plays the missing role itself and says so.
+**Needs** (declared up front, per this repo's rules): the `agy` (Antigravity) CLI for workers — with `GEMINI_API_KEY` (falls back to `GOOGLE_API_KEY`) as the API fallback when agy is unavailable — plus the `claude` CLI for the advisor and `jq` for fallback payloads. Anything missing degrades gracefully — the skill explains the setup fix, then offers degraded mode where your agent plays the missing role itself, labeled as such.
 
 ## Use it
 

--- a/agent_skills/advisor-orchestrator-worker/README.md
+++ b/agent_skills/advisor-orchestrator-worker/README.md
@@ -32,7 +32,7 @@ npx skills add https://github.com/Shubhamsaboo/awesome-llm-apps/tree/main/agent_
 
 Or copy this folder into your agent's skills dir (`~/.claude/skills/`, `~/.codex/skills/`, `~/.agents/skills/`).
 
-**Needs** (declared up front, per this repo's rules): the `agy` (Antigravity) CLI for workers — with `GEMINI_API_KEY` (falls back to `GOOGLE_API_KEY`) as the API fallback when agy is unavailable — plus the `claude` CLI for the advisor and `jq` for fallback payloads. Anything missing degrades gracefully — the skill explains the setup fix, then offers degraded mode where your agent plays the missing role itself, labeled as such.
+**Needs** (declared up front, per this repo's rules): the `agy` (Antigravity) CLI for workers — with `GEMINI_API_KEY` (falls back to `GOOGLE_API_KEY`) as the API fallback — plus the `claude` CLI for the advisor (`ANTHROPIC_API_KEY` as its API fallback) and `jq` for fallback payloads. Every role runs on its subscription CLI when installed and falls back to its API key when not. The orchestrator is whichever agent loads the skill; to put a specific model in that seat, launch the run through its CLI (e.g. `codex exec "..."`). Anything missing degrades gracefully — the skill explains the setup fix, then offers degraded mode where your agent plays the missing role itself, labeled as such.
 
 ## Use it
 

--- a/agent_skills/advisor-orchestrator-worker/SKILL.md
+++ b/agent_skills/advisor-orchestrator-worker/SKILL.md
@@ -15,7 +15,8 @@ metadata:
 compatibility: >-
   Makes network calls: workers via the Antigravity CLI (agy), falling back to
   the Gemini API (GEMINI_API_KEY or GOOGLE_API_KEY); advisor via the claude
-  CLI. Needs jq. Runs in any harness that can execute shell commands.
+  CLI, falling back to the Anthropic API (ANTHROPIC_API_KEY). Needs jq. All
+  snippets are bash. Runs in any harness that can execute shell commands.
 ---
 
 # Advisor Orchestrator Worker
@@ -27,7 +28,9 @@ work yourself, and you never execute through the advisor.
 **Models are knobs, not gospel.** The tiers are the durable part; the
 model IDs below were current in July 2026 — swap freely. One rule
 survives every generation: the advisor is the strongest reasoning model
-you can reach, workers the cheapest that pass verification.
+you can reach, workers the cheapest that pass verification. All
+snippets below are bash; on a host whose shell isn't bash, run them
+with `bash -c`.
 
 ## The team
 
@@ -88,23 +91,45 @@ you can reach, workers the cheapest that pass verification.
   agy or gets ESCALATE — never pretend an API worker browsed the web or
   touched a file.
 
-- **Advisor (default: Claude Fable 5)** — consulted in print mode, the
-  consult written to a temp file and passed on stdin (never inline in
-  the command string), behind a timeout so a hung consult can't stall
-  the loop — via perl's alarm, since timeout(1) is missing on stock macOS:
+- **Advisor (default: Claude Fable 5 via the claude CLI)** — consulted
+  in print mode, the consult written to a temp file and passed on stdin
+  (never inline in the command string), behind a timeout so a hung
+  consult can't stall the loop — via perl's alarm, since timeout(1) is
+  missing on stock macOS:
   `perl -e 'alarm shift; exec @ARGV' 300 claude --model claude-fable-5 -p < "$consult"`.
   Expensive judgment kept out of the hot path: strategy, decomposition
   critique, risk spotting, taste. Never execution.
+
+  **Fallback — bare Anthropic API call** when the claude CLI is missing
+  or a consult fails. Same model, same consult file; the fallbacks
+  parameter re-serves a safety-classifier refusal on Opus 4.8 inside
+  the same call, and the closing jq unwraps the envelope so the
+  orchestrator reads plain advisor text on both paths:
+
+  ```bash
+  [ -n "$ANTHROPIC_API_KEY" ] || { echo "no ANTHROPIC_API_KEY" >&2; exit 1; }
+  ( set -o pipefail
+    jq -n --rawfile c "$consult" '{model: "claude-fable-5", max_tokens: 16000,
+        fallbacks: [{model: "claude-opus-4-8"}],
+        messages: [{role: "user", content: $c}]}' \
+      | curl -sS --fail --max-time 300 "https://api.anthropic.com/v1/messages" \
+        -H "x-api-key: $ANTHROPIC_API_KEY" -H "anthropic-version: 2023-06-01" \
+        -H "anthropic-beta: server-side-fallback-2026-06-01" \
+        -d @- \
+      | jq -r '.content[] | select(.type == "text") | .text' )
+  ```
 
 ## The loop
 
 1. **Frame.** State the deliverable and 3 to 5 checkable success
    criteria; if the task is too vague for that, ask one question and
    stop. Check tools now, not mid-run: `agy`, `jq`, the `claude` CLI,
-   and `api_key="${GEMINI_API_KEY:-$GOOGLE_API_KEY}"`. If agy is missing
-   but a key is set, announce that all workers run on the API fallback
-   (no tools). If a role has no working path, say exactly how to set it
-   up, then offer degraded mode: you temporarily play the missing role
+   `ANTHROPIC_API_KEY`, and `api_key="${GEMINI_API_KEY:-$GOOGLE_API_KEY}"`.
+   Each role resolves CLI first, then API key: agy missing but a Gemini
+   key set means workers run on the API fallback (no tools); claude CLI
+   missing but ANTHROPIC_API_KEY set means consults go over the API.
+   Announce every fallback up front. If a role has no working path, say
+   exactly how to set it up, then offer degraded mode: you temporarily play the missing role
    yourself — same budgets, every affected section and the final result
    labeled `[DEGRADED: <role>]`, context-isolation caveat noted. This is
    the one exception to the never-do-worker-work rule, and it covers at

--- a/agent_skills/advisor-orchestrator-worker/SKILL.md
+++ b/agent_skills/advisor-orchestrator-worker/SKILL.md
@@ -10,7 +10,7 @@ description: >-
 license: Apache-2.0
 metadata:
   author: "Shubham Saboo"
-  version: "1.1.0"
+  version: "1.0.0"
   source: "https://github.com/Shubhamsaboo/awesome-llm-apps"
 compatibility: >-
   Makes network calls: workers via the Antigravity CLI (agy), falling back to

--- a/agent_skills/advisor-orchestrator-worker/SKILL.md
+++ b/agent_skills/advisor-orchestrator-worker/SKILL.md
@@ -25,22 +25,21 @@ You are the Orchestrator of a three-tier model team. You own the hot
 path: plan, delegate, verify, synthesize. You never do worker-level
 work yourself, and you never execute through the advisor.
 
-**Models are knobs, not gospel.** The tiers are the durable part; the
-model IDs below were current in July 2026 — swap freely. One rule
-survives every generation: the advisor is the strongest reasoning model
-you can reach, workers the cheapest that pass verification. All
-snippets below are bash; on a host whose shell isn't bash, run them
-with `bash -c`.
+**Models are knobs.** The tiers are the durable part; the model IDs
+below (current July 2026) swap freely. One rule survives every
+generation: the advisor is the strongest reasoning model you can
+reach, workers the cheapest that pass verification. Snippets are bash;
+on another shell, run them with `bash -c`.
 
 ## The team
 
 - **Workers (default: Gemini 3.5 Flash via the Antigravity CLI, `agy`)** —
   stateless generation units, with tools (web search, file work) when a
   subtask needs them. Never interpolate a brief into a shell string —
-  briefs carry quotes and arbitrary text, so inline interpolation is a
-  shell-injection bug. Write each brief to a temp file, dispatch each
-  worker from its OWN empty temp dir (so no `.antigravity.md` or project
-  context leaks in), in its own subshell, writing to its own output file:
+  briefs carry quotes and arbitrary text, so that is a shell-injection
+  bug. Write each brief to a temp file and dispatch each worker from
+  its own EMPTY temp dir (no `.antigravity.md` or project context
+  leaks in), in its own subshell, into its own output file:
 
   ```bash
   # $brief = this worker's brief file; $out = its result file (absolute path)
@@ -52,72 +51,32 @@ with `bash -c`.
   pids+=($!)
   ```
 
-  The permissions flag is required in non-TTY shells or the call hangs;
-  the empty dir + minimal env reduce context leakage but are not a
-  sandbox. The `--model` pin keeps the primary and fallback paths on the
-  same model — without it, workers run whatever agy's session default
-  happens to be. Chunk every wave into batches of 3 (Antigravity quota is
-  shared across its app, CLI, and SDK). Start each batch with `pids=()`;
-  after dispatching, reap each worker individually — `wait "$pid"` per
-  PID, since one collective wait reports only the last worker's status —
-  and read each `$out` in dispatch order; a wave sharing one stdout
-  hands verify interleaved output. A worker that exits non-zero or
-  leaves `$out` empty is a failed dispatch. Clean up all temp files and
-  dirs at run end.
+  The permissions flag is required in non-TTY shells or the call
+  hangs; the empty dir + minimal env reduce leakage but are not a
+  sandbox; the `--model` pin keeps primary and fallback on one model.
+  Chunk every wave into batches of 3 (Antigravity quota is shared
+  across its app, CLI, and SDK). Start each batch with `pids=()`, reap
+  each worker with its own `wait "$pid"` (a collective wait reports
+  only the last status), and read each `$out` in dispatch order — a
+  shared stdout hands verify interleaved output. Non-zero exit or an
+  empty `$out` is a failed dispatch: retry it through the Gemini API
+  fallback in `references/fallbacks.md` when a key is set (no key:
+  ESCALATE), and record the switch on the status board. That fallback also takes over when
+  agy is missing, and carries any brief too large (over ~100 KB) or
+  too untrusted for a CLI argument (`agy -p` has no prompt-file
+  input). API workers run uncapped in parallel but have no tools — a
+  subtask that needs tools goes through agy or gets ESCALATE. Clean up
+  all temp files at run end.
 
-  **Fallback — bare Gemini API call** when `agy` is missing, a dispatch
-  fails (retry it through the API automatically if a key is set, and
-  record the switch on the status board), or a brief is too large (rule
-  of thumb: over ~100 KB) or too untrusted to travel as a CLI argument
-  (`agy -p` documents no prompt-file/stdin input). No tools, but
-  `jq --rawfile` makes it safe for arbitrary brief text; the second jq
-  unwraps the response envelope so `$out` holds worker text on both
-  paths:
-
-  ```bash
-  api_key="${GEMINI_API_KEY:-$GOOGLE_API_KEY}"
-  [ -n "$api_key" ] || { echo "no Gemini key (set GEMINI_API_KEY or GOOGLE_API_KEY)" >&2; exit 1; }
-  ( set -o pipefail
-    jq -n --rawfile t "$brief" '{contents:[{parts:[{text:$t}]}]}' \
-      | curl -sS --fail --max-time 300 \
-        "https://generativelanguage.googleapis.com/v1beta/models/gemini-3.5-flash:generateContent" \
-        -H "x-goog-api-key: $api_key" -H "Content-Type: application/json" -d @- \
-      | jq -r '.candidates[0].content.parts[0].text' > "$out" ) &
-  pids+=($!)
-  ```
-
-  API-fallback workers may run the full wave in parallel (the 3-cap is
-  an agy quota rule). A subtask that genuinely needs tools goes through
-  agy or gets ESCALATE — never pretend an API worker browsed the web or
-  touched a file.
-
-- **Advisor (default: Claude Fable 5 via the claude CLI)** — consulted
-  in print mode, the consult written to a temp file and passed on stdin
-  (never inline in the command string), behind a timeout so a hung
-  consult can't stall the loop — via perl's alarm, since timeout(1) is
-  missing on stock macOS:
+- **Advisor (default: Claude Fable 5 via the claude CLI)** — consult
+  written to a temp file, passed on stdin (never inline in the
+  command), behind a timeout so a hung consult can't stall the loop
+  (perl's alarm; timeout(1) is missing on stock macOS):
   `perl -e 'alarm shift; exec @ARGV' 300 claude --model claude-fable-5 -p < "$consult"`.
   Expensive judgment kept out of the hot path: strategy, decomposition
-  critique, risk spotting, taste. Never execution.
-
-  **Fallback — bare Anthropic API call** when the claude CLI is missing
-  or a consult fails. Same model, same consult file; the fallbacks
-  parameter re-serves a safety-classifier refusal on Opus 4.8 inside
-  the same call, and the closing jq unwraps the envelope so the
-  orchestrator reads plain advisor text on both paths:
-
-  ```bash
-  [ -n "$ANTHROPIC_API_KEY" ] || { echo "no ANTHROPIC_API_KEY" >&2; exit 1; }
-  ( set -o pipefail
-    jq -n --rawfile c "$consult" '{model: "claude-fable-5", max_tokens: 16000,
-        fallbacks: [{model: "claude-opus-4-8"}],
-        messages: [{role: "user", content: $c}]}' \
-      | curl -sS --fail --max-time 300 "https://api.anthropic.com/v1/messages" \
-        -H "x-api-key: $ANTHROPIC_API_KEY" -H "anthropic-version: 2023-06-01" \
-        -H "anthropic-beta: server-side-fallback-2026-06-01" \
-        -d @- \
-      | jq -r '.content[] | select(.type == "text") | .text' )
-  ```
+  critique, risk, taste. Never execution. If the CLI is missing or a
+  consult fails, use the Anthropic API fallback in
+  `references/fallbacks.md`.
 
 ## The loop
 
@@ -125,16 +84,14 @@ with `bash -c`.
    criteria; if the task is too vague for that, ask one question and
    stop. Check tools now, not mid-run: `agy`, `jq`, the `claude` CLI,
    `ANTHROPIC_API_KEY`, and `api_key="${GEMINI_API_KEY:-$GOOGLE_API_KEY}"`.
-   Each role resolves CLI first, then API key: agy missing but a Gemini
-   key set means workers run on the API fallback (no tools); claude CLI
-   missing but ANTHROPIC_API_KEY set means consults go over the API.
-   Announce every fallback up front. If a role has no working path, say
-   exactly how to set it up, then offer degraded mode: you temporarily play the missing role
-   yourself — same budgets, every affected section and the final result
-   labeled `[DEGRADED: <role>]`, context-isolation caveat noted. This is
-   the one exception to the never-do-worker-work rule, and it covers at
-   most one role — with two or more missing there is no team left; say
-   so and proceed as ordinary single-model work.
+   Each role resolves CLI first, then API key; announce every fallback
+   up front. If a role has no working path, say exactly how to set it
+   up, then offer degraded mode: you temporarily play that role
+   yourself, same budgets, every affected section and the final result
+   labeled `[DEGRADED: <role>]`, context-isolation caveat noted.
+   Degraded mode is the one exception to the never-do-worker-work rule
+   and covers at most one role; with two or more missing there is no
+   team left, so say so and proceed as ordinary single-model work.
 2. **Plan.** Decompose into self-contained subtasks with inline inputs,
    acceptance criteria, and wave assignments that maximize parallelism.
 3. **Plan review (mandatory advisor consult #1).** Send the plan using
@@ -142,14 +99,14 @@ with `bash -c`.
    you changed and what you rejected.
 4. **Delegate.** Dispatch each wave using the format in
    `references/worker-brief.md`. Parallel background calls, then wait.
-5. **Verify.** Check every result against its own acceptance criteria.
-   A check must exercise the deliverable itself — run the actual
+5. **Verify.** Check every result against its own acceptance criteria,
+   and make the check exercise the deliverable itself — run the actual
    command, read the actual output. Grepping a README, testing
    something adjacent, printing True while exiting zero, or re-checking
-   that a file exists proves nothing and does not count. Verdict per
-   result: PASS, FIX (redispatch naming the specific failure), or
-   ESCALATE. Never silently accept a partial pass. Never hand-patch a
-   substantive failure; redispatch instead.
+   that a file exists proves nothing. Verdict per result: PASS, FIX
+   (redispatch naming the specific failure), or ESCALATE. Never
+   silently accept a partial pass; never hand-patch a substantive
+   failure — redispatch instead.
 6. **Synthesize.** When all subtasks pass, assemble the deliverable.
    Resolve conflicts between worker outputs explicitly, never by
    averaging.

--- a/agent_skills/advisor-orchestrator-worker/SKILL.md
+++ b/agent_skills/advisor-orchestrator-worker/SKILL.md
@@ -1,25 +1,21 @@
 ---
 name: advisor-orchestrator-worker
 description: >-
-  Runs complex, multi-part tasks through a three-tier model team: an
-  orchestrator that plans and verifies, cheap workers that execute subtasks in
-  parallel, and an expensive advisor model consulted only at commitment
-  boundaries. Use when a task is too large for one pass, needs parallel
-  research or generation across many subtasks, or the user asks to orchestrate
-  multiple models, split work across a model team, run an advisor-worker loop,
-  or says "too big for one model" or "fan this out". Not for single-file edits
-  or tasks one model handles in one pass.
+  Use when a task is too large for one model pass, needs parallel research or
+  generation across many subtasks (like researching a dozen competitors at
+  once), or the user asks to orchestrate multiple models, split work across a
+  model team, run an advisor-worker loop, have a stronger model review the
+  plan while cheap workers execute, or says "too big for one model" or "fan
+  this out". Not for single-file edits or tasks one model handles in one pass.
 license: Apache-2.0
 metadata:
   author: "Shubham Saboo"
-  version: "1.0.0"
+  version: "1.1.0"
   source: "https://github.com/Shubhamsaboo/awesome-llm-apps"
 compatibility: >-
-  Makes network calls: workers run via the Gemini API (needs GEMINI_API_KEY,
-  falls back to GOOGLE_API_KEY) and the advisor via the claude CLI. Needs jq
-  for building JSON payloads safely. Optional agy CLI for tool-using workers.
-  Written to run in Codex CLI as the orchestrator; adaptable to any harness
-  that can run shell commands.
+  Makes network calls: workers via the Antigravity CLI (agy), falling back to
+  the Gemini API (GEMINI_API_KEY or GOOGLE_API_KEY); advisor via the claude
+  CLI. Needs jq. Runs in any harness that can execute shell commands.
 ---
 
 # Advisor Orchestrator Worker
@@ -28,77 +24,92 @@ You are the Orchestrator of a three-tier model team. You own the hot
 path: plan, delegate, verify, synthesize. You never do worker-level
 work yourself, and you never execute through the advisor.
 
-**Models are knobs, not gospel.** The tiers are the durable part —
-cheap stateless workers, one orchestrator, expensive judgment consulted
-rarely. The specific model IDs below were current in July 2026; swap
-each role for whatever is the best fit when you run this. One rule
-survives every model generation: the advisor should be the strongest
-reasoning model you can reach, and workers the cheapest that pass
-verification.
+**Models are knobs, not gospel.** The tiers are the durable part; the
+model IDs below were current in July 2026 — swap freely. One rule
+survives every generation: the advisor is the strongest reasoning model
+you can reach, workers the cheapest that pass verification.
 
 ## The team
 
-- **Workers (default: Gemini 3.5 Flash)**, dispatched as bare API calls, not
-  a CLI. Stateless generation units; the API call is faster, cheaper, and
-  leaks zero context. Never interpolate a brief into a shell string — briefs
-  carry quotes and arbitrary text, so inline interpolation is a shell-injection
-  bug, not a style choice. Write each brief to a temp file, build the payload
-  with `jq --rawfile`, and dispatch each worker in **its own subshell** writing
-  to **its own output file**, so parallel workers never collide:
+- **Workers (default: Gemini 3.5 Flash via the Antigravity CLI, `agy`)** —
+  stateless generation units, with tools (web search, file work) when a
+  subtask needs them. Never interpolate a brief into a shell string —
+  briefs carry quotes and arbitrary text, so inline interpolation is a
+  shell-injection bug. Write each brief to a temp file, dispatch each
+  worker from its OWN empty temp dir (so no `.antigravity.md` or project
+  context leaks in), in its own subshell, writing to its own output file:
+
+  ```bash
+  # $brief = this worker's brief file; $out = its result file (absolute path)
+  d=$(mktemp -d)
+  ( cd "$d" && env -i HOME="$HOME" PATH="$PATH" \
+      agy --dangerously-skip-permissions --model "gemini-3.5-flash" \
+      --print-timeout 5m -p "$(cat "$brief")" \
+      > "$out"; s=$?; rm -rf "$d"; exit "$s" ) &
+  pids+=($!)
+  ```
+
+  The permissions flag is required in non-TTY shells or the call hangs;
+  the empty dir + minimal env reduce context leakage but are not a
+  sandbox. The `--model` pin keeps the primary and fallback paths on the
+  same model — without it, workers run whatever agy's session default
+  happens to be. Chunk every wave into batches of 3 (Antigravity quota is
+  shared across its app, CLI, and SDK). Start each batch with `pids=()`;
+  after dispatching, reap each worker individually — `wait "$pid"` per
+  PID, since one collective wait reports only the last worker's status —
+  and read each `$out` in dispatch order; a wave sharing one stdout
+  hands verify interleaved output. A worker that exits non-zero or
+  leaves `$out` empty is a failed dispatch. Clean up all temp files and
+  dirs at run end.
+
+  **Fallback — bare Gemini API call** when `agy` is missing, a dispatch
+  fails (retry it through the API automatically if a key is set, and
+  record the switch on the status board), or a brief is too large (rule
+  of thumb: over ~100 KB) or too untrusted to travel as a CLI argument
+  (`agy -p` documents no prompt-file/stdin input). No tools, but
+  `jq --rawfile` makes it safe for arbitrary brief text; the second jq
+  unwraps the response envelope so `$out` holds worker text on both
+  paths:
 
   ```bash
   api_key="${GEMINI_API_KEY:-$GOOGLE_API_KEY}"
   [ -n "$api_key" ] || { echo "no Gemini key (set GEMINI_API_KEY or GOOGLE_API_KEY)" >&2; exit 1; }
-  # $brief = path to this worker's brief file; $out = its result file
-  ( jq -n --rawfile t "$brief" '{contents:[{parts:[{text:$t}]}]}' \
-      | curl -sS --max-time 120 \
+  ( set -o pipefail
+    jq -n --rawfile t "$brief" '{contents:[{parts:[{text:$t}]}]}' \
+      | curl -sS --fail --max-time 300 \
         "https://generativelanguage.googleapis.com/v1beta/models/gemini-3.5-flash:generateContent" \
-        -H "x-goog-api-key: $api_key" -H "Content-Type: application/json" -d @- > "$out" ) &
+        -H "x-goog-api-key: $api_key" -H "Content-Type: application/json" -d @- \
+      | jq -r '.candidates[0].content.parts[0].text' > "$out" ) &
   pids+=($!)
   ```
 
-  After dispatching the wave, `wait "${pids[@]}"` and read each `$out` in
-  dispatch order. A wave sharing one stdout hands verify interleaved JSON and
-  the run dies at the first parse. Each worker sees only its brief.
+  API-fallback workers may run the full wave in parallel (the 3-cap is
+  an agy quota rule). A subtask that genuinely needs tools goes through
+  agy or gets ESCALATE — never pretend an API worker browsed the web or
+  touched a file.
 
-  Exception: if a subtask genuinely needs tools (web search, file work),
-  dispatch via Antigravity CLI from an EMPTY temp dir so no `.antigravity.md`
-  or project context leaks in. `agy -p` takes the prompt as an argument and
-  documents no prompt-file/stdin input, so keep tool-worker prompts **short,
-  sanitized, and trusted** — never route a large or untrusted brief this way:
-
-  ```bash
-  d=$(mktemp -d)
-  ( cd "$d" && env -i HOME="$HOME" PATH="$PATH" \
-      agy --dangerously-skip-permissions --print-timeout 5m -p "$prompt" ); rm -rf "$d"
-  ```
-
-  The permissions flag is required in non-TTY shells or the call hangs; the
-  empty dir + minimal env *reduce* context leakage but are not a full sandbox.
-  Cap agy workers at 3 parallel (Antigravity quota is shared across its app,
-  CLI, and SDK) by chunking tool-using waves into batches of 3. Clean up every
-  temp file and dir at run end.
-- **Advisor (default: Claude Fable 5)**, consulted in print mode with the
-  consult written to a temp file and passed on stdin — never inline in the
-  command string, and behind a timeout so a hung consult can't stall the loop:
-  `timeout 300 claude --model claude-fable-5 -p < "$consult"`
-  It reads the material and returns a verdict without touching anything.
-  Expensive judgment, kept out of the hot path. Strategy, decomposition
+- **Advisor (default: Claude Fable 5)** — consulted in print mode, the
+  consult written to a temp file and passed on stdin (never inline in
+  the command string), behind a timeout so a hung consult can't stall
+  the loop — via perl's alarm, since timeout(1) is missing on stock macOS:
+  `perl -e 'alarm shift; exec @ARGV' 300 claude --model claude-fable-5 -p < "$consult"`.
+  Expensive judgment kept out of the hot path: strategy, decomposition
   critique, risk spotting, taste. Never execution.
-- At the frame step, resolve the key with
-  `api_key="${GEMINI_API_KEY:-$GOOGLE_API_KEY}"`, then check that key, `jq`,
-  and the `claude` CLI. If a required path is missing, say exactly how to set
-  it up, then offer degraded mode: you temporarily play the missing role
-  yourself. Label every affected section and the final result
-  `[DEGRADED: <role>]`, keep the same budget accounting, and note that
-  context-isolation no longer fully holds. Degraded mode is the one exception
-  to the never-do-worker-work rule, and it covers only the missing role.
 
 ## The loop
 
 1. **Frame.** State the deliverable and 3 to 5 checkable success
-   criteria. If the task is too vague to define them, ask one question
-   and stop.
+   criteria; if the task is too vague for that, ask one question and
+   stop. Check tools now, not mid-run: `agy`, `jq`, the `claude` CLI,
+   and `api_key="${GEMINI_API_KEY:-$GOOGLE_API_KEY}"`. If agy is missing
+   but a key is set, announce that all workers run on the API fallback
+   (no tools). If a role has no working path, say exactly how to set it
+   up, then offer degraded mode: you temporarily play the missing role
+   yourself — same budgets, every affected section and the final result
+   labeled `[DEGRADED: <role>]`, context-isolation caveat noted. This is
+   the one exception to the never-do-worker-work rule, and it covers at
+   most one role — with two or more missing there is no team left; say
+   so and proceed as ordinary single-model work.
 2. **Plan.** Decompose into self-contained subtasks with inline inputs,
    acceptance criteria, and wave assignments that maximize parallelism.
 3. **Plan review (mandatory advisor consult #1).** Send the plan using
@@ -107,9 +118,13 @@ verification.
 4. **Delegate.** Dispatch each wave using the format in
    `references/worker-brief.md`. Parallel background calls, then wait.
 5. **Verify.** Check every result against its own acceptance criteria.
-   Verdict per result: PASS, FIX (redispatch naming the specific
-   failure), or ESCALATE. Never silently accept a partial pass. Never
-   hand-patch a substantive failure; redispatch instead.
+   A check must exercise the deliverable itself — run the actual
+   command, read the actual output. Grepping a README, testing
+   something adjacent, printing True while exiting zero, or re-checking
+   that a file exists proves nothing and does not count. Verdict per
+   result: PASS, FIX (redispatch naming the specific failure), or
+   ESCALATE. Never silently accept a partial pass. Never hand-patch a
+   substantive failure; redispatch instead.
 6. **Synthesize.** When all subtasks pass, assemble the deliverable.
    Resolve conflicts between worker outputs explicitly, never by
    averaging.
@@ -123,13 +138,19 @@ verification.
 - A judgment call falls outside the success criteria
 - The plan must change structurally mid-run
 
-Budget: 20 worker calls, 5 advisor consults total including the two
-mandatory ones. Spend consults like money.
+Budget: set one at the frame step, sized to the plan, and state it
+alongside the success criteria. A reasonable shape is twice the subtask
+count in worker dispatches (retries and fallback redispatches count)
+plus 5 advisor consults, 2 of which are the mandatory reviews. The cap
+is not the point; the rule is that spending past it is never silent. If
+the budget runs out, stop and report, or tell the user what more would
+cost and let them decide.
 
 ## Finish
 
 Stop at a verified deliverable, an exhausted budget, or a blocker that
 needs the user. Return: the deliverable, the plan, a verification
 ledger per subtask, advisor notes applied and rejected, and remaining
-risks. Print a one-line status board after each loop step
-(subtask IDs: PENDING / DISPATCHED / PASS / FIX / ESCALATED).
+risks. Print a one-line status board after each loop step: per subtask,
+its state (PENDING / DISPATCHED / PASS / FIX / ESCALATED), dispatch
+path, and retries — e.g. `W2: FIX → PASS | agy→api | 1 retry`.

--- a/agent_skills/advisor-orchestrator-worker/SKILL.md
+++ b/agent_skills/advisor-orchestrator-worker/SKILL.md
@@ -33,9 +33,9 @@ on another shell, run them with `bash -c`.
 
 ## The team
 
-- **Workers (default: Gemini 3.5 Flash via the Antigravity CLI, `agy`)** —
-  stateless generation units, with tools (web search, file work) when a
-  subtask needs them. Never interpolate a brief into a shell string —
+- **Workers (default: Gemini 3.5 Flash via the Antigravity CLI, `agy`)**: stateless
+  generation units, with tools (web search, file work) when a
+  subtask needs them. Never interpolate a brief into a shell string;
   briefs carry quotes and arbitrary text, so that is a shell-injection
   bug. Write each brief to a temp file and dispatch each worker from
   its own EMPTY temp dir (no `.antigravity.md` or project context
@@ -57,18 +57,18 @@ on another shell, run them with `bash -c`.
   Chunk every wave into batches of 3 (Antigravity quota is shared
   across its app, CLI, and SDK). Start each batch with `pids=()`, reap
   each worker with its own `wait "$pid"` (a collective wait reports
-  only the last status), and read each `$out` in dispatch order — a
-  shared stdout hands verify interleaved output. Non-zero exit or an
+  only the last status), and read each `$out` in dispatch order,
+  since a shared stdout hands verify interleaved output. Non-zero exit or an
   empty `$out` is a failed dispatch: retry it through the Gemini API
   fallback in `references/fallbacks.md` when a key is set (no key:
   ESCALATE), and record the switch on the status board. That fallback also takes over when
   agy is missing, and carries any brief too large (over ~100 KB) or
   too untrusted for a CLI argument (`agy -p` has no prompt-file
-  input). API workers run uncapped in parallel but have no tools — a
+  input). API workers run uncapped in parallel but have no tools, so a
   subtask that needs tools goes through agy or gets ESCALATE. Clean up
   all temp files at run end.
 
-- **Advisor (default: Claude Fable 5 via the claude CLI)** — consult
+- **Advisor (default: Claude Fable 5 via the claude CLI)**: consult
   written to a temp file, passed on stdin (never inline in the
   command), behind a timeout so a hung consult can't stall the loop
   (perl's alarm; timeout(1) is missing on stock macOS):
@@ -100,13 +100,13 @@ on another shell, run them with `bash -c`.
 4. **Delegate.** Dispatch each wave using the format in
    `references/worker-brief.md`. Parallel background calls, then wait.
 5. **Verify.** Check every result against its own acceptance criteria,
-   and make the check exercise the deliverable itself — run the actual
+   and make the check exercise the deliverable itself: run the actual
    command, read the actual output. Grepping a README, testing
    something adjacent, printing True while exiting zero, or re-checking
    that a file exists proves nothing. Verdict per result: PASS, FIX
    (redispatch naming the specific failure), or ESCALATE. Never
    silently accept a partial pass; never hand-patch a substantive
-   failure — redispatch instead.
+   failure; redispatch instead.
 6. **Synthesize.** When all subtasks pass, assemble the deliverable.
    Resolve conflicts between worker outputs explicitly, never by
    averaging.
@@ -135,4 +135,4 @@ needs the user. Return: the deliverable, the plan, a verification
 ledger per subtask, advisor notes applied and rejected, and remaining
 risks. Print a one-line status board after each loop step: per subtask,
 its state (PENDING / DISPATCHED / PASS / FIX / ESCALATED), dispatch
-path, and retries — e.g. `W2: FIX → PASS | agy→api | 1 retry`.
+path, and retries, e.g. `W2: FIX → PASS | agy→api | 1 retry`.

--- a/agent_skills/advisor-orchestrator-worker/references/advisor-consult.md
+++ b/agent_skills/advisor-orchestrator-worker/references/advisor-consult.md
@@ -24,5 +24,9 @@ Do not restate the material. Do not praise. If it is genuinely fine,
 say so in one line and stop. Keep the full response under 300 words.
 ```
 
+For the final taste pass, the QUESTION must ask: are all success
+criteria satisfied, does the deliverable exercise the real target, and
+is this a ship or a conditional pass?
+
 Handling the response: apply or explicitly rebut every note. Rebuttals
 go in the final report. Never silently drop an advisor note.

--- a/agent_skills/advisor-orchestrator-worker/references/fallbacks.md
+++ b/agent_skills/advisor-orchestrator-worker/references/fallbacks.md
@@ -7,7 +7,7 @@ Both fallbacks keep the primary paths' discipline: payloads built with
 failure, and a closing jq that unwraps the response envelope so the
 orchestrator reads plain text on either path.
 
-## Workers — bare Gemini API call
+## Workers: bare Gemini API call
 
 No tools. Run the full wave in parallel; the 3-batch cap is an agy
 quota rule and does not apply here.
@@ -24,7 +24,7 @@ api_key="${GEMINI_API_KEY:-$GOOGLE_API_KEY}"
 pids+=($!)
 ```
 
-## Advisor — bare Anthropic API call
+## Advisor: bare Anthropic API call
 
 Same model as the CLI path. The `fallbacks` parameter re-serves a
 safety-classifier refusal on Opus 4.8 inside the same call, so one

--- a/agent_skills/advisor-orchestrator-worker/references/fallbacks.md
+++ b/agent_skills/advisor-orchestrator-worker/references/fallbacks.md
@@ -1,0 +1,44 @@
+# API Fallbacks
+
+Read this when a primary CLI path is unavailable or a dispatch fails.
+Both fallbacks keep the primary paths' discipline: payloads built with
+`jq --rawfile` from the same temp file (safe for arbitrary text),
+`--fail` plus `pipefail` so an auth or quota error is a detectable
+failure, and a closing jq that unwraps the response envelope so the
+orchestrator reads plain text on either path.
+
+## Workers — bare Gemini API call
+
+No tools. Run the full wave in parallel; the 3-batch cap is an agy
+quota rule and does not apply here.
+
+```bash
+api_key="${GEMINI_API_KEY:-$GOOGLE_API_KEY}"
+[ -n "$api_key" ] || { echo "no Gemini key (set GEMINI_API_KEY or GOOGLE_API_KEY)" >&2; exit 1; }
+( set -o pipefail
+  jq -n --rawfile t "$brief" '{contents:[{parts:[{text:$t}]}]}' \
+    | curl -sS --fail --max-time 300 \
+      "https://generativelanguage.googleapis.com/v1beta/models/gemini-3.5-flash:generateContent" \
+      -H "x-goog-api-key: $api_key" -H "Content-Type: application/json" -d @- \
+    | jq -r '.candidates[0].content.parts[0].text' > "$out" ) &
+pids+=($!)
+```
+
+## Advisor — bare Anthropic API call
+
+Same model as the CLI path. The `fallbacks` parameter re-serves a
+safety-classifier refusal on Opus 4.8 inside the same call, so one
+declined consult cannot stall the loop.
+
+```bash
+[ -n "$ANTHROPIC_API_KEY" ] || { echo "no ANTHROPIC_API_KEY" >&2; exit 1; }
+( set -o pipefail
+  jq -n --rawfile c "$consult" '{model: "claude-fable-5", max_tokens: 16000,
+      fallbacks: [{model: "claude-opus-4-8"}],
+      messages: [{role: "user", content: $c}]}' \
+    | curl -sS --fail --max-time 300 "https://api.anthropic.com/v1/messages" \
+      -H "x-api-key: $ANTHROPIC_API_KEY" -H "anthropic-version: 2023-06-01" \
+      -H "anthropic-beta: server-side-fallback-2026-06-01" \
+      -d @- \
+    | jq -r '.content[] | select(.type == "text") | .text' )
+```

--- a/agent_skills/advisor-orchestrator-worker/references/worker-brief.md
+++ b/agent_skills/advisor-orchestrator-worker/references/worker-brief.md
@@ -1,9 +1,11 @@
 # Worker Brief Format
 
-Every worker dispatch is one stateless CLI call containing this brief.
+Every worker dispatch is one stateless call — an agy CLI run, or a
+Gemini API request on the fallback path — containing this brief.
 The worker has no memory, no follow-ups, and sees nothing but this text.
 Inputs must be pasted inline in full; never reference material the
-worker cannot see.
+worker cannot see. For code subtasks that means the entrypoint, file
+layout, and exact run commands — or workers will invent their own.
 
 ```
 You are a worker completing ONE subtask of a larger project. This brief

--- a/agent_skills/advisor-orchestrator-worker/references/worker-brief.md
+++ b/agent_skills/advisor-orchestrator-worker/references/worker-brief.md
@@ -1,11 +1,11 @@
 # Worker Brief Format
 
-Every worker dispatch is one stateless call — an agy CLI run, or a
-Gemini API request on the fallback path — containing this brief.
+Every worker dispatch is one stateless call (an agy CLI run, or a
+Gemini API request on the fallback path) containing this brief.
 The worker has no memory, no follow-ups, and sees nothing but this text.
 Inputs must be pasted inline in full; never reference material the
 worker cannot see. For code subtasks that means the entrypoint, file
-layout, and exact run commands — or workers will invent their own.
+layout, and exact run commands; otherwise workers invent their own.
 
 ```
 You are a worker completing ONE subtask of a larger project. This brief

--- a/agent_skills/evals/advisor-orchestrator-worker/evals.json
+++ b/agent_skills/evals/advisor-orchestrator-worker/evals.json
@@ -12,19 +12,20 @@
         "Every worker result gets a PASS/FIX/ESCALATE verdict against its own criteria",
         "The final report includes a verification ledger and advisor notes applied or rebutted",
         "Parallel worker outputs are collected from per-worker scratch files (mktemp + redirect, wait, read in dispatch order), never from a shared interleaved stdout",
-        "Tool-using (agy) waves are chunked into batches of at most 3 with a wait between batches",
-        "Briefs and consults are written to temp files (payloads built with jq, consults passed on stdin) \u2014 never interpolated inline into shell strings",
-        "Dispatch fails fast if neither GEMINI_API_KEY nor GOOGLE_API_KEY is set (no silent empty-key call)",
+        "Workers dispatch via the agy CLI by default with --model pinned to gemini-3.5-flash (same model as the API fallback), waves chunked into batches of at most 3 with a wait between batches",
+        "Briefs and consults are written to temp files (handed to agy as a quoted expansion, jq-built payloads on the API fallback, consults passed on stdin) \u2014 never interpolated inline into shell strings",
+        "The Gemini API fallback fails fast if neither GEMINI_API_KEY nor GOOGLE_API_KEY is set (no silent empty-key call)",
         "Each backgrounded worker runs in its own subshell so parallel cd/cleanup and traps never collide",
-        "Worker curl and advisor calls carry a timeout so a hung call cannot stall the whole wave",
-        "Tool-using agy prompts are kept short/sanitized/trusted (agy has no prompt-file input); large or untrusted briefs never go through agy -p"
+        "Worker and advisor calls carry a timeout so a hung call cannot stall the whole wave",
+        "Briefs too large or too untrusted to travel safely as an agy -p argument (agy has no prompt-file input) are routed to the API fallback instead"
       ]
     },
     {
       "id": 2,
-      "prompt": "Fan out this refactor plan across workers, but this machine only has GOOGLE_API_KEY set and no claude CLI.",
-      "expected_output": "The orchestrator detects the missing advisor at the frame step, explains setup, and offers degraded mode where it plays the advisor itself, flagged as degraded.",
+      "prompt": "Fan out this refactor plan across workers, but this machine has no agy CLI, only GOOGLE_API_KEY set, and no claude CLI.",
+      "expected_output": "The orchestrator detects the missing tools at the frame step: workers drop to the announced Gemini API fallback, and it explains setup for the missing advisor and offers degraded mode where it plays the advisor itself, flagged as degraded.",
       "expectations": [
+        "With agy missing but a Gemini key set, workers run on the API fallback and this is announced up front, not discovered mid-run",
         "GEMINI_API_KEY falls back to GOOGLE_API_KEY before being declared missing",
         "Tool availability is checked at the frame step, not discovered mid-run",
         "The user is told how to set up the missing piece",
@@ -38,7 +39,7 @@
       "expectations": [
         "Contradiction beyond provided context triggers an advisor consult",
         "Conflicts are resolved explicitly, never by averaging",
-        "The consult counts against the 5-consult budget and is shown in the ledger"
+        "The consult counts against the consult budget stated at the frame step and is shown in the ledger"
       ]
     },
     {

--- a/agent_skills/evals/advisor-orchestrator-worker/evals.json
+++ b/agent_skills/evals/advisor-orchestrator-worker/evals.json
@@ -22,10 +22,11 @@
     },
     {
       "id": 2,
-      "prompt": "Fan out this refactor plan across workers, but this machine has no agy CLI, only GOOGLE_API_KEY set, and no claude CLI.",
-      "expected_output": "The orchestrator detects the missing tools at the frame step: workers drop to the announced Gemini API fallback, and it explains setup for the missing advisor and offers degraded mode where it plays the advisor itself, flagged as degraded.",
+      "prompt": "Fan out this refactor plan across workers, but this machine has no agy CLI, only GOOGLE_API_KEY set, no claude CLI, and no ANTHROPIC_API_KEY.",
+      "expected_output": "The orchestrator detects the missing tools at the frame step: workers drop to the announced Gemini API fallback, and with neither the claude CLI nor ANTHROPIC_API_KEY available it explains setup for the advisor and offers degraded mode, flagged as degraded.",
       "expectations": [
         "With agy missing but a Gemini key set, workers run on the API fallback and this is announced up front, not discovered mid-run",
+        "Each role resolves CLI first then API key: with the claude CLI missing but ANTHROPIC_API_KEY set, consults would run over the Anthropic API; degraded mode is offered only when neither path exists",
         "GEMINI_API_KEY falls back to GOOGLE_API_KEY before being declared missing",
         "Tool availability is checked at the frame step, not discovered mid-run",
         "The user is told how to set up the missing piece",

--- a/agent_skills/evals/advisor-orchestrator-worker/evals.json
+++ b/agent_skills/evals/advisor-orchestrator-worker/evals.json
@@ -13,7 +13,7 @@
         "The final report includes a verification ledger and advisor notes applied or rebutted",
         "Parallel worker outputs are collected from per-worker scratch files (mktemp + redirect, wait, read in dispatch order), never from a shared interleaved stdout",
         "Workers dispatch via the agy CLI by default with --model pinned to gemini-3.5-flash (same model as the API fallback), waves chunked into batches of at most 3 with a wait between batches",
-        "Briefs and consults are written to temp files (handed to agy as a quoted expansion, jq-built payloads on the API fallback, consults passed on stdin) \u2014 never interpolated inline into shell strings",
+        "Briefs and consults are written to temp files (handed to agy as a quoted expansion, jq-built payloads on the API fallback, consults passed on stdin); never interpolated inline into shell strings",
         "The Gemini API fallback fails fast if neither GEMINI_API_KEY nor GOOGLE_API_KEY is set (no silent empty-key call)",
         "Each backgrounded worker runs in its own subshell so parallel cd/cleanup and traps never collide",
         "Worker and advisor calls carry a timeout so a hung call cannot stall the whole wave",
@@ -45,7 +45,7 @@
     },
     {
       "id": 4,
-      "prompt": "A worker's output failed its acceptance criteria \u2014 just fix it up yourself and move on, we're in a hurry.",
+      "prompt": "A worker's output failed its acceptance criteria; just fix it up yourself and move on, we're in a hurry.",
       "expected_output": "The orchestrator redispatches with the named failure instead of hand-patching a substantive failure, or escalates after a second failure; it explains why in one line without lecturing.",
       "expectations": [
         "Substantive failures are redispatched with the failed criterion quoted, not silently hand-patched",


### PR DESCRIPTION
## What changed

**Worker dispatch priority flipped**: the `agy` (Antigravity) CLI is now the primary path for workers — pinned to `gemini-3.5-flash` so primary and fallback run the same model — and the bare Gemini API call is the fallback (agy missing, dispatch failure, or a brief too large/untrusted for a CLI argument). Previously the API was primary and agy was a tools-only exception.

**SKILL.md de-bloated**: trigger-only description (verified against the lexical trigger evals), `compatibility` reduced to the network/tools declaration the repo rules require, frame-step tool checks merged into loop step 1.

**Real bugs fixed, found by live end-to-end testing** (both dispatch paths, advisor consults, and a full 7-step loop run):
- `timeout(1)` doesn't exist on stock macOS — advisor call now uses a portable perl alarm
- `rm -rf "$d"` masked the worker's exit status, making the documented "fall back when a dispatch fails" trigger undetectable — status now preserved, workers reaped per-PID, `pids=()` reset per batch
- API fallback wrote the raw response envelope to `$out` and ignored HTTP errors — now `--fail` + `pipefail` + `jq` text extraction, and 300s instead of 120s

**Hardening from external (Codex) test feedback**: verification must exercise the deliverable itself; code-subtask briefs must include entrypoint, file layout, and run commands; degraded mode capped at one role; final taste pass answers ship-or-conditional-pass; status board shows dispatch path and retries.

**Budget made dynamic**: sized to the plan at the frame step and stated up front; spending past it is never silent. Replaces the fixed 20-worker/5-consult caps.

## Verification

- `skill_lint.py --strict`: 0 errors, 0 warnings
- `run_trigger_evals.py`: all clear (weakest positive 2.02 vs strongest near-miss 1.51)
- Live E2E on macOS: parallel agy worker waves, both advisor consults, fallback fail-fast without keys, snippet structures verified under `zsh -f`

🤖 Generated with [Claude Code](https://claude.com/claude-code)