### PR TITLE
Fix typo "scrae" -> "scrape" in web scraping agent prompt

### DIFF
--- a/starter_ai_agents/web_scraping_ai_agent/ai_scrapper.py
+++ b/starter_ai_agents/web_scraping_ai_agent/ai_scrapper.py
@@ -24,7 +24,7 @@ if openai_access_token:
     # Get the URL of the website to scrape
     url = st.text_input("Enter the URL of the website you want to scrape")
     # Get the user prompt
-    user_prompt = st.text_input("What you want the AI agent to scrae from the website?")
+    user_prompt = st.text_input("What you want the AI agent to scrape from the website?")
     
     # Create a SmartScraperGraph object
     smart_scraper_graph = SmartScraperGraph(


### PR DESCRIPTION
Fixes #948.

### What

`starter_ai_agents/web_scraping_ai_agent/ai_scrapper.py:27` had a one-character typo in a user-facing `st.text_input` label — "scrae" instead of "scrape".

### Diff

```diff
-    user_prompt = st.text_input("What you want the AI agent to scrae from the website?")
+    user_prompt = st.text_input("What you want the AI agent to scrape from the website?")
```

No behavior change, just the label users see when opening the app.