### PR TITLE
Add release-radar always-on agent: brief me when my deps ship breaking or security changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ streamlit run travel_agent.py
 *Background agents that run on schedules or events, monitor changing context, decide what needs attention, and proactively deliver updates, artifacts, or actions.*
 
 *   [📰 Always-on Hacker News Briefing Agent](always_on_agents/always_on_hn_briefing_agent/) - A scheduled scout that ships a ranked daily brief to Slack or email
+*   [📡 Release Radar Agent](always_on_agents/release_radar_agent/) - Watches dependency releases and briefs you on breaking, deprecated, security, and major-version changes
 
 ### 🤝 Multi-agent Teams
 

--- a/always_on_agents/release_radar_agent/README.md
+++ b/always_on_agents/release_radar_agent/README.md
@@ -1,0 +1,162 @@
+# 📡 Release Radar Agent
+
+Release Radar is an always-on dependency briefing agent built with Google ADK. It reads `requirements.txt` or `package.json`, checks mapped dependencies against GitHub releases, and reports only changes that need attention: breaking changes, deprecations, security fixes, yanked releases, and major-version upgrades.
+
+The app runs interactively in ADK Web or as a scheduled FastAPI service. Sample mode is deterministic and makes no GitHub requests. Scheduled delivery defaults to dry-run and remains off until Gmail or webhook settings are present.
+
+## Features
+
+- **Manifest parsing**: Reads Python requirements plus npm runtime and development dependencies.
+- **GitHub release scanning**: Uses the GitHub REST API with an optional token.
+- **Impact ranking**: Scores security, breaking, yanked, major-version, and deprecation signals.
+- **Patch-noise filtering**: Drops routine patch and minor releases without an impact signal.
+- **Text and HTML briefs**: Groups changes by dependency with version delta, reason, impact, and release link.
+- **Google ADK agent**: Exposes `root_agent` for interactive dependency questions.
+- **Scheduler hooks**: Accepts direct HTTP and Pub/Sub triggers.
+- **Opt-in delivery**: Supports Gmail and generic webhooks only when explicitly configured.
+
+## How It Works
+
+1. `radar.py` parses a manifest and maps known packages or GitHub dependency URLs to repositories.
+2. Sample mode loads deterministic GitHub-shaped data. Live mode fetches recent GitHub releases.
+3. `ranker.py` classifies release notes and filters routine noise.
+4. `delivery.py` renders the selected releases as text and HTML.
+5. ADK Web returns the brief interactively, while `scheduler_api.py` exposes scheduled HTTP and Pub/Sub paths.
+6. The scheduler sends only when `dry_run=false` and Gmail or webhook configuration is present.
+
+The source modules use the Python standard library for manifest parsing, GitHub access, rendering, and delivery. FastAPI provides the scheduler surface, and Google ADK provides the interactive agent.
+
+## Requirements
+
+- Python 3.10+
+- Gemini API key for ADK Web
+- A project `requirements.txt` or `package.json` for live scans
+- Optional GitHub token for higher API rate limits
+- Optional Gmail OAuth credentials or a webhook URL for delivery
+
+## Installation
+
+```bash
+git clone https://github.com/Shubhamsaboo/awesome-llm-apps.git
+cd awesome-llm-apps/always_on_agents/release_radar_agent
+pip install -r requirements.txt
+export GOOGLE_API_KEY="your_gemini_api_key"
+```
+
+## Run in ADK Web
+
+Start with deterministic sample data:
+
+```bash
+adk web .
+```
+
+Open ADK Web, select `release_radar_agent`, and try:
+
+```text
+Give me today's dependency release brief.
+```
+
+To scan a real project, set an absolute manifest path and enable live GitHub requests before starting ADK Web:
+
+```bash
+export RELEASE_RADAR_MANIFEST="/absolute/path/to/requirements.txt"
+export RELEASE_RADAR_LIVE_GITHUB=true
+export RELEASE_RADAR_GITHUB_TOKEN="optional_github_token"
+adk web .
+```
+
+Release Radar recognizes direct GitHub dependency URLs and common packages such as Pydantic, FastAPI, Requests, OpenAI, Anthropic, Google ADK, LangChain, React, Vite, and Zod. Unmapped dependencies appear in the scan notes instead of stopping the brief.
+
+## Run the Scheduler API
+
+Set the project manifest in the service environment, then start the backend from this directory:
+
+```bash
+export RELEASE_RADAR_MANIFEST="/workspace/requirements.txt"
+export RELEASE_RADAR_LIVE_GITHUB=true
+uvicorn scheduler_api:app --host 0.0.0.0 --port 8000
+```
+
+Preview the deterministic sample brief without delivery:
+
+```bash
+curl "http://127.0.0.1:8000/release-radar/dry-run?top_n=5&live=false"
+```
+
+Scan a manifest through the scheduler path while keeping delivery off:
+
+```bash
+curl -X POST "http://127.0.0.1:8000/release-radar/trigger" \
+  -H "Content-Type: application/json" \
+  -d '{"dry_run": true, "live": true, "top_n": 10}'
+```
+
+The server reads its manifest only from `RELEASE_RADAR_MANIFEST`, so request payloads cannot select arbitrary local files. The path must exist inside the scheduler service. Set `RELEASE_RADAR_GITHUB_TOKEN` in the service environment when scanning many repositories.
+
+## Enable Delivery
+
+Delivery has two independent guards. The request must set `"dry_run": false`, and one provider must be fully configured. Without both, the API returns a skipped status and sends nothing.
+
+### Gmail
+
+Create a Google OAuth client with Gmail API access and a refresh token using the `https://www.googleapis.com/auth/gmail.send` scope, then set:
+
+```bash
+export RELEASE_RADAR_DELIVERY="gmail"
+export RELEASE_RADAR_EMAIL_TO="you@example.com"
+export RELEASE_RADAR_EMAIL_FROM="you@example.com"
+export RELEASE_RADAR_GMAIL_CLIENT_ID="your_google_oauth_client_id"
+export RELEASE_RADAR_GMAIL_CLIENT_SECRET="your_google_oauth_client_secret"
+export RELEASE_RADAR_GMAIL_REFRESH_TOKEN="your_gmail_refresh_token"
+```
+
+### Webhook
+
+Use a webhook to route the brief to Slack, Linear, Jira, or an internal workflow:
+
+```bash
+export RELEASE_RADAR_DELIVERY="webhook"
+export RELEASE_RADAR_WEBHOOK_URL="https://example.com/dependency-brief"
+export RELEASE_RADAR_WEBHOOK_TOKEN="optional_bearer_token"
+```
+
+After configuring a provider, trigger a live delivery:
+
+```bash
+curl -X POST "http://127.0.0.1:8000/release-radar/trigger" \
+  -H "Content-Type: application/json" \
+  -d '{"dry_run": false, "live": true, "top_n": 10}'
+```
+
+## Cloud Scheduler
+
+Deploy the FastAPI service behind Cloud Run or another HTTP service. Cloud Scheduler can call the direct endpoint:
+
+```text
+https://YOUR_SERVICE_URL/release-radar/trigger
+```
+
+It can also publish base64-encoded JSON to the Pub/Sub push endpoint:
+
+```text
+https://YOUR_SERVICE_URL/release-radar/pubsub
+```
+
+A weekday morning schedule is:
+
+```text
+0 9 * * 1-5
+```
+
+Keep `dry_run` set to `true` while validating the deployment.
+
+## Test
+
+```bash
+python3 -m pytest always_on_agents/release_radar_agent/tests/unit -q
+```
+
+The tests use deterministic sample releases and patch network access when checking delivery safety.
+
+This app is licensed under Apache-2.0 through the repository's root license.

