### PR TITLE
Add starter: Local AI News Brief with Receipts (fully local, one-file app)

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@ streamlit run travel_agent.py
 *   [🩻 AI Medical Imaging Agent](starter_ai_agents/ai_medical_imaging_agent/)
 *   [😂 AI Meme Generator Agent (Browser)](starter_ai_agents/ai_meme_generator_agent_browseruse/)
 *   [🎵 AI Music Generator Agent](starter_ai_agents/ai_music_generator_agent/)
+*   [📰 Local AI News Brief with Receipts](starter_ai_agents/local_ai_news_brief_with_receipts/)
 *   [🛫 AI Travel Agent (Local & Cloud)](starter_ai_agents/ai_travel_agent/)
 *   [✨ Gemini Multimodal Agent](starter_ai_agents/multimodal_ai_agent/)
 *   [🔄 Mixture of Agents](starter_ai_agents/mixture_of_agents/)

--- a/starter_ai_agents/local_ai_news_brief_with_receipts/README.md
+++ b/starter_ai_agents/local_ai_news_brief_with_receipts/README.md
@@ -1,0 +1,45 @@
+# 📰 Local AI News Brief — with Receipts
+
+A morning tech brief that runs **fully local** (Ollama) and leaves **receipts**: the whole pipeline is one plain-text workflow file, statically audited *before a single token is spent*, and every run writes a hash-chained trace you can verify after.
+
+No Python here — the entire app is one YAML file run by a single binary ([nika](https://github.com/supernovae-st/nika), AGPL-3.0 Rust engine; I'm its author).
+
+## Features
+
+- **One file is the whole app**: fetch the Hacker News front-page feed → keep the top 8 stories → a local model writes the brief → save `brief.md`. Diffable, reviewable, reusable.
+- **Checked before it runs**: `nika check` audits the DAG, types, secret flows and an honest cost floor — *before* anything executes. Broken pipeline = named finding, zero tokens spent.
+- **Receipts after it runs**: every run writes a hash-chained trace; `nika trace verify` exits 0 or names the first broken link. The proof comes from the runner, not from the model's prose.
+- **Local-first**: defaults to `ollama/llama3.2:3b`. Zero API keys. Swap one line for any provider (Claude, GPT, Gemini, Qwen…) — the logic doesn't change.
+- **Zero-setup dry run**: an offline mock provider lets you prove the whole pipeline without Ollama or keys.
+
+## How to get Started
+
+1. Install the engine (single binary) and, for the real run, [Ollama](https://ollama.com):
+
+```bash
+brew install supernovae-st/tap/nika     # or grab a release tarball
+ollama pull llama3.2:3b                  # ~2 GB, once
+```
+
+2. Audit the pipeline before running it (offline):
+
+```bash
+nika check news_brief.nika.yaml
+```
+
+3. Run it:
+
+```bash
+nika run news_brief.nika.yaml                    # real local run
+nika run news_brief.nika.yaml --model mock/echo  # zero-setup dry run (no Ollama, no keys)
+```
+
+4. Read `brief.md` — then verify the run wasn't tampered with:
+
+```bash
+nika trace verify .nika/traces/*.ndjson   # exit 0 = chain intact
+```
+
+## How it works
+
+Four tasks, one DAG: `fetch_feed` (RSS, parsed natively) → `top_stories` (a jq reshape) → `brief` (the only LLM call, budget-visible) → `save`. Change the feed URL, the story count, or the model — it's all in the file's `vars:`.

--- a/starter_ai_agents/local_ai_news_brief_with_receipts/README.md
+++ b/starter_ai_agents/local_ai_news_brief_with_receipts/README.md
@@ -1,15 +1,15 @@
-# 📰 Local AI News Brief — with Receipts
+# 📰 Local AI News Brief, with Receipts
 
 A morning tech brief that runs **fully local** (Ollama) and leaves **receipts**: the whole pipeline is one plain-text workflow file, statically audited *before a single token is spent*, and every run writes a hash-chained trace you can verify after.
 
-No Python here — the entire app is one YAML file run by a single binary ([nika](https://github.com/supernovae-st/nika), AGPL-3.0 Rust engine; I'm its author).
+No Python here. The entire app is one YAML file run by a single binary ([nika](https://github.com/supernovae-st/nika), AGPL-3.0 Rust engine; I'm its author).
 
 ## Features
 
-- **One file is the whole app**: fetch the Hacker News front-page feed → keep the top 8 stories → a local model writes the brief → save `brief.md`. Diffable, reviewable, reusable.
-- **Checked before it runs**: `nika check` audits the DAG, types, secret flows and an honest cost floor — *before* anything executes. Broken pipeline = named finding, zero tokens spent.
+- **One file is the whole app**: fetch the Hacker News front-page feed, keep the top 8 stories, have a local model write the brief, save `brief.md`. Diffable, reviewable, reusable.
+- **Checked before it runs**: `nika check` audits the DAG, types, secret flows and an honest cost floor *before* anything executes. Broken pipeline = named finding, zero tokens spent.
 - **Receipts after it runs**: every run writes a hash-chained trace; `nika trace verify` exits 0 or names the first broken link. The proof comes from the runner, not from the model's prose.
-- **Local-first**: defaults to `ollama/llama3.2:3b`. Zero API keys. Swap one line for any provider (Claude, GPT, Gemini, Qwen…) — the logic doesn't change.
+- **Local-first**: defaults to `ollama/llama3.2:3b`. Zero API keys. Swap one line for any provider (Claude, GPT, Gemini, Qwen) and the logic doesn't change.
 - **Zero-setup dry run**: an offline mock provider lets you prove the whole pipeline without Ollama or keys.
 
 ## How to get Started
@@ -34,7 +34,7 @@ nika run news_brief.nika.yaml                    # real local run
 nika run news_brief.nika.yaml --model mock/echo  # zero-setup dry run (no Ollama, no keys)
 ```
 
-4. Read `brief.md` — then verify the run wasn't tampered with:
+4. Read `brief.md`, then verify the run wasn't tampered with:
 
 ```bash
 nika trace verify .nika/traces/*.ndjson   # exit 0 = chain intact
@@ -42,4 +42,4 @@ nika trace verify .nika/traces/*.ndjson   # exit 0 = chain intact
 
 ## How it works
 
-Four tasks, one DAG: `fetch_feed` (RSS, parsed natively) → `top_stories` (a jq reshape) → `brief` (the only LLM call, budget-visible) → `save`. Change the feed URL, the story count, or the model — it's all in the file's `vars:`.
+Four tasks, one DAG: `fetch_feed` (RSS, parsed natively), `top_stories` (a jq reshape), `brief` (the only LLM call, budget-visible), `save`. Change the feed URL, the story count, or the model: it's all in the file's `vars:`.

--- a/starter_ai_agents/local_ai_news_brief_with_receipts/news_brief.nika.yaml
+++ b/starter_ai_agents/local_ai_news_brief_with_receipts/news_brief.nika.yaml
@@ -1,8 +1,8 @@
 # yaml-language-server: $schema=https://nika.sh/spec/v1/workflow.schema.json
 #
-# Local AI News Brief — with receipts.
-# Fetch Hacker News' front-page feed → keep the top stories → a LOCAL
-# model writes the brief → save it. Every run leaves a hash-chained
+# Local AI News Brief, with receipts.
+# Fetch Hacker News' front-page feed, keep the top stories, have a LOCAL
+# model write the brief, save it. Every run leaves a hash-chained
 # trace (`nika trace verify`), and `nika check` audits the whole plan
 # BEFORE a single token is spent.
 #
@@ -13,7 +13,7 @@ nika: v1
 workflow: local-ai-news-brief
 description: "HN front page → top 8 stories → local-model brief → brief.md (+ tamper-evident trace)"
 
-model: ollama/llama3.2:3b        # local by default — swap for any provider
+model: ollama/llama3.2:3b        # local by default, swap for any provider
 
 vars:
   feed_url: "https://news.ycombinator.com/rss"
@@ -45,7 +45,7 @@ tasks:
 
         ${{ tasks.top_stories.output }}
 
-        Write a short brief: one section per story — the title as a
+        Write a short brief: one section per story, the title as a
         heading, then ONE sentence on why it might matter to a
         developer. Plain markdown, no preamble.
       max_tokens: 600

--- a/starter_ai_agents/local_ai_news_brief_with_receipts/news_brief.nika.yaml
+++ b/starter_ai_agents/local_ai_news_brief_with_receipts/news_brief.nika.yaml
@@ -1,0 +1,66 @@
+# yaml-language-server: $schema=https://nika.sh/spec/v1/workflow.schema.json
+#
+# Local AI News Brief — with receipts.
+# Fetch Hacker News' front-page feed → keep the top stories → a LOCAL
+# model writes the brief → save it. Every run leaves a hash-chained
+# trace (`nika trace verify`), and `nika check` audits the whole plan
+# BEFORE a single token is spent.
+#
+#   nika check news_brief.nika.yaml            # static audit (offline)
+#   nika run  news_brief.nika.yaml             # real local run (Ollama)
+#   nika run  news_brief.nika.yaml --model mock/echo   # zero-setup dry run
+nika: v1
+workflow: local-ai-news-brief
+description: "HN front page → top 8 stories → local-model brief → brief.md (+ tamper-evident trace)"
+
+model: ollama/llama3.2:3b        # local by default — swap for any provider
+
+vars:
+  feed_url: "https://news.ycombinator.com/rss"
+  out_path: "./brief.md"
+
+tasks:
+  - id: fetch_feed
+    invoke:
+      tool: "nika:fetch"
+      args:
+        url: "${{ vars.feed_url }}"
+        mode: feed
+
+  - id: top_stories
+    depends_on: [fetch_feed]
+    invoke:
+      tool: "nika:jq"
+      args:
+        input: ${{ tasks.fetch_feed.output }}
+        expression: |
+          [.items[]? | {title, url: .link}] | .[0:8]
+
+  - id: brief
+    depends_on: [top_stories]
+    infer:
+      prompt: |
+        You are writing a morning tech brief. Here are today's top
+        Hacker News stories as JSON:
+
+        ${{ tasks.top_stories.output }}
+
+        Write a short brief: one section per story — the title as a
+        heading, then ONE sentence on why it might matter to a
+        developer. Plain markdown, no preamble.
+      max_tokens: 600
+
+  - id: save
+    depends_on: [brief]
+    invoke:
+      tool: "nika:write"
+      args:
+        path: "${{ vars.out_path }}"
+        content: "${{ tasks.brief.output }}"
+        overwrite: true
+
+outputs:
+  stories:
+    value: ${{ tasks.top_stories.output }}
+    type: array
+    description: "the stories the brief covers (title + url)"


### PR DESCRIPTION
Adds `starter_ai_agents/local_ai_news_brief_with_receipts/` — a morning tech brief that runs fully local (Ollama, zero API keys) and leaves receipts: the whole app is **one plain-text workflow file**, statically audited before a single token is spent, with a hash-chained trace verifiable after each run.

A different angle from the existing starters: no Python — the app IS the file, run by a single Rust binary ([nika](https://github.com/supernovae-st/nika), AGPL-3.0). Fits the repo's provider-agnostic promise literally: swap `ollama/llama3.2:3b` for Claude/GPT/Gemini/Qwen in one line, logic unchanged.

Proven before this PR: `nika check` green · offline dry run green (mock provider — reviewers can prove the pipeline with zero setup) · real HN feed fetched · `nika trace verify` chain intact.

Full disclosure: I'm nika's author. Happy to adjust format/section if you'd rather see it elsewhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)