### PR TITLE
Add a self-contained work-history MCP tutorial

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,7 @@ streamlit run travel_agent.py
 *   [♾️ Browser MCP Agent](mcp_ai_agents/browser_mcp_agent/) - Drive a real browser with natural language over MCP
 *   [🐙 GitHub MCP Agent](mcp_ai_agents/github_mcp_agent/) - Explore and analyze any repo in plain English
 *   [📑 Notion MCP Agent](mcp_ai_agents/notion_mcp_agent) - Talk to your Notion pages from the terminal
+*   [🧠 Screenpipe Work Memory Agent](mcp_ai_agents/screenpipe_work_memory_agent/) - Ask questions about real screen, audio, meeting, and input history through a local MCP server
 *   [🌍 AI Travel Planner MCP Agent](mcp_ai_agents/ai_travel_planner_mcp_agent_team) - Itineraries built on live Airbnb and Google Maps data
 *   [🔀 Multi-MCP Agent Router](mcp_ai_agents/multi_mcp_agent_router/) - Specialist agents, each wired to its own MCP server
 

--- a/mcp_ai_agents/screenpipe_work_memory_agent/.env.example
+++ b/mcp_ai_agents/screenpipe_work_memory_agent/.env.example
@@ -1,0 +1,9 @@
+OPENAI_API_KEY=your-openai-api-key
+OPENAI_MODEL=gpt-4o-mini
+
+# Optional: point the OpenAI client at a compatible local model server.
+# OPENAI_BASE_URL=http://localhost:11434/v1
+
+# Optional: override local screenpipe endpoints or the MCP launch command.
+# SCREENPIPE_HEALTH_URL=http://localhost:3030/health
+# SCREENPIPE_MCP_COMMAND=npx -y screenpipe-mcp

