### PR TITLE
Add wechat-mac-rpa to Always-on Agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,7 @@ streamlit run travel_agent.py
 *Background agents that run on schedules or events, monitor changing context, decide what needs attention, and proactively deliver updates, artifacts, or actions.*
 
 *   [📰 Always-on Hacker News Briefing Agent](always_on_agents/always_on_hn_briefing_agent/)
+*   [💬 WeChat Mac RPA](https://github.com/wq19901103wq/wechat-mac-rpa) <sub>↗ external</sub> - Always-on visual AI agent for WeChat automation on macOS using multimodal vision perception and LLM, with memory system and multi-agent architecture
 
 ### 🤝 Multi-agent Teams
 *Multiple agents collaborating to accomplish complex, cross-domain tasks.*


### PR DESCRIPTION
## What is this?

[wechat-mac-rpa](https://github.com/wq19901103wq/wechat-mac-rpa) is an always-on visual AI agent for WeChat automation on macOS. It uses multimodal vision perception and LLM to 'see' the WeChat interface and auto-reply messages — no protocol reverse engineering, no database access.

### Key Features
- **Visual AI Perception**: Uses multimodal LLM vision to understand WeChat UI — no protocol hacking, no database access
- **Always-on Agent**: Monitors WeChat messages and auto-responds in real-time
- **Memory System**: Vector database for conversation memory and context retention
- **Multi-Agent Architecture**: Supports digital twin and multi-agent orchestration
- **Skill System**: Extensible skills for smart home control, 3D printing, and more
- **Tech Stack**: Python / AppleScript / Multimodal LLM / Vector Database

### Where it fits
Added under **Always-on Agents** section, as it's a background agent that monitors changing context (WeChat messages) and proactively delivers actions (auto-replies).

### License
MIT License

---