### PR TITLE
Fix missing spaces in openai_research_agent Agent instructions

### DIFF
--- a/starter_ai_agents/openai_research_agent/research_agent.py
+++ b/starter_ai_agents/openai_research_agent/research_agent.py
@@ -79,11 +79,11 @@ def save_important_fact(fact: str, source: str = None) -> str:
 # Define the agents
 research_agent = Agent(
     name="Research Agent",
-    instructions="You are a research assistant. Given a search term, you search the web for that term and"
-    "produce a concise summary of the results. The summary must 2-3 paragraphs and less than 300"
-    "words. Capture the main points. Write succintly, no need to have complete sentences or good"
-    "grammar. This will be consumed by someone synthesizing a report, so its vital you capture the"
-    "essence and ignore any fluff. Do not include any additional commentary other than the summary"
+    instructions="You are a research assistant. Given a search term, you search the web for that term and "
+    "produce a concise summary of the results. The summary must be 2-3 paragraphs and less than 300 "
+    "words. Capture the main points. Write succinctly, no need to have complete sentences or good "
+    "grammar. This will be consumed by someone synthesizing a report, so it's vital you capture the "
+    "essence and ignore any fluff. Do not include any additional commentary other than the summary "
     "itself.",
     model="gpt-4o-mini",
     tools=[


### PR DESCRIPTION
Fixes #949.

### What

The `research_agent`'s `instructions` in `starter_ai_agents/openai_research_agent/research_agent.py` (lines 82–87) used multi-line Python implicit string concatenation but each line was missing its trailing space. The prompt actually shipped to the model contained fused words: `term andproduce`, `less than 300words`, `or goodgrammar`, `capture theessence`, `the summaryitself`.

### Diff

```diff
-    instructions="You are a research assistant. Given a search term, you search the web for that term and"
-    "produce a concise summary of the results. The summary must 2-3 paragraphs and less than 300"
-    "words. Capture the main points. Write succintly, no need to have complete sentences or good"
-    "grammar. This will be consumed by someone synthesizing a report, so its vital you capture the"
-    "essence and ignore any fluff. Do not include any additional commentary other than the summary"
+    instructions="You are a research assistant. Given a search term, you search the web for that term and "
+    "produce a concise summary of the results. The summary must be 2-3 paragraphs and less than 300 "
+    "words. Capture the main points. Write succinctly, no need to have complete sentences or good "
+    "grammar. This will be consumed by someone synthesizing a report, so it's vital you capture the "
+    "essence and ignore any fluff. Do not include any additional commentary other than the summary "
     "itself.",
```

While touching those lines, I also fixed three small English typos in the same block: `succintly` → `succinctly`, `must 2-3 paragraphs` → `must be 2-3 paragraphs`, `its vital` → `it's vital`. Happy to split those out if you'd prefer only the mechanical space fix.

### Not touched

Other files in the repo have the same "implicit-concat with missing spaces" pattern too — not fixing those here to keep this PR scoped to a single template.