--- a/mcp_ai_agents/screenpipe_work_memory_agent/README.md
+++ b/mcp_ai_agents/screenpipe_work_memory_agent/README.md
@@ -1,0 +1,112 @@
+# Screenpipe Work Memory Agent
+
+This MCP agent answers questions about what actually happened on your computer.
+It searches local screen recordings, audio transcripts, meetings, input events,
+and UI context captured by [screenpipe](https://screenpipe.com).
+
+Instead of pasting context into every prompt, ask questions such as:
+
+- "Summarize what I worked on in the last two hours, grouped by project."
+- "What did I promise during my meeting with Alex last week?"
+- "Find the page where I saw that pricing."
+- "Turn the client onboarding process I followed yesterday into an SOP."
+- "Which repeated steps from this week are good automation candidates?"
+
+## How it works
+
+```text
+screenpipe on your computer
+    -> local screenpipe API
+    -> screenpipe-mcp
+    -> work memory agent
+    -> your configured LLM
+```
+
+The agent uses screenpipe MCP tools to summarize activity, search OCR and audio,
+inspect meetings and UI elements, and export recordings. It is instructed to
+ground answers in observed evidence and label inferred SOP steps.
+
+## Prerequisites
+
+- Python 3.10+
+- Node.js 18+ with `npx`
+- screenpipe installed, running, and allowed to record the context you want to query
+- An OpenAI API key, or an OpenAI-compatible local model endpoint
+
+Download screenpipe from [screenpipe.com](https://screenpipe.com) or build it
+from the [source-available repository](https://github.com/screenpipe/screenpipe).
+
+## Setup
+
+```bash
+git clone https://github.com/Shubhamsaboo/awesome-llm-apps.git
+cd awesome-llm-apps/mcp_ai_agents/screenpipe_work_memory_agent
+
+python -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+
+cp .env.example .env
+```
+
+Add your key to `.env`:
+
+```env
+OPENAI_API_KEY=your-openai-api-key
+OPENAI_MODEL=gpt-4o-mini
+```
+
+Check that screenpipe and `npx` are ready:
+
+```bash
+python screenpipe_work_memory_agent.py --check
+```
+
+## Run
+
+Start an interactive session:
+
+```bash
+python screenpipe_work_memory_agent.py
+```
+
+Or run one question:
+
+```bash
+python screenpipe_work_memory_agent.py \
+  "Summarize my work from the last two hours with supporting evidence"
+```
+
+The app launches the published `screenpipe-mcp` package with:
+
+```bash
+npx -y screenpipe-mcp
+```
+
+## Use a local model
+
+Any OpenAI-compatible endpoint can be used. For example, with Ollama:
+
+```env
+OPENAI_API_KEY=ollama
+OPENAI_MODEL=qwen3:8b
+OPENAI_BASE_URL=http://localhost:11434/v1
+```
+
+## Privacy boundary
+
+The screenpipe MCP server talks only to the local screenpipe API and stores no
+data itself. The context returned by MCP tools is still sent to the LLM endpoint
+you configure. Use a local endpoint when work data must remain on the device.
+
+You control what screenpipe records, which apps and URLs are excluded, and how
+long local data is retained.
+
+## Embed capture in your own application
+
+This example uses the installed screenpipe app because that is the fastest way
+to try the agent. To embed capture directly in an Electron, Swift, or Tauri app,
+see the runnable
+[screenpipe SDK examples](https://github.com/screenpipe/screenpipe/tree/main/ee/sdk/examples),
+including the
+[Electron recorder example](https://github.com/screenpipe/screenpipe/tree/main/ee/sdk/examples/electron-app).

--- a/mcp_ai_agents/screenpipe_work_memory_agent/requirements.txt
+++ b/mcp_ai_agents/screenpipe_work_memory_agent/requirements.txt
@@ -1,0 +1,4 @@
+agno>=2.2.10
+mcp
+openai
+python-dotenv

--- a/mcp_ai_agents/screenpipe_work_memory_agent/screenpipe_work_memory_agent.py
+++ b/mcp_ai_agents/screenpipe_work_memory_agent/screenpipe_work_memory_agent.py
@@ -1,0 +1,160 @@
+import argparse
+import asyncio
+import json
+import os
+import shutil
+import sys
+from textwrap import dedent
+from urllib.error import HTTPError, URLError
+from urllib.request import Request, urlopen
+
+from agno.agent import Agent
+from agno.models.openai import OpenAIChat
+from agno.tools.mcp import MCPTools
+from dotenv import load_dotenv
+
+
+load_dotenv()
+
+HEALTH_URL = os.getenv("SCREENPIPE_HEALTH_URL", "http://localhost:3030/health")
+MCP_COMMAND = os.getenv("SCREENPIPE_MCP_COMMAND", "npx -y screenpipe-mcp")
+MODEL_ID = os.getenv("OPENAI_MODEL", "gpt-4o-mini")
+
+
+def screenpipe_health(timeout: float = 3.0) -> tuple[bool, str]:
+    request = Request(HEALTH_URL, headers={"Accept": "application/json"})
+    try:
+        with urlopen(request, timeout=timeout) as response:
+            payload = json.load(response)
+    except HTTPError as error:
+        return False, f"screenpipe health check returned HTTP {error.code}"
+    except (URLError, TimeoutError, json.JSONDecodeError) as error:
+        return False, f"cannot reach screenpipe at {HEALTH_URL}: {error}"
+
+    status = payload.get("status", "unknown")
+    version = payload.get("version", "unknown")
+    if response.status != 200:
+        return False, f"screenpipe reported HTTP {response.status} ({status})"
+    return True, f"screenpipe {version} is reachable ({status})"
+
+
+def environment_errors(require_model: bool = True) -> list[str]:
+    errors = []
+    if shutil.which("npx") is None:
+        errors.append("Node.js and npx are required to launch screenpipe-mcp")
+    if require_model and not os.getenv("OPENAI_API_KEY"):
+        errors.append(
+            "OPENAI_API_KEY is required; for a local OpenAI-compatible server, "
+            "set it to any non-empty value"
+        )
+
+    healthy, message = screenpipe_health()
+    if not healthy:
+        errors.append(message)
+    return errors
+
+
+def build_model() -> OpenAIChat:
+    options = {
+        "id": MODEL_ID,
+        "api_key": os.environ["OPENAI_API_KEY"],
+    }
+    base_url = os.getenv("OPENAI_BASE_URL")
+    if base_url:
+        options["base_url"] = base_url
+    return OpenAIChat(**options)
+
+
+def build_agent(mcp_tools: MCPTools) -> Agent:
+    return Agent(
+        name="ScreenpipeWorkMemoryAgent",
+        model=build_model(),
+        tools=[mcp_tools],
+        description=(
+            "An evidence-first work memory agent backed by the user's local "
+            "screenpipe history."
+        ),
+        instructions=dedent(
+            """
+            You answer questions about the user's real computer activity using
+            the screenpipe MCP tools.
+
+            Rules:
+            - Use screenpipe tools before answering questions about past work.
+            - Treat tool results as evidence. Do not invent missing activity.
+            - State the time range you searched and mention relevant apps,
+              meetings, or speakers when the evidence includes them.
+            - Prefer compact activity summaries before broad raw searches.
+            - Narrow searches by time, app, window, speaker, or content type.
+            - When asked for an SOP, reconstruct ordered steps and clearly mark
+              any step that is inferred rather than directly observed.
+            - When asked what to automate, identify repeated actions and cite
+              the observed pattern before proposing an automation.
+            - Avoid exposing unrelated sensitive content from tool results.
+            """
+        ),
+        markdown=True,
+        add_history_to_context=True,
+        num_history_runs=5,
+        retries=2,
+    )
+
+
+async def run_agent(query: str | None) -> None:
+    env = os.environ.copy()
+    async with MCPTools(command=MCP_COMMAND, env=env) as mcp_tools:
+        agent = build_agent(mcp_tools)
+        if query:
+            response = await agent.arun(query)
+            print(response.content)
+            return
+
+        await agent.acli_app(
+            user="You",
+            stream=True,
+            markdown=True,
+            exit_on=["exit", "quit", "bye"],
+        )
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Ask an AI agent about your local screenpipe work history."
+    )
+    parser.add_argument(
+        "query",
+        nargs="?",
+        help="Run one question and exit. Omit it to start an interactive session.",
+    )
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Check local prerequisites without starting the agent.",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    errors = environment_errors(require_model=not args.check)
+    if errors:
+        print("Setup check failed:", file=sys.stderr)
+        for error in errors:
+            print(f"- {error}", file=sys.stderr)
+        return 1
+
+    healthy, message = screenpipe_health()
+    print(message)
+    if args.check:
+        print("npx is available; setup is ready for an LLM key")
+        return 0
+
+    try:
+        asyncio.run(run_agent(args.query))
+    except KeyboardInterrupt:
+        print("\nStopped.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
This tutorial teaches bounded work-history retrieval over stdio MCP and source-cited generation. It includes a read-only MCP server, four fictional activity records, a Python client, and tests. The local retrieval demo runs without an account, recorder, Screenpipe installation, or LLM credentials.

The revised example replaces the product-dependent wrapper. It removes the marketing image, commercial SDK links, and product installation requirement. Screenpipe appears only as an optional documented capture source alongside manually authored logs and application exports.

Validation on September 16, 2026:
- Installed dependencies in a fresh Python 3.12 virtual environment.
- Four retrieval-contract tests pass: project/time bounds, truncation, keyword/missing evidence, and invalid inputs.
- Ran the actual MCP stdio client/server with `--inspect`; it returned the three Atlas records and excluded Orion.
- Python compilation passes.
- LLM generation has not been exercised against a paid provider; the README states the data flow and model-dependent limits.

Disclosure: I maintain Screenpipe.
