### PR TITLE
Add Manifest — structured action maps for AI agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,7 @@ streamlit run travel_agent.py
 *   [📑 Notion MCP Agent](mcp_ai_agents/notion_mcp_agent) - Talk to your Notion pages from the terminal
 *   [🌍 AI Travel Planner MCP Agent](mcp_ai_agents/ai_travel_planner_mcp_agent_team) - Itineraries built on live Airbnb and Google Maps data
 *   [🔀 Multi-MCP Agent Router](mcp_ai_agents/multi_mcp_agent_router/) - Specialist agents, each wired to its own MCP server
+*   [🗺️ Manifest](https://omfang.io/manifest-overview) - Converts any webpage into a structured JSON action map so agents know what they can do on a page — buttons, forms, inputs, required fields, cross-action dependencies
 
 ### 📀 RAG (Retrieval Augmented Generation)
 


### PR DESCRIPTION
Manifest converts any webpage into a structured JSON action map — buttons, forms, inputs, required fields, and cross-action dependencies — so AI agents know what they can *do* on a page, not just what's on it.

Homepage: https://omfang.io/manifest-overview
Docs: https://omfang.io/manifest-docs
PyPI: `pip install manifest-api`
MCP server: available on Smithery and Glama