--- a/always_on_agents/release_radar_agent/__init__.py
+++ b/always_on_agents/release_radar_agent/__init__.py
@@ -1,0 +1,9 @@
+__all__ = ["root_agent"]
+
+
+def __getattr__(name: str):
+    if name == "root_agent":
+        from .agent import root_agent
+
+        return root_agent
+    raise AttributeError(name)

--- a/always_on_agents/release_radar_agent/agent.py
+++ b/always_on_agents/release_radar_agent/agent.py
@@ -1,0 +1,53 @@
+"""Release Radar: an always-on dependency release briefing agent."""
+
+from __future__ import annotations
+
+from google.adk.agents import LlmAgent
+
+from .radar import run_release_radar
+
+
+def preview_dependency_brief(manifest_path: str = "", top_n: int = 10) -> dict:
+    """Build today's dependency release brief.
+
+    Args:
+        manifest_path: Optional path to requirements.txt or package.json.
+        top_n: Maximum number of important releases to include.
+
+    Returns:
+        A rendered text and HTML brief with ranked dependency changes.
+    """
+
+    return run_release_radar(
+        manifest_path=manifest_path or None,
+        live=None,
+        top_n=top_n,
+    )
+
+
+root_agent = LlmAgent(
+    name="release_radar",
+    model="gemini-3-flash-preview",
+    description=(
+        "Always-on dependency release agent that finds breaking changes, "
+        "deprecations, security fixes, and major-version upgrades."
+    ),
+    instruction="""
+You are Release Radar, an always-on dependency change briefing agent for
+software teams.
+
+Your job is to produce a short daily brief from the user's dependency manifest:
+- Surface breaking changes, deprecations, security fixes, and major versions.
+- Skip routine patch noise.
+- Explain why each release matters to this project in one line.
+- Include the release-notes link for every finding.
+- When asked for today's brief or a dependency update, call
+  preview_dependency_brief.
+- Separate rendering from delivery. Never claim that email or a webhook was sent.
+
+The tool returns handoff-ready text and HTML. Scheduled delivery is a separate,
+opt-in API path that defaults to dry-run.
+""",
+    tools=[preview_dependency_brief],
+)
+

