### PR TITLE
Add Manifest MCP Agent — structured action maps for AI agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,7 @@ streamlit run travel_agent.py
 *   [📑 Notion MCP Agent](mcp_ai_agents/notion_mcp_agent) - Talk to your Notion pages from the terminal
 *   [🌍 AI Travel Planner MCP Agent](mcp_ai_agents/ai_travel_planner_mcp_agent_team) - Itineraries built on live Airbnb and Google Maps data
 *   [🔀 Multi-MCP Agent Router](mcp_ai_agents/multi_mcp_agent_router/) - Specialist agents, each wired to its own MCP server
+*   [🗺️ Manifest MCP Agent](mcp_ai_agents/manifest_mcp_agent/) - Turn any URL into a structured JSON action map so agents know what they can do on a page — buttons, forms, inputs, required fields, cross-action dependencies
 *   [🗺️ Manifest](https://omfang.io/manifest-overview) - Converts any webpage into a structured JSON action map so agents know what they can do on a page — buttons, forms, inputs, required fields, cross-action dependencies
 
 ### 📀 RAG (Retrieval Augmented Generation)

--- a/README.md
+++ b/README.md
@@ -194,6 +194,7 @@ streamlit run travel_agent.py
 *   [📑 Notion MCP Agent](mcp_ai_agents/notion_mcp_agent) - Talk to your Notion pages from the terminal
 *   [🌍 AI Travel Planner MCP Agent](mcp_ai_agents/ai_travel_planner_mcp_agent_team) - Itineraries built on live Airbnb and Google Maps data
 *   [🔀 Multi-MCP Agent Router](mcp_ai_agents/multi_mcp_agent_router/) - Specialist agents, each wired to its own MCP server
+*   [🗺️ Manifest](https://omfang.io/manifest-overview) - Converts any webpage into a structured JSON action map so agents know what they can do on a page — buttons, forms, inputs, required fields, cross-action dependencies
 
 ### 📀 RAG (Retrieval Augmented Generation)
 

--- a/mcp_ai_agents/manifest_mcp_agent/.env.example
+++ b/mcp_ai_agents/manifest_mcp_agent/.env.example
@@ -1,0 +1,6 @@
+# Get your Manifest API key free at https://app.manifest.omfang.io
+MANIFEST_API_KEY=your-manifest-api-key
+
+# Add at least one LLM key
+OPENAI_API_KEY=your-openai-api-key
+ANTHROPIC_API_KEY=your-anthropic-api-key

--- a/mcp_ai_agents/manifest_mcp_agent/README.md
+++ b/mcp_ai_agents/manifest_mcp_agent/README.md
@@ -1,0 +1,85 @@
+# 🗺️ Manifest MCP Agent
+
+A Streamlit app that turns any URL into a structured action map using the [Manifest API](https://omfang.io/manifest-overview), then uses an LLM to reason about what an agent could do on that page.
+
+## What it does
+
+- Paste any URL and call the Manifest API with one click
+- See every action on the page: buttons, forms, inputs — with types, required flags, and cross-action dependencies
+- Ask an LLM (OpenAI or Anthropic) to describe how an agent would interact with the page based on the manifest
+- No screenshots, no brittle selectors — structured JSON that agents can act on directly
+
+## Why Manifest?
+
+Most agents interact with web UIs by screenshotting and guessing, or through hand-written selectors that break on every redesign. Manifest sits between a browser tool and your agent logic: it returns a structured description of what the agent can *do* on the page, not just what's on it.
+
+## Setup
+
+### Requirements
+
+- Python 3.9+
+- A Manifest API key — get one free at [app.manifest.omfang.io](https://app.manifest.omfang.io)
+- An OpenAI or Anthropic API key
+
+### Installation
+
+1. Clone this repository:
+   ```bash
+   git clone https://github.com/Shubhamsaboo/awesome-llm-apps.git
+   cd mcp_ai_agents/manifest_mcp_agent
+   ```
+
+2. Install dependencies:
+   ```bash
+   pip install -r requirements.txt
+   ```
+
+3. Set up your API keys:
+   ```bash
+   cp .env.example .env
+   # Edit .env and add your keys
+   ```
+
+4. Run the app:
+   ```bash
+   streamlit run main.py
+   ```
+
+## Usage
+
+1. Enter any URL in the input field
+2. Click **Generate Manifest** to fetch the action map
+3. Browse the structured JSON — every action with its locator, type, required flag, and dependencies
+4. Click **Explain agent plan** to have the LLM describe how an agent would interact with the page
+
+## Example output
+
+```json
+{
+  "url": "https://example.com/checkout",
+  "current_page_state": "Checkout form with email and payment fields",
+  "actions": [
+    {
+      "id": "email",
+      "label": "Email address",
+      "type": "email",
+      "required": true,
+      "locator": {"css": "input[type='email']", "role": "input"}
+    },
+    {
+      "id": "place-order",
+      "label": "Place order",
+      "type": "button",
+      "required": false,
+      "requires": ["email", "card-number"]
+    }
+  ]
+}
+```
+
+## Links
+
+- [Manifest homepage](https://omfang.io/manifest-overview)
+- [Manifest docs](https://omfang.io/manifest-docs)
+- [Live demo (no account needed)](https://demo.manifest.omfang.io/demo)
+- [PyPI](https://pypi.org/project/manifest-api/)

--- a/mcp_ai_agents/manifest_mcp_agent/README.md
+++ b/mcp_ai_agents/manifest_mcp_agent/README.md
@@ -1,6 +1,6 @@
 # 🗺️ Manifest MCP Agent
 
-A Streamlit app that turns any URL into a structured action map using the [Manifest API](https://omfang.io/manifest-overview), then uses an LLM to reason about what an agent could do on that page.
+A Streamlit app that turns any URL into a structured action map using the [Manifest API](https://omfang.io/), then uses an LLM to reason about what an agent could do on that page.
 
 ## What it does
 

--- a/mcp_ai_agents/manifest_mcp_agent/main.py
+++ b/mcp_ai_agents/manifest_mcp_agent/main.py
@@ -1,0 +1,93 @@
+import streamlit as st
+import requests
+import json
+import os
+from dotenv import load_dotenv
+
+load_dotenv()
+
+MANIFEST_API_KEY = os.getenv("MANIFEST_API_KEY")
+OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
+ANTHROPIC_API_KEY = os.getenv("ANTHROPIC_API_KEY")
+
+st.set_page_config(page_title="Manifest MCP Agent", page_icon="🗺️", layout="wide")
+st.title("🗺️ Manifest MCP Agent")
+st.markdown(
+    "Turn any URL into a structured action map, then let an LLM reason about "
+    "what an agent could do on that page."
+)
+
+url = st.text_input("Enter a URL", placeholder="https://example.com/checkout")
+
+col1, col2 = st.columns([1, 1])
+
+manifest_data = None
+
+with col1:
+    if st.button("Generate Manifest", type="primary", disabled=not url):
+        if not MANIFEST_API_KEY:
+            st.error("MANIFEST_API_KEY not set in .env")
+        else:
+            with st.spinner("Calling Manifest API..."):
+                try:
+                    resp = requests.post(
+                        "https://api.manifest.omfang.io/manifest",
+                        headers={"X-API-Key": MANIFEST_API_KEY, "Content-Type": "application/json"},
+                        json={"url": url},
+                        timeout=30,
+                    )
+                    resp.raise_for_status()
+                    manifest_data = resp.json()
+                    st.session_state["manifest"] = manifest_data
+                except requests.exceptions.RequestException as e:
+                    st.error(f"API error: {e}")
+
+if "manifest" in st.session_state:
+    manifest_data = st.session_state["manifest"]
+    
+    st.subheader("Page state")
+    st.info(manifest_data.get("current_page_state", "Unknown"))
+
+    st.subheader(f"Actions ({len(manifest_data.get('actions', []))})")
+    for action in manifest_data.get("actions", []):
+        with st.expander(f"{action.get('label', action.get('id'))} — `{action.get('type')}` {'🔴 required' if action.get('required') else ''}"):
+            st.json(action)
+
+    if manifest_data.get("navigation"):
+        st.subheader("Navigation")
+        for nav in manifest_data["navigation"]:
+            st.markdown(f"- [{nav.get('label')}]({nav.get('url')})")
+
+    st.divider()
+    
+    if st.button("Explain agent plan"):
+        if not OPENAI_API_KEY and not ANTHROPIC_API_KEY:
+            st.error("Set OPENAI_API_KEY or ANTHROPIC_API_KEY in .env")
+        else:
+            prompt = (
+                f"You are an AI agent. You have been given this action manifest for the URL {manifest_data.get('url')}:\n\n"
+                f"{json.dumps(manifest_data, indent=2)}\n\n"
+                "Describe step by step how you would interact with this page to complete a typical task. "
+                "Reference specific action IDs, note required fields, and explain the order of operations based on the requires field."
+            )
+            with st.spinner("Thinking..."):
+                if OPENAI_API_KEY:
+                    import openai
+                    client = openai.OpenAI(api_key=OPENAI_API_KEY)
+                    response = client.chat.completions.create(
+                        model="gpt-4o-mini",
+                        messages=[{"role": "user", "content": prompt}],
+                    )
+                    plan = response.choices[0].message.content
+                else:
+                    import anthropic
+                    client = anthropic.Anthropic(api_key=ANTHROPIC_API_KEY)
+                    message = client.messages.create(
+                        model="claude-haiku-4-5",
+                        max_tokens=1024,
+                        messages=[{"role": "user", "content": prompt}],
+                    )
+                    plan = message.content[0].text
+
+            st.subheader("Agent interaction plan")
+            st.markdown(plan)

--- a/mcp_ai_agents/manifest_mcp_agent/main.py
+++ b/mcp_ai_agents/manifest_mcp_agent/main.py
@@ -31,7 +31,7 @@ with col1:
             with st.spinner("Calling Manifest API..."):
                 try:
                     resp = requests.post(
-                        "https://api.manifest.omfang.io/manifest",
+                        "https://manifest.omfang.io/manifest",
                         headers={"X-API-Key": MANIFEST_API_KEY, "Content-Type": "application/json"},
                         json={"url": url},
                         timeout=30,
@@ -83,7 +83,7 @@ if "manifest" in st.session_state:
                     import anthropic
                     client = anthropic.Anthropic(api_key=ANTHROPIC_API_KEY)
                     message = client.messages.create(
-                        model="claude-haiku-4-5",
+                        model="claude-haiku-4-5-20251001",
                         max_tokens=1024,
                         messages=[{"role": "user", "content": prompt}],
                     )

--- a/mcp_ai_agents/manifest_mcp_agent/requirements.txt
+++ b/mcp_ai_agents/manifest_mcp_agent/requirements.txt
@@ -1,0 +1,5 @@
+streamlit>=1.32.0
+requests>=2.31.0
+python-dotenv>=1.0.0
+openai>=1.0.0
+anthropic>=0.20.0


### PR DESCRIPTION
This PR adds a self-contained Manifest MCP Agent example under `mcp_ai_agents/manifest_mcp_agent/`.

**What it does:** A Streamlit app that calls the Manifest API to convert any URL into a structured JSON action map, then uses an LLM to reason about how an agent would interact with the page.

**Files:**
- `main.py` — Streamlit app
- `README.md` — setup and usage instructions
- `requirements.txt` — dependencies
- `.env.example` — required API keys

**Manifest API:** Free tier available at app.manifest.omfang.io — no screenshots, no brittle selectors, structured JSON an agent can act on directly.

Closes the previous link-only PR.