### PR TITLE
docs: fix research agent startup command

### DIFF
--- a/starter_ai_agents/openai_research_agent/README.md
+++ b/starter_ai_agents/openai_research_agent/README.md
@@ -38,7 +38,7 @@ export OPENAI_API_KEY='your-api-key-here'
 
 4. Run the team of AI Agents
 ```bash
-streamlit run openai_researcher_agent.py
+streamlit run research_agent.py
 ```
 
 Then open your browser and navigate to the URL shown in the terminal (typically http://localhost:8501).


### PR DESCRIPTION
Corrects the README quick-start command for the OpenAI Researcher Agent to use the existing `research_agent.py` entrypoint instead of the nonexistent `openai_researcher_agent.py`.

Closes #966