### PR TITLE
Add Eval-First RAG — a RAG app that scores its own answers

### DIFF
--- a/rag_tutorials/eval_first_rag/.env.example
+++ b/rag_tutorials/eval_first_rag/.env.example
@@ -1,0 +1,1 @@
+OPENAI_API_KEY=your-key-here

--- a/rag_tutorials/eval_first_rag/.gitignore
+++ b/rag_tutorials/eval_first_rag/.gitignore
@@ -1,0 +1,4 @@
+.env
+.venv/
+__pycache__/
+*.pyc

--- a/rag_tutorials/eval_first_rag/README.md
+++ b/rag_tutorials/eval_first_rag/README.md
@@ -1,0 +1,41 @@
+## 🧪 Eval-First RAG
+
+Most RAG demos stop at **retrieve → generate**. This one adds the layer that actually matters in production: after every answer it runs an **evaluation pass** that scores retrieval confidence and answer groundedness, then flags the failure mode standard RAG silently ships — a **confident answer the retrieved context does not support** (a "confident hallucination").
+
+This Streamlit app runs locally with only an OpenAI API key. It ships with a small built-in financial document so it works with zero setup, and you can paste in your own.
+
+### Features
+
+- **Answer + self-evaluation**: every response comes with a groundedness score and a verdict
+- **Three verdicts**: `grounded`, `honest_refusal` (correctly declines when the answer isn't in context), and `confident_hallucination` (the dangerous case — flagged in red)
+- **Retrieval confidence**: top cosine-similarity score, surfaced alongside the answer
+- **LLM-as-judge**: a strict evaluator scores support-by-context, not fluent wording
+- **Zero-setup corpus**: built-in sample doc with specific numbers so hallucinations are easy to catch; editable to test your own text
+- **Minimal stack**: OpenAI embeddings + `gpt-4o-mini` + NumPy cosine search — no vector DB required
+
+### Why it's different
+
+In finance, healthcare, or legal RAG, a confident wrong answer is worse than an honest "I don't know" — but most eval setups score both the same. This app makes that distinction visible in the loop. It's a compact demo of the eval-first pattern behind [finrag-eval](https://github.com/Ruthwik-Data/finrag-eval), where the same approach surfaced a metric bug now merged into DeepEval.
+
+### How to Get Started?
+
+1. Clone the GitHub repository
+```bash
+git clone https://github.com/Shubhamsaboo/awesome-llm-apps.git
+cd awesome-llm-apps/rag_tutorials/eval_first_rag
+```
+
+2. Install the required dependencies:
+```bash
+pip install -r requirements.txt
+```
+
+3. Run the Streamlit app:
+```bash
+streamlit run eval_first_rag.py
+```
+
+4. Paste your OpenAI API key in the sidebar, then try:
+   - *"What was FY2025 revenue?"* → **grounded**
+   - *"What was the FY2025 dividend per share?"* → **honest refusal** (the doc says no dividend was declared)
+   - *"What is Acme's 2026 revenue guidance?"* → **confident-hallucination trap** (not in the doc)

--- a/rag_tutorials/eval_first_rag/README.md
+++ b/rag_tutorials/eval_first_rag/README.md
@@ -40,15 +40,15 @@ streamlit run eval_first_rag.py
 4. Add your OpenAI API key (sidebar, or a local `.env` with `OPENAI_API_KEY=...`), then try:
 
    **Strict mode (context only):**
-   - *"What was FY2025 revenue?"* → ✅ **grounded** ($412.6M)
-   - *"What was the FY2025 dividend per share?"* → ✅ **honest refusal** (the doc says none was declared)
+   - *"What was Apple's FY2024 revenue?"* → ✅ **grounded** ($391.0B)
+   - *"How much did Apple spend on marketing in FY2024?"* → ✅ **honest refusal** (not in the summary)
 
    **Loose mode (answer freely):**
-   - *"What was Apple's FY2019 revenue?"* → ⚠️ **confident hallucination** — the model answers from its own memory, but the answer isn't grounded in the retrieved Acme context, so the evaluator flags it. This is the classic RAG failure: answering from parametric memory instead of the documents.
+   - *"What was Tesla's FY2024 revenue?"* → ⚠️ **confident hallucination** — the model answers from its own memory, but the answer isn't grounded in the retrieved Apple context, so the evaluator flags it. This is the classic RAG failure: answering from parametric memory instead of the documents.
 
 > Note: modern aligned models often *refuse* rather than hallucinate on clean factual questions (a good thing) — Strict mode shows that. Loose mode makes the ungrounded-answer failure reproducible so you can see the evaluator catch it.
 
-**Guaranteed demo of the ⚠️ flag** (deterministic, no reliance on model behavior): ask *"What was FY2025 revenue?"*, then paste this into **"Audit an answer"**:
-> `Acme Robotics reported FY2025 revenue of $500.0 million.`
+**Guaranteed demo of the ⚠️ flag** (deterministic, no reliance on model behavior): ask *"What was Apple's FY2024 revenue?"*, then paste this into **"Audit an answer"**:
+> `Apple reported FY2024 revenue of $450.0 billion.`
 
-The real figure is $412.6M, so the evaluator flags it as a **confident hallucination** (groundedness 0.0) every time.
+The real figure is $391.0B, so the evaluator flags it as a **confident hallucination** (groundedness 0.0) every time.

--- a/rag_tutorials/eval_first_rag/README.md
+++ b/rag_tutorials/eval_first_rag/README.md
@@ -10,6 +10,8 @@ This Streamlit app runs locally with only an OpenAI API key. It ships with a sma
 - **Three verdicts**: `grounded`, `honest_refusal` (correctly declines when the answer isn't in context), and `confident_hallucination` (the dangerous case — flagged in red)
 - **Retrieval confidence**: top cosine-similarity score, surfaced alongside the answer
 - **LLM-as-judge**: a strict evaluator scores support-by-context, not fluent wording
+- **Audit any answer**: paste any answer to score it against the retrieved context — a deterministic way to watch the evaluator catch a wrong claim
+- **Strict / Loose grounding toggle**: Strict answers from context only; Loose lets the model answer freely so you can see ungrounded answers get flagged
 - **Zero-setup corpus**: built-in sample doc with specific numbers so hallucinations are easy to catch; editable to test your own text
 - **Minimal stack**: OpenAI embeddings + `gpt-4o-mini` + NumPy cosine search — no vector DB required
 
@@ -35,7 +37,18 @@ pip install -r requirements.txt
 streamlit run eval_first_rag.py
 ```
 
-4. Paste your OpenAI API key in the sidebar, then try:
-   - *"What was FY2025 revenue?"* → **grounded**
-   - *"What was the FY2025 dividend per share?"* → **honest refusal** (the doc says no dividend was declared)
-   - *"What is Acme's 2026 revenue guidance?"* → **confident-hallucination trap** (not in the doc)
+4. Add your OpenAI API key (sidebar, or a local `.env` with `OPENAI_API_KEY=...`), then try:
+
+   **Strict mode (context only):**
+   - *"What was FY2025 revenue?"* → ✅ **grounded** ($412.6M)
+   - *"What was the FY2025 dividend per share?"* → ✅ **honest refusal** (the doc says none was declared)
+
+   **Loose mode (answer freely):**
+   - *"What was Apple's FY2019 revenue?"* → ⚠️ **confident hallucination** — the model answers from its own memory, but the answer isn't grounded in the retrieved Acme context, so the evaluator flags it. This is the classic RAG failure: answering from parametric memory instead of the documents.
+
+> Note: modern aligned models often *refuse* rather than hallucinate on clean factual questions (a good thing) — Strict mode shows that. Loose mode makes the ungrounded-answer failure reproducible so you can see the evaluator catch it.
+
+**Guaranteed demo of the ⚠️ flag** (deterministic, no reliance on model behavior): ask *"What was FY2025 revenue?"*, then paste this into **"Audit an answer"**:
+> `Acme Robotics reported FY2025 revenue of $500.0 million.`
+
+The real figure is $412.6M, so the evaluator flags it as a **confident hallucination** (groundedness 0.0) every time.

--- a/rag_tutorials/eval_first_rag/README.md
+++ b/rag_tutorials/eval_first_rag/README.md
@@ -2,7 +2,7 @@
 
 Most RAG demos stop at **retrieve → generate**. This one adds the layer that actually matters in production: after every answer it runs an **evaluation pass** that scores retrieval confidence and answer groundedness, then flags the failure mode standard RAG silently ships — a **confident answer the retrieved context does not support** (a "confident hallucination").
 
-This Streamlit app runs locally with only an OpenAI API key. It ships with a small built-in financial document so it works with zero setup, and you can paste in your own.
+This Streamlit app runs locally with only an OpenAI API key. Paste in any document — a 10-K excerpt, a report, meeting notes — and ask questions against it.
 
 ### Features
 
@@ -12,7 +12,7 @@ This Streamlit app runs locally with only an OpenAI API key. It ships with a sma
 - **LLM-as-judge**: a strict evaluator scores support-by-context, not fluent wording
 - **Audit any answer**: paste any answer to score it against the retrieved context — a deterministic way to watch the evaluator catch a wrong claim
 - **Strict / Loose grounding toggle**: Strict answers from context only; Loose lets the model answer freely so you can see ungrounded answers get flagged
-- **Zero-setup corpus**: built-in sample doc with specific numbers so hallucinations are easy to catch; editable to test your own text
+- **Bring your own document**: no bundled data — paste any text and query it
 - **Minimal stack**: OpenAI embeddings + `gpt-4o-mini` + NumPy cosine search — no vector DB required
 
 ### Why it's different
@@ -37,18 +37,10 @@ pip install -r requirements.txt
 streamlit run eval_first_rag.py
 ```
 
-4. Add your OpenAI API key (sidebar, or a local `.env` with `OPENAI_API_KEY=...`), then try:
+4. Add your OpenAI API key (sidebar, or a local `.env` with `OPENAI_API_KEY=...`), paste a document in the sidebar, then see each verdict:
 
-   **Strict mode (context only):**
-   - *"What was Apple's FY2024 revenue?"* → ✅ **grounded** ($391.0B)
-   - *"How much did Apple spend on marketing in FY2024?"* → ✅ **honest refusal** (not in the summary)
+   - **Grounded** — ask something your document answers → the answer comes back with a high groundedness score.
+   - **Honest refusal** — ask something *not* in your document → in Strict mode the model replies "Not found in context," scored as a correct refusal.
+   - **Confident hallucination** — switch to Loose mode (the model may answer from memory), or use **Audit an answer** to paste a claim your document contradicts → the evaluator flags it in red with groundedness ~0.
 
-   **Loose mode (answer freely):**
-   - *"What was Tesla's FY2024 revenue?"* → ⚠️ **confident hallucination** — the model answers from its own memory, but the answer isn't grounded in the retrieved Apple context, so the evaluator flags it. This is the classic RAG failure: answering from parametric memory instead of the documents.
-
-> Note: modern aligned models often *refuse* rather than hallucinate on clean factual questions (a good thing) — Strict mode shows that. Loose mode makes the ungrounded-answer failure reproducible so you can see the evaluator catch it.
-
-**Guaranteed demo of the ⚠️ flag** (deterministic, no reliance on model behavior): ask *"What was Apple's FY2024 revenue?"*, then paste this into **"Audit an answer"**:
-> `Apple reported FY2024 revenue of $450.0 billion.`
-
-The real figure is $391.0B, so the evaluator flags it as a **confident hallucination** (groundedness 0.0) every time.
+> Note: modern aligned models often *refuse* rather than hallucinate on clean factual questions (a good thing) — Strict mode shows that. Loose mode and the answer-audit make the ungrounded-answer failure reproducible so you can watch the evaluator catch it deterministically.

--- a/rag_tutorials/eval_first_rag/eval_first_rag.py
+++ b/rag_tutorials/eval_first_rag/eval_first_rag.py
@@ -11,10 +11,14 @@ Built by Ruthwik Arepelly (https://github.com/Ruthwik-Data) — eval-first AI PM
 """
 
 import json
+import os
 
 import numpy as np
 import streamlit as st
+from dotenv import load_dotenv
 from openai import OpenAI
+
+load_dotenv()  # optional: read OPENAI_API_KEY from a local .env
 
 EMBED_MODEL = "text-embedding-3-small"
 CHAT_MODEL = "gpt-4o-mini"
@@ -111,7 +115,9 @@ st.caption(
 
 with st.sidebar:
     st.header("Setup")
-    api_key = st.text_input("OpenAI API key", type="password")
+    api_key = st.text_input(
+        "OpenAI API key", type="password", value=os.getenv("OPENAI_API_KEY", "")
+    )
     st.markdown("**Corpus** (edit to test your own):")
     doc = st.text_area("Document", SAMPLE_DOC, height=240)
     st.markdown(

--- a/rag_tutorials/eval_first_rag/eval_first_rag.py
+++ b/rag_tutorials/eval_first_rag/eval_first_rag.py
@@ -1,0 +1,169 @@
+"""
+Eval-First RAG — a RAG app that scores its own answers.
+
+Most RAG demos stop at "retrieve + generate". This one adds the layer that
+matters in production: after every answer it runs an evaluation pass that scores
+retrieval confidence and answer groundedness, then flags the dangerous failure
+mode standard RAG misses — a confident answer that the retrieved context does
+NOT support (a "confident hallucination").
+
+Built by Ruthwik Arepelly (https://github.com/Ruthwik-Data) — eval-first AI PM.
+"""
+
+import json
+
+import numpy as np
+import streamlit as st
+from openai import OpenAI
+
+EMBED_MODEL = "text-embedding-3-small"
+CHAT_MODEL = "gpt-4o-mini"
+
+# A small built-in corpus so the app runs with zero setup. Numbers are specific
+# on purpose — they make hallucinations easy to catch.
+SAMPLE_DOC = """Acme Robotics - FY2025 Annual Report (excerpt)
+
+Revenue for fiscal year 2025 was $412.6 million, up 18% from $349.7 million in FY2024.
+Gross margin was 61.2%, compared to 58.9% in the prior year.
+Net income was $47.3 million, or $1.12 per diluted share.
+Research and development expense was $88.4 million, roughly 21% of revenue.
+The company ended the year with $210.0 million in cash and cash equivalents and no long-term debt.
+Acme shipped 24,500 industrial robot units in FY2025, up from 19,800 units in FY2024.
+The Board did not declare a dividend in FY2025.
+"""
+
+
+def chunk_text(text, size=60, overlap=15):
+    """Word-based chunking with overlap so sentence context is preserved."""
+    words = text.split()
+    chunks, i = [], 0
+    while i < len(words):
+        chunks.append(" ".join(words[i : i + size]))
+        i += size - overlap
+    return [c for c in chunks if c.strip()]
+
+
+def embed(client, texts):
+    resp = client.embeddings.create(model=EMBED_MODEL, input=texts)
+    return np.array([d.embedding for d in resp.data], dtype=np.float32)
+
+
+def top_k(query_vec, doc_vecs, k=3):
+    q = query_vec / (np.linalg.norm(query_vec) + 1e-9)
+    d = doc_vecs / (np.linalg.norm(doc_vecs, axis=1, keepdims=True) + 1e-9)
+    sims = d @ q
+    idx = np.argsort(sims)[::-1][:k]
+    return idx, sims[idx]
+
+
+def generate_answer(client, question, context):
+    prompt = (
+        "Answer the question using ONLY the context below. "
+        "If the answer is not in the context, reply exactly: 'Not found in context.'\n\n"
+        f"Context:\n{context}\n\nQuestion: {question}"
+    )
+    resp = client.chat.completions.create(
+        model=CHAT_MODEL,
+        messages=[{"role": "user", "content": prompt}],
+        temperature=0,
+    )
+    return resp.choices[0].message.content.strip()
+
+
+def evaluate(client, question, answer, context):
+    """LLM-as-judge groundedness check. Returns {score, verdict, reason}."""
+    rubric = (
+        "You are a strict RAG evaluator. Given a QUESTION, an ANSWER, and the "
+        "CONTEXT the answer was supposed to be grounded in, decide how well the "
+        "answer is SUPPORTED BY THE CONTEXT. Do not reward fluent wording. "
+        "Return JSON: {\"groundedness\": 0.0-1.0, \"verdict\": one of "
+        "['grounded','honest_refusal','confident_hallucination'], \"reason\": short}. "
+        "Rules: if the answer says it cannot find the info, verdict='honest_refusal' "
+        "and groundedness=1.0 (refusing when unsupported is correct). If the answer "
+        "makes a specific claim not supported by the context, verdict="
+        "'confident_hallucination' and groundedness<=0.3."
+    )
+    resp = client.chat.completions.create(
+        model=CHAT_MODEL,
+        messages=[
+            {"role": "system", "content": rubric},
+            {
+                "role": "user",
+                "content": f"QUESTION:\n{question}\n\nANSWER:\n{answer}\n\nCONTEXT:\n{context}",
+            },
+        ],
+        temperature=0,
+        response_format={"type": "json_object"},
+    )
+    try:
+        return json.loads(resp.choices[0].message.content)
+    except (json.JSONDecodeError, TypeError):
+        return {"groundedness": None, "verdict": "unknown", "reason": "eval parse failed"}
+
+
+# ------------------------------- UI -------------------------------
+st.set_page_config(page_title="Eval-First RAG", page_icon="🧪")
+st.title("🧪 Eval-First RAG")
+st.caption(
+    "A RAG app that scores its own answers — flags confident hallucinations, "
+    "not just retrieves and generates."
+)
+
+with st.sidebar:
+    st.header("Setup")
+    api_key = st.text_input("OpenAI API key", type="password")
+    st.markdown("**Corpus** (edit to test your own):")
+    doc = st.text_area("Document", SAMPLE_DOC, height=240)
+    st.markdown(
+        "Try: *What was FY2025 revenue?* (grounded) · "
+        "*What was the FY2025 dividend per share?* (should refuse) · "
+        "*What is Acme's 2026 revenue guidance?* (hallucination trap)"
+    )
+
+question = st.text_input("Ask a question about the document")
+
+if st.button("Run") and question:
+    if not api_key:
+        st.error("Add your OpenAI API key in the sidebar.")
+        st.stop()
+
+    client = OpenAI(api_key=api_key)
+    with st.spinner("Retrieving, answering, and evaluating..."):
+        chunks = chunk_text(doc)
+        doc_vecs = embed(client, chunks)
+        q_vec = embed(client, [question])[0]
+        idx, sims = top_k(q_vec, doc_vecs, k=3)
+        retrieved = [chunks[i] for i in idx]
+        context = "\n\n".join(retrieved)
+        answer = generate_answer(client, question, context)
+        report = evaluate(client, question, answer, context)
+
+    st.subheader("Answer")
+    st.write(answer)
+
+    st.subheader("🔬 Evaluation")
+    verdict = report.get("verdict", "unknown")
+    grounded = report.get("groundedness")
+    top_sim = float(sims[0]) if len(sims) else 0.0
+
+    c1, c2 = st.columns(2)
+    c1.metric("Retrieval confidence", f"{top_sim:.2f}")
+    c2.metric("Groundedness", "—" if grounded is None else f"{grounded:.2f}")
+
+    labels = {
+        "grounded": ("✅ Grounded", "Answer is supported by the retrieved context."),
+        "honest_refusal": ("✅ Honest refusal", "Correctly declined — info isn't in the context."),
+        "confident_hallucination": (
+            "⚠️ Confident hallucination",
+            "Answer makes a claim the context does NOT support. This is the dangerous case.",
+        ),
+        "unknown": ("❓ Unknown", "Evaluator could not parse a verdict."),
+    }
+    title, desc = labels.get(verdict, labels["unknown"])
+    (st.error if verdict == "confident_hallucination" else st.success)(f"**{title}** — {desc}")
+    if report.get("reason"):
+        st.caption(f"Judge: {report['reason']}")
+
+    with st.expander("Retrieved context (top 3 chunks + similarity)"):
+        for i, sim in zip(idx, sims):
+            st.markdown(f"**sim {sim:.2f}** — {chunks[i]}")

--- a/rag_tutorials/eval_first_rag/eval_first_rag.py
+++ b/rag_tutorials/eval_first_rag/eval_first_rag.py
@@ -23,21 +23,6 @@ load_dotenv()  # optional: read OPENAI_API_KEY from a local .env
 EMBED_MODEL = "text-embedding-3-small"
 CHAT_MODEL = "gpt-4o-mini"
 
-# A small built-in corpus of REAL, public financial facts so the app runs with
-# zero setup. Figures are Apple's reported FY2024 results (fiscal year ended
-# Sept 28, 2024) — stated as facts, not reproduced document prose.
-SAMPLE_DOC = """Apple Inc. - FY2024 financial summary (fiscal year ended September 28, 2024).
-Reported figures from Apple's public annual results.
-
-Total revenue (net sales) for FY2024 was $391.0 billion, up about 2% from $383.3 billion in FY2023.
-Services revenue reached a record $96.2 billion.
-Total company gross margin was 46.2%.
-Net income for FY2024 was $93.7 billion.
-Research and development expense was $31.4 billion.
-Apple returned cash to shareholders through share buybacks and dividends, and paid a quarterly cash dividend of $0.25 per share.
-"""
-
-
 def chunk_text(text, size=60, overlap=15):
     """Word-based chunking with overlap so sentence context is preserved."""
     words = text.split()
@@ -139,15 +124,19 @@ with st.sidebar:
         help="Paste ANY answer to score it against the retrieved context — a "
         "deterministic way to watch the evaluator catch a wrong answer. "
         "Leave empty to evaluate the model's own answer.",
-        placeholder="e.g. Apple reported FY2024 revenue of $450.0 billion.",
+        placeholder="e.g. paste an answer that contradicts your document.",
     )
-    st.markdown("**Corpus** (edit to test your own):")
-    doc = st.text_area("Document", SAMPLE_DOC, height=240)
+    st.markdown("**Document** (paste the text you want to query):")
+    doc = st.text_area(
+        "Document",
+        "",
+        height=240,
+        placeholder="Paste any document here — a 10-K excerpt, a report, notes...",
+    )
     st.markdown(
-        "**Strict mode:** *What was Apple's FY2024 revenue?* → grounded · "
-        "*How much did Apple spend on marketing?* → honest refusal.\n\n"
-        "**Loose mode:** *What was Tesla's FY2024 revenue?* → the model answers "
-        "from memory, ungrounded in this doc → ⚠️ confident hallucination."
+        "**To see each verdict:** ask something answered in your doc → *grounded* · "
+        "ask something not in it → *honest refusal* · use **Audit an answer** to "
+        "paste a claim your doc contradicts → *⚠️ confident hallucination*."
     )
 
 question = st.text_input("Ask a question about the document")
@@ -155,6 +144,9 @@ question = st.text_input("Ask a question about the document")
 if st.button("Run") and question:
     if not api_key:
         st.error("Add your OpenAI API key in the sidebar.")
+        st.stop()
+    if not doc.strip():
+        st.error("Paste a document in the sidebar first.")
         st.stop()
 
     client = OpenAI(api_key=api_key)

--- a/rag_tutorials/eval_first_rag/eval_first_rag.py
+++ b/rag_tutorials/eval_first_rag/eval_first_rag.py
@@ -23,17 +23,18 @@ load_dotenv()  # optional: read OPENAI_API_KEY from a local .env
 EMBED_MODEL = "text-embedding-3-small"
 CHAT_MODEL = "gpt-4o-mini"
 
-# A small built-in corpus so the app runs with zero setup. Numbers are specific
-# on purpose — they make hallucinations easy to catch.
-SAMPLE_DOC = """Acme Robotics - FY2025 Annual Report (excerpt)
+# A small built-in corpus of REAL, public financial facts so the app runs with
+# zero setup. Figures are Apple's reported FY2024 results (fiscal year ended
+# Sept 28, 2024) — stated as facts, not reproduced document prose.
+SAMPLE_DOC = """Apple Inc. - FY2024 financial summary (fiscal year ended September 28, 2024).
+Reported figures from Apple's public annual results.
 
-Revenue for fiscal year 2025 was $412.6 million, up 18% from $349.7 million in FY2024.
-Gross margin was 61.2%, compared to 58.9% in the prior year.
-Net income was $47.3 million, or $1.12 per diluted share.
-Research and development expense was $88.4 million, roughly 21% of revenue.
-The company ended the year with $210.0 million in cash and cash equivalents and no long-term debt.
-Acme shipped 24,500 industrial robot units in FY2025, up from 19,800 units in FY2024.
-The Board did not declare a dividend in FY2025.
+Total revenue (net sales) for FY2024 was $391.0 billion, up about 2% from $383.3 billion in FY2023.
+Services revenue reached a record $96.2 billion.
+Total company gross margin was 46.2%.
+Net income for FY2024 was $93.7 billion.
+Research and development expense was $31.4 billion.
+Apple returned cash to shareholders through share buybacks and dividends, and paid a quarterly cash dividend of $0.25 per share.
 """
 
 
@@ -138,14 +139,14 @@ with st.sidebar:
         help="Paste ANY answer to score it against the retrieved context — a "
         "deterministic way to watch the evaluator catch a wrong answer. "
         "Leave empty to evaluate the model's own answer.",
-        placeholder="e.g. Acme Robotics reported FY2025 revenue of $500.0 million.",
+        placeholder="e.g. Apple reported FY2024 revenue of $450.0 billion.",
     )
     st.markdown("**Corpus** (edit to test your own):")
     doc = st.text_area("Document", SAMPLE_DOC, height=240)
     st.markdown(
-        "**Strict mode:** *What was FY2025 revenue?* → grounded · "
-        "*FY2025 dividend per share?* → honest refusal.\n\n"
-        "**Loose mode:** *What was Apple's FY2019 revenue?* → the model answers "
+        "**Strict mode:** *What was Apple's FY2024 revenue?* → grounded · "
+        "*How much did Apple spend on marketing?* → honest refusal.\n\n"
+        "**Loose mode:** *What was Tesla's FY2024 revenue?* → the model answers "
         "from memory, ungrounded in this doc → ⚠️ confident hallucination."
     )
 

--- a/rag_tutorials/eval_first_rag/eval_first_rag.py
+++ b/rag_tutorials/eval_first_rag/eval_first_rag.py
@@ -60,12 +60,20 @@ def top_k(query_vec, doc_vecs, k=3):
     return idx, sims[idx]
 
 
-def generate_answer(client, question, context):
-    prompt = (
-        "Answer the question using ONLY the context below. "
-        "If the answer is not in the context, reply exactly: 'Not found in context.'\n\n"
-        f"Context:\n{context}\n\nQuestion: {question}"
-    )
+def generate_answer(client, question, context, strict=True):
+    if strict:
+        instruction = (
+            "Answer the question using ONLY the context below. "
+            "If the answer is not in the context, reply exactly: 'Not found in context.'"
+        )
+    else:
+        # "Loose" mode: the model may answer from general knowledge — this is how
+        # confident hallucinations happen, and how this app catches them.
+        instruction = (
+            "Answer the question. Use the context if relevant; otherwise answer "
+            "from your general knowledge. Always give a concrete answer."
+        )
+    prompt = f"{instruction}\n\nContext:\n{context}\n\nQuestion: {question}"
     resp = client.chat.completions.create(
         model=CHAT_MODEL,
         messages=[{"role": "user", "content": prompt}],
@@ -118,12 +126,27 @@ with st.sidebar:
     api_key = st.text_input(
         "OpenAI API key", type="password", value=os.getenv("OPENAI_API_KEY", "")
     )
+    mode = st.radio(
+        "Grounding mode",
+        ["Strict (context only)", "Loose (answer freely)"],
+        help="Loose lets the model answer from general knowledge — the fastest way "
+        "to see a confident hallucination get caught.",
+    )
+    strict = mode.startswith("Strict")
+    audit_answer = st.text_area(
+        "Audit an answer (optional)",
+        help="Paste ANY answer to score it against the retrieved context — a "
+        "deterministic way to watch the evaluator catch a wrong answer. "
+        "Leave empty to evaluate the model's own answer.",
+        placeholder="e.g. Acme Robotics reported FY2025 revenue of $500.0 million.",
+    )
     st.markdown("**Corpus** (edit to test your own):")
     doc = st.text_area("Document", SAMPLE_DOC, height=240)
     st.markdown(
-        "Try: *What was FY2025 revenue?* (grounded) · "
-        "*What was the FY2025 dividend per share?* (should refuse) · "
-        "*What is Acme's 2026 revenue guidance?* (hallucination trap)"
+        "**Strict mode:** *What was FY2025 revenue?* → grounded · "
+        "*FY2025 dividend per share?* → honest refusal.\n\n"
+        "**Loose mode:** *What was Apple's FY2019 revenue?* → the model answers "
+        "from memory, ungrounded in this doc → ⚠️ confident hallucination."
     )
 
 question = st.text_input("Ask a question about the document")
@@ -141,7 +164,10 @@ if st.button("Run") and question:
         idx, sims = top_k(q_vec, doc_vecs, k=3)
         retrieved = [chunks[i] for i in idx]
         context = "\n\n".join(retrieved)
-        answer = generate_answer(client, question, context)
+        if audit_answer.strip():
+            answer = audit_answer.strip()
+        else:
+            answer = generate_answer(client, question, context, strict=strict)
         report = evaluate(client, question, answer, context)
 
     st.subheader("Answer")

--- a/rag_tutorials/eval_first_rag/requirements.txt
+++ b/rag_tutorials/eval_first_rag/requirements.txt
@@ -1,3 +1,4 @@
 streamlit>=1.30
 openai>=1.30
 numpy>=1.24
+python-dotenv>=1.0

--- a/rag_tutorials/eval_first_rag/requirements.txt
+++ b/rag_tutorials/eval_first_rag/requirements.txt
@@ -1,0 +1,3 @@
+streamlit>=1.30
+openai>=1.30
+numpy>=1.24


### PR DESCRIPTION
## 🧪 Eval-First RAG

Adds a new app under `rag_tutorials/eval_first_rag/`.

### What it is
A Streamlit RAG app that doesn't stop at **retrieve → generate**. After every answer it runs an **evaluation pass** that scores retrieval confidence and answer groundedness, then returns one of three verdicts — `grounded`, `honest_refusal`, or `confident_hallucination` — so the dangerous case (a confident answer the retrieved context doesn't support) is visible in the loop, not discovered in prod.

### Why it's different
Every RAG entry here shows how to *build* a pipeline. This one shows how to *trust* one. That distinction matters most in finance/health/legal RAG, where a confident wrong answer is worse than an honest "I don't know" — yet most setups score both the same.

### Bring your own document (no bundled data)
Paste any text — a 10-K excerpt, a report, meeting notes — and query it. Three ways to see each verdict:
- **Grounded**: ask something your document answers
- **Honest refusal**: ask something not in it (Strict mode)
- **Confident hallucination**: switch to **Loose mode**, or use **Audit an answer** to paste a claim your document contradicts — the evaluator flags it in red with groundedness ~0 and cites the exact mismatch

### Runs with just an OpenAI key
- Single file + `requirements.txt`; key via sidebar or a local `.env`
- Minimal stack: OpenAI embeddings + `gpt-4o-mini` + NumPy cosine search — no vector DB

### How to run
```bash
cd rag_tutorials/eval_first_rag
pip install -r requirements.txt
streamlit run eval_first_rag.py
```

### Conventions followed
- [x] New folder under the right category (`rag_tutorials/`)
- [x] `README.md` with description, features, and run steps
- [x] `requirements.txt` included
- [x] Self-contained and runnable
- [x] No API keys or bundled data committed

Built on the eval-first approach behind my [finrag-eval](https://github.com/Ruthwik-Data/finrag-eval), where the same method surfaced a metric bug now merged into DeepEval.