--- a/always_on_agents/release_radar_agent/delivery.py
+++ b/always_on_agents/release_radar_agent/delivery.py
@@ -1,0 +1,310 @@
+"""Brief rendering and opt-in delivery for Release Radar."""
+
+from __future__ import annotations
+
+import base64
+import datetime as dt
+import html
+import json
+import os
+import urllib.error
+import urllib.parse
+import urllib.request
+from dataclasses import dataclass
+from email.message import EmailMessage
+from typing import Any
+
+try:
+    from .ranker import RankedRelease
+except ImportError:
+    from ranker import RankedRelease
+
+
+GMAIL_REQUIRED_ENV = [
+    "RELEASE_RADAR_EMAIL_TO",
+    "RELEASE_RADAR_EMAIL_FROM",
+    "RELEASE_RADAR_GMAIL_CLIENT_ID",
+    "RELEASE_RADAR_GMAIL_CLIENT_SECRET",
+    "RELEASE_RADAR_GMAIL_REFRESH_TOKEN",
+]
+
+
+@dataclass(frozen=True)
+class Brief:
+    generated_at: str
+    watch_mode: str
+    manifest_path: str
+    subject: str
+    text: str
+    html: str
+    releases: list[RankedRelease]
+    dependencies_checked: int
+    errors: list[str]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "generated_at": self.generated_at,
+            "watch_mode": self.watch_mode,
+            "manifest_path": self.manifest_path,
+            "subject": self.subject,
+            "text": self.text,
+            "html": self.html,
+            "releases": [release.to_dict() for release in self.releases],
+            "dependencies_checked": self.dependencies_checked,
+            "errors": self.errors,
+        }
+
+
+def render_brief(
+    releases: list[RankedRelease],
+    *,
+    watch_mode: str,
+    manifest_path: str,
+    dependencies_checked: int,
+    errors: list[str] | None = None,
+    now: dt.datetime | None = None,
+) -> Brief:
+    """Render ranked dependency changes in plain text and HTML."""
+
+    now = now or dt.datetime.now(dt.timezone.utc)
+    generated_at = now.isoformat(timespec="seconds")
+    subject = f"Release Radar dependency brief - {now:%Y-%m-%d}"
+    text_lines = [
+        "Release Radar Dependency Brief",
+        f"Generated: {generated_at}",
+        f"Manifest: {manifest_path}",
+        f"Watch mode: {watch_mode}",
+        f"Dependencies checked: {dependencies_checked}",
+        "",
+        "Changes that need attention:",
+    ]
+    html_lines = [
+        "<h2>Release Radar Dependency Brief</h2>",
+        f"<p><strong>Generated:</strong> {html.escape(generated_at)}<br>",
+        f"<strong>Manifest:</strong> {html.escape(manifest_path)}<br>",
+        f"<strong>Watch mode:</strong> {html.escape(watch_mode)}<br>",
+        f"<strong>Dependencies checked:</strong> {dependencies_checked}</p>",
+    ]
+
+    grouped: dict[str, list[RankedRelease]] = {}
+    for release in releases:
+        grouped.setdefault(release.dependency, []).append(release)
+
+    for dependency, dependency_releases in grouped.items():
+        text_lines.extend(["", dependency])
+        html_lines.extend([f"<h3>{html.escape(dependency)}</h3>", "<ul>"])
+        for release in dependency_releases:
+            current = release.current_version or "unknown"
+            version_change = f"{current} -> {release.release_version}"
+            reasons = ", ".join(release.reasons)
+            text_lines.extend(
+                [
+                    f"- {version_change}: {release.title}",
+                    f"  Reason: {reasons}",
+                    f"  Why you care: {release.why_you_care}",
+                    f"  Link: {release.release_url}",
+                ]
+            )
+            html_lines.extend(
+                [
+                    "<li>",
+                    f"<strong>{html.escape(version_change)}: {html.escape(release.title)}</strong>",
+                    f"<p><strong>Reason:</strong> {html.escape(reasons)}<br>",
+                    f"<strong>Why you care:</strong> {html.escape(release.why_you_care)}<br>",
+                    f'<a href="{html.escape(release.release_url)}">release notes</a></p>',
+                    "</li>",
+                ]
+            )
+        html_lines.append("</ul>")
+
+    if not releases:
+        text_lines.append("No breaking, deprecation, security, or major-version changes found.")
+        html_lines.append(
+            "<p>No breaking, deprecation, security, or major-version changes found.</p>"
+        )
+
+    brief_errors = errors or []
+    if brief_errors:
+        text_lines.extend(["", "Scan notes:", *[f"- {error}" for error in brief_errors]])
+        html_lines.extend(
+            [
+                "<h3>Scan notes</h3>",
+                "<ul>",
+                *[f"<li>{html.escape(error)}</li>" for error in brief_errors],
+                "</ul>",
+            ]
+        )
+
+    return Brief(
+        generated_at=generated_at,
+        watch_mode=watch_mode,
+        manifest_path=manifest_path,
+        subject=subject,
+        text="\n".join(text_lines),
+        html="\n".join(html_lines),
+        releases=releases,
+        dependencies_checked=dependencies_checked,
+        errors=brief_errors,
+    )
+
+
+def _gmail_configured() -> bool:
+    return all(os.environ.get(name) for name in GMAIL_REQUIRED_ENV)
+
+
+def _missing_gmail_config() -> list[str]:
+    return [name for name in GMAIL_REQUIRED_ENV if not os.environ.get(name)]
+
+
+def send_brief(payload: dict[str, Any]) -> dict[str, Any]:
+    """Send a rendered brief only when a delivery target is configured."""
+
+    delivery_mode = os.environ.get("RELEASE_RADAR_DELIVERY", "auto").lower()
+    if delivery_mode == "gmail":
+        return send_gmail(payload)
+    if delivery_mode == "webhook":
+        return send_webhook(payload)
+    if _gmail_configured():
+        return send_gmail(payload)
+    if os.environ.get("RELEASE_RADAR_WEBHOOK_URL"):
+        return send_webhook(payload)
+    return {
+        "configured": False,
+        "sent": False,
+        "status": "skipped_no_delivery",
+        "detail": (
+            "Set Gmail environment variables or RELEASE_RADAR_WEBHOOK_URL to "
+            "deliver scheduled briefs."
+        ),
+    }
+
+
+def _fetch_gmail_access_token() -> str:
+    request = urllib.request.Request(
+        "https://oauth2.googleapis.com/token",
+        data=urllib.parse.urlencode(
+            {
+                "client_id": os.environ["RELEASE_RADAR_GMAIL_CLIENT_ID"],
+                "client_secret": os.environ["RELEASE_RADAR_GMAIL_CLIENT_SECRET"],
+                "refresh_token": os.environ["RELEASE_RADAR_GMAIL_REFRESH_TOKEN"],
+                "grant_type": "refresh_token",
+            }
+        ).encode("utf-8"),
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+        method="POST",
+    )
+    with urllib.request.urlopen(request, timeout=20) as response:
+        token_payload = json.loads(response.read().decode("utf-8"))
+    return str(token_payload["access_token"])
+
+
+def send_gmail(payload: dict[str, Any]) -> dict[str, Any]:
+    """Send the brief through Gmail when all OAuth settings are present."""
+
+    missing = _missing_gmail_config()
+    if missing:
+        return {
+            "provider": "gmail",
+            "configured": False,
+            "sent": False,
+            "status": "skipped_missing_gmail_config",
+            "missing": missing,
+        }
+
+    try:
+        message = EmailMessage()
+        message["To"] = os.environ["RELEASE_RADAR_EMAIL_TO"]
+        message["From"] = os.environ["RELEASE_RADAR_EMAIL_FROM"]
+        message["Subject"] = payload["subject"]
+        message.set_content(payload["text"])
+        message.add_alternative(payload["html"], subtype="html")
+        encoded_message = base64.urlsafe_b64encode(message.as_bytes()).decode("ascii")
+        request = urllib.request.Request(
+            "https://gmail.googleapis.com/gmail/v1/users/me/messages/send",
+            data=json.dumps({"raw": encoded_message}).encode("utf-8"),
+            headers={
+                "Authorization": f"Bearer {_fetch_gmail_access_token()}",
+                "Content-Type": "application/json",
+            },
+            method="POST",
+        )
+        with urllib.request.urlopen(request, timeout=20) as response:
+            response_payload = json.loads(response.read().decode("utf-8"))
+        return {
+            "provider": "gmail",
+            "configured": True,
+            "sent": True,
+            "status": "sent",
+            "message_id": response_payload.get("id"),
+        }
+    except urllib.error.HTTPError as exc:
+        return {
+            "provider": "gmail",
+            "configured": True,
+            "sent": False,
+            "status": exc.code,
+            "error": exc.read().decode("utf-8", errors="replace")[:500],
+        }
+    except (KeyError, urllib.error.URLError, TimeoutError, json.JSONDecodeError) as exc:
+        return {
+            "provider": "gmail",
+            "configured": True,
+            "sent": False,
+            "status": "connection_error",
+            "error": str(exc),
+        }
+
+
+def send_webhook(payload: dict[str, Any]) -> dict[str, Any]:
+    """Post the brief to a configured webhook."""
+
+    webhook_url = os.environ.get("RELEASE_RADAR_WEBHOOK_URL")
+    if not webhook_url:
+        return {
+            "provider": "webhook",
+            "configured": False,
+            "sent": False,
+            "status": "skipped_no_webhook",
+            "detail": "Set RELEASE_RADAR_WEBHOOK_URL to deliver scheduled briefs.",
+        }
+
+    body = json.dumps(
+        {
+            "subject": payload["subject"],
+            "text": payload["text"],
+            "html": payload["html"],
+            "releases": payload["releases"],
+        }
+    ).encode("utf-8")
+    headers = {"Content-Type": "application/json"}
+    token = os.environ.get("RELEASE_RADAR_WEBHOOK_TOKEN")
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    request = urllib.request.Request(webhook_url, data=body, headers=headers, method="POST")
+    try:
+        with urllib.request.urlopen(request, timeout=20) as response:
+            response_text = response.read().decode("utf-8", errors="replace")
+            return {
+                "provider": "webhook",
+                "configured": True,
+                "sent": 200 <= response.status < 300,
+                "status": response.status,
+                "response": response_text[:500],
+            }
+    except urllib.error.HTTPError as exc:
+        return {
+            "provider": "webhook",
+            "configured": True,
+            "sent": False,
+            "status": exc.code,
+            "error": exc.read().decode("utf-8", errors="replace")[:500],
+        }
+    except (urllib.error.URLError, TimeoutError) as exc:
+        return {
+            "provider": "webhook",
+            "configured": True,
+            "sent": False,
+            "status": "connection_error",
+            "error": str(exc),
+        }
+

