### PR TITLE
docs: fix research agent startup command

### DIFF
--- a/starter_ai_agents/openai_research_agent/README.md
+++ b/starter_ai_agents/openai_research_agent/README.md
@@ -38,7 +38,7 @@ export OPENAI_API_KEY='your-api-key-here'
 
 4. Run the team of AI Agents
 ```bash
-streamlit run openai_researcher_agent.py
+streamlit run research_agent.py
 ```
 
 Then open your browser and navigate to the URL shown in the terminal (typically http://localhost:8501).


### PR DESCRIPTION
## Summary

Correct the OpenAI Researcher Agent quick-start command to use the checked-in Streamlit entrypoint, `research_agent.py`.

## Root cause and impact

The README referenced `openai_researcher_agent.py`, which does not exist in the example directory. Following the documented command therefore fails before Streamlit can launch the application.

## Validation

- `python -m py_compile starter_ai_agents/openai_research_agent/research_agent.py`
- verified `research_agent.py` exists and the previously documented filename does not
- `git diff --check`

This changes documentation only; no agent behavior or dependencies are modified.
