### PR TITLE
feat: Add Quay (Autonomous AI Software Factory)

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@ streamlit run travel_agent.py
 ### 🚀 Advanced AI Agents
 *Production-style agents with tools, memory, and multi-step reasoning.*
 
+*   [🔀 A3M Router](https://github.com/Das-rebel/a3m-router) - Adaptive multi-model LLM router with parallel ensemble routing, Shapley value credit allocation, game-theoretic risk profiling, 47+ providers, circuit breaker, semantic cache, guardrails, ObsidianVault memory, multimodal routing. 19K+ npm downloads, highest robustness (0.8524) on RouterArena. <sub>↗ external</sub>
 *   [🏚️ 🍌 AI Home Renovation Agent with Nano Banana Pro](advanced_ai_agents/multi_agent_apps/ai_home_renovation_agent)
 *   [🧠 DevPulse AI - Multi-Agent Signal Intelligence](advanced_ai_agents/multi_agent_apps/devpulse_ai/)
 *   [🔍 AI Deep Research Agent](advanced_ai_agents/single_agent_apps/ai_deep_research_agent/)

--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ streamlit run travel_agent.py
 
 *   [🔀 A3M Router](https://github.com/Das-rebel/a3m-router) - Adaptive multi-model LLM router with parallel ensemble routing, Shapley value credit allocation, game-theoretic risk profiling, 47+ providers, circuit breaker, semantic cache, guardrails, ObsidianVault memory, multimodal routing. 19K+ npm downloads, highest robustness (0.8524) on RouterArena. <sub>↗ external</sub>
 *   [🏚️ 🍌 AI Home Renovation Agent with Nano Banana Pro](advanced_ai_agents/multi_agent_apps/ai_home_renovation_agent)
+*   [⚓ Quay](https://github.com/Das-rebel/quay) - Autonomous AI Software Factory. Self-hosted AI agents with customizable pipelines, MCP integration, real-time Mission Control dashboard, cost tracking. TypeScript/Svelte, MIT license. <sub>↗ external</sub>
 *   [🧠 DevPulse AI - Multi-Agent Signal Intelligence](advanced_ai_agents/multi_agent_apps/devpulse_ai/)
 *   [🔍 AI Deep Research Agent](advanced_ai_agents/single_agent_apps/ai_deep_research_agent/)
 *   [📊 AI VC Due Diligence Agent Team](advanced_ai_agents/multi_agent_apps/agent_teams/ai_vc_due_diligence_agent_team)


### PR DESCRIPTION
## Add Quay

**Quay** is an open-source Autonomous AI Software Factory:

- Self-hosted AI agents with customizable pipelines
- MCP (Model Context Protocol) integration  
- Real-time Mission Control dashboard
- Cost tracking and transparency
- TypeScript/Svelte, MIT license
- npm: quay-ai-factory (1,500+ monthly downloads)

GitHub: https://github.com/Das-rebel/quay