--- a/always_on_agents/release_radar_agent/radar.py
+++ b/always_on_agents/release_radar_agent/radar.py
@@ -1,0 +1,394 @@
+"""Dependency manifest and GitHub release pipeline for Release Radar."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import urllib.error
+import urllib.request
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any
+
+
+KNOWN_GITHUB_REPOS = {
+    "anthropic": "anthropics/anthropic-sdk-python",
+    "fastapi": "fastapi/fastapi",
+    "google-adk": "google/adk-python",
+    "langchain": "langchain-ai/langchain",
+    "openai": "openai/openai-python",
+    "pydantic": "pydantic/pydantic",
+    "react": "facebook/react",
+    "requests": "psf/requests",
+    "urllib3": "urllib3/urllib3",
+    "vite": "vitejs/vite",
+    "zod": "colinhacks/zod",
+}
+
+VERSION_PATTERN = re.compile(r"(?<!\d)(\d+(?:\.\d+){1,3})(?:[-+][0-9A-Za-z.-]+)?")
+GITHUB_PATTERN = re.compile(
+    r"(?:github\.com/|github:)([A-Za-z0-9_.-]+)/([A-Za-z0-9_.-]+)", re.IGNORECASE
+)
+
+
+@dataclass(frozen=True)
+class Dependency:
+    name: str
+    current_version: str | None
+    github_repo: str | None
+    manifest: str
+
+
+@dataclass(frozen=True)
+class ReleaseCandidate:
+    dependency: str
+    github_repo: str
+    current_version: str | None
+    release_version: str
+    version_delta: str
+    title: str
+    notes: str
+    release_url: str
+    published_at: str
+    prerelease: bool
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+def _normalize_name(name: str) -> str:
+    return re.sub(r"[-_.]+", "-", name.strip().lower())
+
+
+def _extract_version(specifier: str) -> str | None:
+    matches = VERSION_PATTERN.findall(specifier)
+    return matches[-1] if matches else None
+
+
+def _github_repo_from_spec(specifier: str) -> str | None:
+    match = GITHUB_PATTERN.search(specifier)
+    if not match:
+        return None
+    owner, repo = match.groups()
+    return f"{owner}/{repo.removesuffix('.git')}"
+
+
+def _dependency(name: str, specifier: str, manifest: str) -> Dependency:
+    normalized_name = _normalize_name(name)
+    github_repo = _github_repo_from_spec(specifier) or KNOWN_GITHUB_REPOS.get(
+        normalized_name
+    )
+    version_specifier = specifier.split(";", 1)[0]
+    return Dependency(
+        name=normalized_name,
+        current_version=_extract_version(version_specifier),
+        github_repo=github_repo,
+        manifest=manifest,
+    )
+
+
+def _parse_requirements(path: Path) -> list[Dependency]:
+    dependencies: list[Dependency] = []
+    for raw_line in path.read_text(encoding="utf-8").splitlines():
+        line = raw_line.split(" #", 1)[0].strip()
+        if not line or line.startswith(("#", "-")):
+            continue
+        match = re.match(r"^([A-Za-z0-9_.-]+)(?:\[[^]]+\])?\s*(.*)$", line)
+        if not match:
+            continue
+        name, specifier = match.groups()
+        dependencies.append(_dependency(name, specifier, path.name))
+    return dependencies
+
+
+def _parse_package_json(path: Path) -> list[Dependency]:
+    try:
+        document = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"Could not parse {path}: {exc}") from exc
+
+    declared: dict[str, str] = {}
+    for group in ("dependencies", "devDependencies"):
+        entries = document.get(group, {})
+        if not isinstance(entries, dict):
+            continue
+        for name, specifier in entries.items():
+            if isinstance(name, str) and isinstance(specifier, str):
+                declared.setdefault(name, specifier)
+    return [
+        _dependency(name, specifier, path.name)
+        for name, specifier in declared.items()
+    ]
+
+
+def parse_manifest(path: str | Path) -> list[Dependency]:
+    """Parse requirements.txt or package.json into dependency records."""
+
+    manifest_path = Path(path).expanduser()
+    if not manifest_path.is_file():
+        raise FileNotFoundError(f"Dependency manifest not found: {manifest_path}")
+    if manifest_path.name == "package.json":
+        return _parse_package_json(manifest_path)
+    if manifest_path.name.startswith("requirements") and manifest_path.suffix == ".txt":
+        return _parse_requirements(manifest_path)
+    raise ValueError("Release Radar supports requirements*.txt and package.json manifests.")
+
+
+def _version_tuple(version: str | None) -> tuple[int, int, int] | None:
+    if not version:
+        return None
+    extracted = _extract_version(version)
+    if not extracted:
+        return None
+    parts = [int(part) for part in extracted.split(".")[:3]]
+    parts.extend([0] * (3 - len(parts)))
+    return parts[0], parts[1], parts[2]
+
+
+def version_delta(current: str | None, released: str | None) -> str:
+    """Return the semantic size of a dependency version change."""
+
+    current_tuple = _version_tuple(current)
+    released_tuple = _version_tuple(released)
+    if current_tuple is None or released_tuple is None:
+        return "unknown"
+    if released_tuple == current_tuple:
+        return "same"
+    if released_tuple < current_tuple:
+        return "older"
+    if released_tuple[0] != current_tuple[0]:
+        return "major"
+    if released_tuple[1] != current_tuple[1]:
+        return "minor"
+    return "patch"
+
+
+def sample_dependencies() -> list[Dependency]:
+    """Return deterministic dependencies for demos and tests."""
+
+    return [
+        _dependency("pydantic", "==1.10.14", "sample/requirements.txt"),
+        _dependency("requests", "==2.31.0", "sample/requirements.txt"),
+        _dependency("fastapi", "==0.114.0", "sample/requirements.txt"),
+        _dependency("react", "^18.2.0", "sample/package.json"),
+        _dependency("urllib3", "==2.2.1", "sample/requirements.txt"),
+    ]
+
+
+def sample_release_data() -> dict[str, list[dict[str, Any]]]:
+    """Return GitHub-shaped release fixtures with signal and routine noise."""
+
+    return {
+        "pydantic/pydantic": [
+            {
+                "tag_name": "v3.0.0-beta.1",
+                "name": "Pydantic 3 beta",
+                "body": "Preview release for early testing.",
+                "html_url": "https://github.com/pydantic/pydantic/releases/tag/v3.0.0-beta.1",
+                "published_at": "2026-07-15T08:00:00Z",
+                "draft": False,
+                "prerelease": True,
+            },
+            {
+                "tag_name": "v2.0.0",
+                "name": "Pydantic 2.0",
+                "body": "Breaking change with a migration guide. Deprecated V1 validators.",
+                "html_url": "https://github.com/pydantic/pydantic/releases/tag/v2.0.0",
+                "published_at": "2026-07-14T08:00:00Z",
+                "draft": False,
+                "prerelease": False,
+            },
+        ],
+        "psf/requests": [
+            {
+                "tag_name": "v2.32.3",
+                "name": "Requests 2.32.3",
+                "body": "Security fix for a proxy credential vulnerability.",
+                "html_url": "https://github.com/psf/requests/releases/tag/v2.32.3",
+                "published_at": "2026-07-16T07:00:00Z",
+                "draft": False,
+                "prerelease": False,
+            }
+        ],
+        "fastapi/fastapi": [
+            {
+                "tag_name": "0.115.0",
+                "name": "FastAPI 0.115.0",
+                "body": "Breaking change: removed support for the legacy dependency hook.",
+                "html_url": "https://github.com/fastapi/fastapi/releases/tag/0.115.0",
+                "published_at": "2026-07-13T07:00:00Z",
+                "draft": False,
+                "prerelease": False,
+            }
+        ],
+        "facebook/react": [
+            {
+                "tag_name": "v19.0.0",
+                "name": "React 19",
+                "body": "New stable release with compiler and action APIs.",
+                "html_url": "https://github.com/facebook/react/releases/tag/v19.0.0",
+                "published_at": "2026-07-12T07:00:00Z",
+                "draft": False,
+                "prerelease": False,
+            }
+        ],
+        "urllib3/urllib3": [
+            {
+                "tag_name": "2.2.2",
+                "name": "urllib3 2.2.2 routine patch",
+                "body": "Documentation corrections and small test cleanup.",
+                "html_url": "https://github.com/urllib3/urllib3/releases/tag/2.2.2",
+                "published_at": "2026-07-11T07:00:00Z",
+                "draft": False,
+                "prerelease": False,
+            }
+        ],
+    }
+
+
+def fetch_github_releases(
+    github_repo: str, *, timeout_seconds: int = 15, per_page: int = 5
+) -> list[dict[str, Any]]:
+    """Fetch recent releases for one owner/repository pair."""
+
+    request = urllib.request.Request(
+        f"https://api.github.com/repos/{github_repo}/releases?per_page={per_page}",
+        headers={
+            "Accept": "application/vnd.github+json",
+            "User-Agent": "release-radar-agent",
+            "X-GitHub-Api-Version": "2022-11-28",
+        },
+    )
+    token = os.environ.get("RELEASE_RADAR_GITHUB_TOKEN")
+    if token:
+        request.add_header("Authorization", f"Bearer {token}")
+    try:
+        with urllib.request.urlopen(request, timeout=timeout_seconds) as response:
+            payload = json.loads(response.read().decode("utf-8"))
+    except (urllib.error.HTTPError, urllib.error.URLError, TimeoutError) as exc:
+        raise RuntimeError(f"Could not fetch releases for {github_repo}: {exc}") from exc
+    except json.JSONDecodeError as exc:
+        raise RuntimeError(f"GitHub returned invalid JSON for {github_repo}.") from exc
+    if not isinstance(payload, list):
+        raise RuntimeError(f"GitHub returned an unexpected response for {github_repo}.")
+    return [release for release in payload if isinstance(release, dict)]
+
+
+def build_release_candidates(
+    dependencies: list[Dependency],
+    release_data_by_repo: dict[str, list[dict[str, Any]]],
+) -> tuple[list[ReleaseCandidate], list[str]]:
+    """Join dependencies to GitHub releases and compute version deltas."""
+
+    candidates: list[ReleaseCandidate] = []
+    errors: list[str] = []
+    for dependency in dependencies:
+        if not dependency.github_repo:
+            errors.append(f"No GitHub repository mapping for {dependency.name}.")
+            continue
+        for release in release_data_by_repo.get(dependency.github_repo, []):
+            if release.get("draft") or release.get("prerelease"):
+                continue
+            tag_name = str(release.get("tag_name") or release.get("name") or "")
+            release_version = _extract_version(tag_name)
+            if not release_version:
+                continue
+            delta = version_delta(dependency.current_version, release_version)
+            if delta in {"same", "older"}:
+                continue
+            candidates.append(
+                ReleaseCandidate(
+                    dependency=dependency.name,
+                    github_repo=dependency.github_repo,
+                    current_version=dependency.current_version,
+                    release_version=release_version,
+                    version_delta=delta,
+                    title=str(release.get("name") or tag_name),
+                    notes=str(release.get("body") or ""),
+                    release_url=str(
+                        release.get("html_url")
+                        or f"https://github.com/{dependency.github_repo}/releases"
+                    ),
+                    published_at=str(release.get("published_at") or ""),
+                    prerelease=False,
+                )
+            )
+    return candidates, errors
+
+
+def _live_release_data(
+    dependencies: list[Dependency],
+) -> tuple[dict[str, list[dict[str, Any]]], list[str]]:
+    release_data: dict[str, list[dict[str, Any]]] = {}
+    errors: list[str] = []
+    repositories = sorted(
+        {dependency.github_repo for dependency in dependencies if dependency.github_repo}
+    )
+    if not repositories:
+        return release_data, errors
+
+    with ThreadPoolExecutor(max_workers=min(8, len(repositories))) as executor:
+        requests = {
+            executor.submit(fetch_github_releases, repository): repository
+            for repository in repositories
+        }
+        for request in as_completed(requests):
+            repository = requests[request]
+            try:
+                release_data[repository] = request.result()
+            except RuntimeError as exc:
+                errors.append(str(exc))
+    return release_data, sorted(errors)
+
+
+def _live_mode_enabled() -> bool:
+    return os.environ.get("RELEASE_RADAR_LIVE_GITHUB", "").lower() in {
+        "1",
+        "true",
+        "yes",
+    }
+
+
+def run_release_radar(
+    *,
+    manifest_path: str | Path | None = None,
+    live: bool | None = None,
+    top_n: int = 10,
+) -> dict[str, Any]:
+    """Run manifest parsing, GitHub release scanning, ranking, and rendering."""
+
+    configured_manifest = manifest_path or os.environ.get("RELEASE_RADAR_MANIFEST")
+    dependencies = (
+        parse_manifest(configured_manifest)
+        if configured_manifest
+        else sample_dependencies()
+    )
+    live = _live_mode_enabled() if live is None else live
+    release_data, fetch_errors = (
+        _live_release_data(dependencies) if live else (sample_release_data(), [])
+    )
+    candidates, mapping_errors = build_release_candidates(dependencies, release_data)
+
+    try:
+        from .delivery import render_brief
+        from .ranker import rank_releases
+    except ImportError:
+        from delivery import render_brief
+        from ranker import rank_releases
+
+    ranked = rank_releases(candidates)[: max(1, min(int(top_n), 25))]
+    errors = [*fetch_errors, *mapping_errors]
+    brief = render_brief(
+        ranked,
+        watch_mode="live_github" if live else "sample",
+        manifest_path=str(configured_manifest or "deterministic sample data"),
+        dependencies_checked=len(dependencies),
+        errors=errors,
+    ).to_dict()
+    brief["delivery_note"] = (
+        "The brief is rendered only. Scheduled delivery stays off until dry_run=false "
+        "and Gmail or webhook settings are present."
+    )
+    return brief

--- a/always_on_agents/release_radar_agent/ranker.py
+++ b/always_on_agents/release_radar_agent/ranker.py
@@ -1,0 +1,124 @@
+"""Signal classifier and ranker for dependency releases."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from typing import Any
+
+try:
+    from .radar import ReleaseCandidate
+except ImportError:
+    from radar import ReleaseCandidate
+
+
+SIGNAL_TERMS = {
+    "security fix": (
+        "security fix",
+        "security vulnerability",
+        "vulnerability",
+        "cve-",
+        "security advisory",
+    ),
+    "breaking change": (
+        "breaking change",
+        "breaking:",
+        "not backward compatible",
+        "migration required",
+        "removed support",
+    ),
+    "deprecation": ("deprecated", "deprecation", "will be removed"),
+    "yanked release": ("yanked", "withdrawn release", "do not use this release"),
+}
+
+SIGNAL_SCORES = {
+    "security fix": 100,
+    "breaking change": 90,
+    "yanked release": 85,
+    "major version": 70,
+    "deprecation": 60,
+}
+
+REASON_ORDER = tuple(SIGNAL_SCORES)
+
+
+@dataclass(frozen=True)
+class RankedRelease:
+    dependency: str
+    github_repo: str
+    current_version: str | None
+    release_version: str
+    version_delta: str
+    title: str
+    notes: str
+    release_url: str
+    published_at: str
+    reasons: tuple[str, ...]
+    score: int
+    why_you_care: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+def _why_you_care(dependency: str, reasons: tuple[str, ...]) -> str:
+    if "security fix" in reasons:
+        return f"{dependency} fixes a security risk; review exposure and patch promptly."
+    if "breaking change" in reasons:
+        return f"{dependency} may break existing integrations; read its migration notes before upgrading."
+    if "yanked release" in reasons:
+        return f"Avoid the affected {dependency} release and check whether your lockfile selected it."
+    if "major version" in reasons:
+        return f"{dependency} crossed a major version, so expect migration work before upgrading."
+    return f"{dependency} is retiring an API; plan its replacement before removal."
+
+
+def classify_release(candidate: ReleaseCandidate) -> RankedRelease | None:
+    """Classify one release and drop it when it contains only routine noise."""
+
+    searchable = f"{candidate.title}\n{candidate.notes}".lower()
+    reasons = {
+        reason
+        for reason, terms in SIGNAL_TERMS.items()
+        if any(term in searchable for term in terms)
+    }
+    if candidate.version_delta == "major":
+        reasons.add("major version")
+    ordered_reasons = tuple(reason for reason in REASON_ORDER if reason in reasons)
+    if not ordered_reasons:
+        return None
+
+    score = max(SIGNAL_SCORES[reason] for reason in ordered_reasons)
+    score += max(0, len(ordered_reasons) - 1) * 5
+    return RankedRelease(
+        dependency=candidate.dependency,
+        github_repo=candidate.github_repo,
+        current_version=candidate.current_version,
+        release_version=candidate.release_version,
+        version_delta=candidate.version_delta,
+        title=candidate.title,
+        notes=candidate.notes,
+        release_url=candidate.release_url,
+        published_at=candidate.published_at,
+        reasons=ordered_reasons,
+        score=score,
+        why_you_care=_why_you_care(candidate.dependency, ordered_reasons),
+    )
+
+
+def rank_releases(candidates: list[ReleaseCandidate]) -> list[RankedRelease]:
+    """Filter routine releases and sort the rest by user impact."""
+
+    classified = [
+        release
+        for candidate in candidates
+        if (release := classify_release(candidate)) is not None
+    ]
+    return sorted(
+        classified,
+        key=lambda release: (
+            release.score,
+            release.published_at,
+            release.release_version,
+        ),
+        reverse=True,
+    )

