### PR TITLE
feat: add gptme - self-hosted terminal AI agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ streamlit run travel_agent.py
 *   [👨🏻‍💼 AI Sales Intelligence Agent Team](advanced_ai_agents/multi_agent_apps/agent_teams/ai_sales_intelligence_agent_team) - Generates competitive sales battle cards in real time
 *   [🎧 AI Social Media News and Podcast Agent](advanced_ai_agents/multi_agent_apps/ai_news_and_podcast_agents/) - Curates your trusted sources into briefs and generated podcasts
 *   [🌐 Openwork - Open Browser Automation Agent](https://github.com/accomplish-ai/openwork) <sub>↗ external</sub> - Open-source agent that operates a real browser
+*   [🖥️ gptme - Self-hosted AI agent that runs in your terminal and executes code](https://github.com/ErikBjare/gptme) <sub>↗ external</sub>
 *   [🛡️ Trust-Gated Multi-Agent Research Team](advanced_ai_agents/multi_agent_apps/trust_gated_agent_team/) - Every agent verified, every action in a hash-chained audit trail
 
 ### 🛰️ Always-on Agents


### PR DESCRIPTION
## What's being added

**gptme** — a self-hosted, open-source AI agent that runs in your terminal.

**Why it fits here**: gptme is a production-ready autonomous agent with tool use, code execution, memory, and multi-provider LLM support. It belongs in the Advanced AI Agents section alongside Openwork and other external projects.

### Key features
- **Terminal-native**: Runs locally on your machine, no web UI required
- **Code execution**: Actually runs the code it writes (Python, shell, etc.)
- **Tool use**: Browser automation, file operations, shell commands, computer use
- **Autonomous operation**: Can run unattended sessions completing multi-step tasks
- **Multi-provider**: Claude, GPT, Gemini, Mistral, Ollama, and more
- **Memory**: Persistent context across sessions

### Links
- GitHub: https://github.com/ErikBjare/gptme (MIT license)
- Website: https://gptme.ai
- Docs: https://gptme.org/docs/

### Change
Single line added to README under "Advanced AI Agents":
```
*   [🖥️ gptme - Self-hosted AI agent that runs in your terminal and executes code](https://github.com/ErikBjare/gptme) <sub>↗ external</sub>
```