### PR TITLE
Invoke researcher in local_travel_agent + fix missing comma in instructions

### DIFF
--- a/starter_ai_agents/ai_travel_agent/local_travel_agent.py
+++ b/starter_ai_agents/ai_travel_agent/local_travel_agent.py
@@ -84,7 +84,7 @@ if serp_api_key:
         ),
         instructions=[
             "Given a travel destination and the number of days the user wants to travel for, first generate a list of 3 search terms related to that destination and the number of days.",
-            "For each search term, `search_google` and analyze the results."
+            "For each search term, `search_google` and analyze the results.",
             "From the results of all searches, return the 10 most relevant results to the user's preferences.",
             "Remember: the quality of the results is important.",
         ],
@@ -120,9 +120,21 @@ if serp_api_key:
     
     with col1:
         if st.button("Generate Itinerary"):
-            with st.spinner("Processing..."):
-                # Get the response from the assistant
-                response: RunOutput = planner.run(f"{destination} for {num_days} days", stream=False)
+            with st.spinner("Researching your destination..."):
+                research_results: RunOutput = researcher.run(
+                    f"Research {destination} for a {num_days} day trip", stream=False
+                )
+                st.write("Research completed")
+
+            with st.spinner("Creating your personalized itinerary..."):
+                prompt = f"""
+                Destination: {destination}
+                Duration: {num_days} days
+                Research Results: {research_results.content}
+
+                Please create a detailed itinerary based on this research.
+                """
+                response: RunOutput = planner.run(prompt, stream=False)
                 # Store the response in session state
                 st.session_state.itinerary = response.content
                 st.write(response.content)

--- a/starter_ai_agents/ai_travel_agent/travel_agent.py
+++ b/starter_ai_agents/ai_travel_agent/travel_agent.py
@@ -86,7 +86,7 @@ if openai_api_key and serp_api_key:
         ),
         instructions=[
             "Given a travel destination and the number of days the user wants to travel for, first generate a list of 3 search terms related to that destination and the number of days.",
-            "For each search term, `search_google` and analyze the results."
+            "For each search term, `search_google` and analyze the results.",
             "From the results of all searches, return the 10 most relevant results to the user's preferences.",
             "Remember: the quality of the results is important.",
         ],


### PR DESCRIPTION
Fixes #950.

### What

Two related bugs in the AI Travel Agent starter:

**1. `local_travel_agent.py` never actually calls the researcher.**

The file defines a `researcher` Agent wired up with `SerpApiTools(api_key=serp_api_key)`, but the button handler only calls `planner.run(...)` — the researcher is dead code, so:

- the SerpAPI key the user is asked for is collected but never used,
- no web search ever happens in the local variant,
- the itinerary comes purely from local Llama-3.2, with none of the research context that `travel_agent.py` (the online variant) actually delivers.

Mirror the two-step flow that the online `travel_agent.py` already uses: run `researcher.run(...)` first, then pass its `.content` into `planner.run(...)` as research context.

```diff
     with col1:
         if st.button("Generate Itinerary"):
-            with st.spinner("Processing..."):
-                # Get the response from the assistant
-                response: RunOutput = planner.run(f"{destination} for {num_days} days", stream=False)
+            with st.spinner("Researching your destination..."):
+                research_results: RunOutput = researcher.run(
+                    f"Research {destination} for a {num_days} day trip", stream=False
+                )
+                st.write("Research completed")
+
+            with st.spinner("Creating your personalized itinerary..."):
+                prompt = f\"\"\"
+                Destination: {destination}
+                Duration: {num_days} days
+                Research Results: {research_results.content}
+
+                Please create a detailed itinerary based on this research.
+                \"\"\"
+                response: RunOutput = planner.run(prompt, stream=False)
                 # Store the response in session state
                 st.session_state.itinerary = response.content
                 st.write(response.content)
```

**2. Missing comma in the researcher's `instructions` list — in both files.**

`local_travel_agent.py` line 87 and `travel_agent.py` line 89 end with `"…analyze the results."` and no trailing comma. Python's implicit string-literal concatenation silently merges the next intended list item into the same string, so the researcher gets 3 instructions instead of 4, with two run-on into one (`"…analyze the results.From the results…"`).

```diff
         instructions=[
             "Given a travel destination and the number of days the user wants to travel for, first generate a list of 3 search terms related to that destination and the number of days.",
-            "For each search term, `search_google` and analyze the results."
+            "For each search term, `search_google` and analyze the results.",
             "From the results of all searches, return the 10 most relevant results to the user's preferences.",
             "Remember: the quality of the results is important.",
         ],
```

### Verification

- `python -m py_compile starter_ai_agents/ai_travel_agent/local_travel_agent.py starter_ai_agents/ai_travel_agent/travel_agent.py` — clean.
- Manually diffed the new local variant flow against `travel_agent.py` to confirm the two-step research→plan handoff matches.