--- a/always_on_agents/release_radar_agent/requirements.txt
+++ b/always_on_agents/release_radar_agent/requirements.txt
@@ -1,0 +1,4 @@
+google-adk==1.9.0
+fastapi==0.115.12
+uvicorn==0.34.2
+

--- a/always_on_agents/release_radar_agent/scheduler_api.py
+++ b/always_on_agents/release_radar_agent/scheduler_api.py
@@ -1,0 +1,122 @@
+"""HTTP and Pub/Sub scheduler hooks for Release Radar.
+
+Run locally with:
+    uvicorn scheduler_api:app --host 0.0.0.0 --port 8000
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+from json import JSONDecodeError
+from typing import Any, Optional
+
+from fastapi import FastAPI, Request
+from fastapi.concurrency import run_in_threadpool
+
+try:
+    from .delivery import send_brief
+    from .radar import run_release_radar
+except ImportError:
+    from delivery import send_brief
+    from radar import run_release_radar
+
+
+app = FastAPI(
+    title="Release Radar Scheduler API",
+    description="HTTP and Pub/Sub hooks for scheduled dependency release briefs.",
+)
+
+
+def _as_bool(value: Any, *, default: bool | None = None) -> bool | None:
+    if value is None:
+        return default
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        lowered = value.lower()
+        if lowered in {"1", "true", "yes"}:
+            return True
+        if lowered in {"0", "false", "no"}:
+            return False
+    return default
+
+
+def _as_top_n(value: Any) -> int:
+    try:
+        top_n = int(value)
+    except (TypeError, ValueError):
+        return 10
+    return max(1, min(top_n, 25))
+
+
+def run_scheduled_radar(payload: dict[str, Any] | None = None) -> dict[str, Any]:
+    """Run Release Radar from a scheduler payload with dry-run as the default."""
+
+    payload = payload if isinstance(payload, dict) else {}
+    dry_run = _as_bool(payload.get("dry_run"), default=True)
+    live = _as_bool(payload.get("live"), default=None)
+    top_n = _as_top_n(payload.get("top_n"))
+
+    brief = run_release_radar(
+        live=live,
+        top_n=top_n,
+    )
+    delivery = {
+        "attempted": False,
+        "sent": False,
+        "status": "dry_run",
+        "detail": "Set dry_run=false to use configured Gmail or webhook delivery.",
+    }
+    if dry_run is False:
+        delivery = {"attempted": True, **send_brief(brief)}
+    return {
+        "dry_run": dry_run,
+        "top_n": top_n,
+        "delivery": delivery,
+        "brief": brief,
+    }
+
+
+@app.get("/health")
+def health() -> dict[str, str]:
+    return {"status": "ok"}
+
+
+@app.get("/release-radar/dry-run")
+def dry_run_preview(
+    top_n: int = 10,
+    live: Optional[bool] = None,
+) -> dict[str, Any]:
+    return run_scheduled_radar(
+        {
+            "dry_run": True,
+            "top_n": top_n,
+            "live": live,
+        }
+    )
+
+
+@app.post("/release-radar/trigger")
+async def scheduler_trigger(request: Request) -> dict[str, Any]:
+    try:
+        payload = await request.json() if request.headers.get("content-length") else {}
+    except JSONDecodeError:
+        payload = {}
+    return await run_in_threadpool(run_scheduled_radar, payload)
+
+
+@app.post("/release-radar/pubsub")
+async def pubsub_trigger(request: Request) -> dict[str, Any]:
+    """Handle a Cloud Scheduler to Pub/Sub push envelope."""
+
+    envelope = await request.json()
+    message = envelope.get("message", {}) if isinstance(envelope, dict) else {}
+    payload: dict[str, Any] = {}
+    encoded_data = message.get("data") if isinstance(message, dict) else None
+    if encoded_data:
+        try:
+            payload = json.loads(base64.b64decode(encoded_data).decode("utf-8"))
+        except (ValueError, JSONDecodeError, UnicodeDecodeError):
+            payload = {}
+    return await run_in_threadpool(run_scheduled_radar, payload)

--- a/always_on_agents/release_radar_agent/tests/eval/eval_config.yaml
+++ b/always_on_agents/release_radar_agent/tests/eval/eval_config.yaml
@@ -1,0 +1,22 @@
+eval_set_id: release_radar_dependency_brief
+name: Release Radar dependency brief eval prompts
+description: Prompts for checking that Release Radar filters noise and explains impact.
+eval_cases:
+  - name: daily_brief
+    prompt: Give me today's dependency release brief.
+    expected_behavior:
+      - Calls preview_dependency_brief.
+      - Returns only breaking, deprecation, security, yanked, or major-version changes.
+      - Includes a release link and one-line impact for every finding.
+  - name: manifest_brief
+    prompt: Check /workspace/package.json and show me the five dependency changes that matter.
+    expected_behavior:
+      - Passes the manifest path and a limit of five to the tool.
+      - Groups findings by dependency.
+      - Skips routine patch notes.
+  - name: no_false_delivery
+    prompt: Email this dependency brief to the team.
+    expected_behavior:
+      - Does not claim to send email or call a webhook.
+      - Provides handoff-ready text or HTML.
+

--- a/always_on_agents/release_radar_agent/tests/unit/test_radar.py
+++ b/always_on_agents/release_radar_agent/tests/unit/test_radar.py
@@ -1,0 +1,92 @@
+import json
+
+from always_on_agents.release_radar_agent.radar import (
+    build_release_candidates,
+    parse_manifest,
+    run_release_radar,
+    sample_dependencies,
+    sample_release_data,
+    version_delta,
+)
+
+
+def test_parse_requirements_manifest(tmp_path):
+    manifest = tmp_path / "requirements.txt"
+    manifest.write_text(
+        "# production dependencies\n"
+        "pydantic==1.10.14\n"
+        'requests[security]>=2.31.0; python_version >= "3.10"\n'
+        "internal-tool @ git+https://github.com/acme/internal-tool.git@v3.2.1\n",
+        encoding="utf-8",
+    )
+
+    dependencies = parse_manifest(manifest)
+
+    assert [dependency.name for dependency in dependencies] == [
+        "pydantic",
+        "requests",
+        "internal-tool",
+    ]
+    assert dependencies[0].current_version == "1.10.14"
+    assert dependencies[0].github_repo == "pydantic/pydantic"
+    assert dependencies[1].current_version == "2.31.0"
+    assert dependencies[2].github_repo == "acme/internal-tool"
+
+
+def test_parse_package_json_includes_runtime_and_dev_dependencies(tmp_path):
+    manifest = tmp_path / "package.json"
+    manifest.write_text(
+        json.dumps(
+            {
+                "dependencies": {"react": "^18.2.0", "zod": "3.23.8"},
+                "devDependencies": {"vite": "~5.4.0"},
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    dependencies = parse_manifest(manifest)
+
+    assert [dependency.name for dependency in dependencies] == ["react", "zod", "vite"]
+    assert [dependency.current_version for dependency in dependencies] == [
+        "18.2.0",
+        "3.23.8",
+        "5.4.0",
+    ]
+    assert dependencies[0].github_repo == "facebook/react"
+
+
+def test_version_delta_distinguishes_release_sizes():
+    assert version_delta("1.4.2", "v2.0.0") == "major"
+    assert version_delta("1.4.2", "1.5.0") == "minor"
+    assert version_delta("1.4.2", "1.4.3") == "patch"
+    assert version_delta("1.4.2", "1.4.2") == "same"
+    assert version_delta(None, "1.4.3") == "unknown"
+
+
+def test_sample_candidates_include_version_context_and_skip_prereleases():
+    candidates, errors = build_release_candidates(
+        sample_dependencies(), sample_release_data()
+    )
+
+    assert errors == []
+    assert candidates
+    assert all(candidate.current_version for candidate in candidates)
+    assert all(candidate.release_url.startswith("https://github.com/") for candidate in candidates)
+    assert not any(candidate.prerelease for candidate in candidates)
+
+
+def test_sample_run_renders_text_and_html_without_patch_noise():
+    payload = run_release_radar(live=False, top_n=10)
+
+    assert payload["watch_mode"] == "sample"
+    assert payload["releases"]
+    assert "Release Radar Dependency Brief" in payload["text"]
+    assert "<h2>Release Radar Dependency Brief</h2>" in payload["html"]
+    assert "routine patch" not in payload["text"].lower()
+    reasons = {
+        reason
+        for release in payload["releases"]
+        for reason in release["reasons"]
+    }
+    assert {"breaking change", "deprecation", "security fix", "major version"} <= reasons

--- a/always_on_agents/release_radar_agent/tests/unit/test_ranker.py
+++ b/always_on_agents/release_radar_agent/tests/unit/test_ranker.py
@@ -1,0 +1,94 @@
+from always_on_agents.release_radar_agent.radar import ReleaseCandidate
+from always_on_agents.release_radar_agent.ranker import (
+    classify_release,
+    rank_releases,
+)
+
+
+def candidate(
+    *,
+    dependency="demo",
+    current="1.2.3",
+    latest="1.2.4",
+    delta="patch",
+    title="Demo 1.2.4",
+    notes="Small fixes and documentation updates.",
+    published="2026-07-15T12:00:00Z",
+):
+    return ReleaseCandidate(
+        dependency=dependency,
+        github_repo="example/demo",
+        current_version=current,
+        release_version=latest,
+        version_delta=delta,
+        title=title,
+        notes=notes,
+        release_url="https://github.com/example/demo/releases/tag/v1.2.4",
+        published_at=published,
+        prerelease=False,
+    )
+
+
+def test_routine_patch_release_is_filtered():
+    assert classify_release(candidate()) is None
+
+
+def test_breaking_deprecation_and_security_signals_are_classified():
+    breaking = classify_release(candidate(notes="Breaking change: remove the legacy client."))
+    deprecated = classify_release(candidate(notes="Deprecated the old configuration API."))
+    security = classify_release(candidate(notes="Security fix for CVE-2026-1234."))
+
+    assert breaking and "breaking change" in breaking.reasons
+    assert deprecated and "deprecation" in deprecated.reasons
+    assert security and "security fix" in security.reasons
+
+
+def test_major_version_is_relevant_without_keywords():
+    release = classify_release(
+        candidate(current="1.9.0", latest="2.0.0", delta="major", title="Demo 2.0")
+    )
+
+    assert release and release.reasons == ("major version",)
+    assert "migration" in release.why_you_care.lower()
+
+
+def test_yanked_release_signal_is_not_lost():
+    release = classify_release(candidate(notes="This release was yanked. Do not use it."))
+
+    assert release and "yanked release" in release.reasons
+
+
+def test_ranker_prioritizes_security_and_breaking_releases():
+    ranked = rank_releases(
+        [
+            candidate(dependency="major", latest="2.0.0", delta="major"),
+            candidate(dependency="security", notes="Security vulnerability fixed."),
+            candidate(dependency="breaking", notes="Breaking change to authentication."),
+            candidate(dependency="noise"),
+        ]
+    )
+
+    assert [release.dependency for release in ranked] == [
+        "security",
+        "breaking",
+        "major",
+    ]
+
+
+def test_equal_priority_releases_put_the_newest_first():
+    ranked = rank_releases(
+        [
+            candidate(
+                latest="1.2.4",
+                notes="Security fix.",
+                published="2026-07-14T12:00:00Z",
+            ),
+            candidate(
+                latest="1.2.5",
+                notes="Security fix.",
+                published="2026-07-16T12:00:00Z",
+            ),
+        ]
+    )
+
+    assert [release.release_version for release in ranked] == ["1.2.5", "1.2.4"]

--- a/always_on_agents/release_radar_agent/tests/unit/test_scheduler_api.py
+++ b/always_on_agents/release_radar_agent/tests/unit/test_scheduler_api.py
@@ -1,0 +1,83 @@
+import base64
+import json
+import os
+from unittest.mock import patch
+
+from fastapi.testclient import TestClient
+
+from always_on_agents.release_radar_agent.delivery import send_brief
+from always_on_agents.release_radar_agent.scheduler_api import (
+    app,
+    run_scheduled_radar,
+)
+
+
+def test_scheduled_radar_defaults_to_sample_dry_run():
+    result = run_scheduled_radar({"top_n": 2, "live": False})
+
+    assert result["dry_run"] is True
+    assert result["delivery"]["status"] == "dry_run"
+    assert result["brief"]["watch_mode"] == "sample"
+    assert len(result["brief"]["releases"]) == 2
+
+
+def test_delivery_without_credentials_never_calls_network():
+    payload = run_scheduled_radar({"dry_run": True, "top_n": 1, "live": False})[
+        "brief"
+    ]
+
+    with patch.dict(os.environ, {}, clear=True), patch(
+        "urllib.request.urlopen"
+    ) as urlopen:
+        delivery = send_brief(payload)
+
+    assert delivery["sent"] is False
+    assert delivery["status"] == "skipped_no_delivery"
+    urlopen.assert_not_called()
+
+
+def test_explicit_non_dry_run_still_requires_delivery_configuration():
+    with patch.dict(os.environ, {}, clear=True), patch(
+        "urllib.request.urlopen"
+    ) as urlopen:
+        result = run_scheduled_radar({"dry_run": False, "top_n": 1, "live": False})
+
+    assert result["delivery"]["attempted"] is True
+    assert result["delivery"]["sent"] is False
+    assert result["delivery"]["status"] == "skipped_no_delivery"
+    urlopen.assert_not_called()
+
+
+def test_scheduler_manifest_path_is_server_configured(tmp_path):
+    requested_manifest = tmp_path / "package.json"
+    requested_manifest.write_text('{"dependencies": {"react": "18.2.0"}}')
+
+    with patch.dict(os.environ, {}, clear=True):
+        result = run_scheduled_radar(
+            {
+                "dry_run": True,
+                "live": False,
+                "manifest_path": str(requested_manifest),
+            }
+        )
+
+    assert result["brief"]["manifest_path"] == "deterministic sample data"
+
+
+def test_trigger_and_pubsub_endpoints_return_briefs():
+    client = TestClient(app)
+    response = client.post(
+        "/release-radar/trigger",
+        json={"dry_run": True, "top_n": 1, "live": False},
+    )
+    message = base64.b64encode(
+        json.dumps({"dry_run": True, "top_n": 1, "live": False}).encode("utf-8")
+    ).decode("ascii")
+    pubsub_response = client.post(
+        "/release-radar/pubsub", json={"message": {"data": message}}
+    )
+
+    assert response.status_code == 200
+    assert response.json()["brief"]["releases"]
+    assert pubsub_response.status_code == 200
+    assert pubsub_response.json()["delivery"]["status"] == "dry_run"


### PR DESCRIPTION
## What this adds

A new always-on agent, **release-radar**, under `always_on_agents/`. It reads a project's dependency manifest, checks each dependency's recent GitHub releases, and produces a short daily brief of what actually matters: breaking changes, deprecations, security fixes, and major-version bumps. Routine patch noise is filtered out.

![demo](https://github.com/mvanhorn/awesome-llm-apps/releases/download/demo-assets/release-radar-always-on.gif)

## Why it fits

It mirrors the existing `always_on_hn_briefing_agent`: built on Google ADK, with `agent.py` / `radar.py` / `ranker.py` / `delivery.py` / `scheduler_api.py` and `tests/unit` + `tests/eval`. Delivery defaults to dry-run and only sends via Gmail or a webhook when credentials are explicitly set. It runs interactively in ADK Web or as a scheduled FastAPI/Pub-Sub hook.

## Testing

Deterministic sample mode (no live GitHub calls). `tests/unit` pass (16/16) against sample release data. Added to the README "Always-on Agents" section.

AI was used for assistance.
