### PR TITLE
fix: invoke researcher agent in local_travel_agent and fix missing comma in instructions

### DIFF
--- a/starter_ai_agents/ai_travel_agent/local_travel_agent.py
+++ b/starter_ai_agents/ai_travel_agent/local_travel_agent.py
@@ -84,7 +84,7 @@ if serp_api_key:
         ),
         instructions=[
             "Given a travel destination and the number of days the user wants to travel for, first generate a list of 3 search terms related to that destination and the number of days.",
-            "For each search term, `search_google` and analyze the results."
+            "For each search term, `search_google` and analyze the results.",
             "From the results of all searches, return the 10 most relevant results to the user's preferences.",
             "Remember: the quality of the results is important.",
         ],
@@ -120,9 +120,23 @@ if serp_api_key:
     
     with col1:
         if st.button("Generate Itinerary"):
-            with st.spinner("Processing..."):
-                # Get the response from the assistant
-                response: RunOutput = planner.run(f"{destination} for {num_days} days", stream=False)
+            with st.spinner("Researching your destination..."):
+                # First get research results
+                research_results: RunOutput = researcher.run(f"Research {destination} for a {num_days} day trip", stream=False)
+
+                # Show research progress
+                st.write(" Research completed")
+
+            with st.spinner("Creating your personalized itinerary..."):
+                # Pass research results to planner
+                prompt = f"""
+                Destination: {destination}
+                Duration: {num_days} days
+                Research Results: {research_results.content}
+
+                Please create a detailed itinerary based on this research.
+                """
+                response: RunOutput = planner.run(prompt, stream=False)
                 # Store the response in session state
                 st.session_state.itinerary = response.content
                 st.write(response.content)

--- a/starter_ai_agents/ai_travel_agent/travel_agent.py
+++ b/starter_ai_agents/ai_travel_agent/travel_agent.py
@@ -86,7 +86,7 @@ if openai_api_key and serp_api_key:
         ),
         instructions=[
             "Given a travel destination and the number of days the user wants to travel for, first generate a list of 3 search terms related to that destination and the number of days.",
-            "For each search term, `search_google` and analyze the results."
+            "For each search term, `search_google` and analyze the results.",
             "From the results of all searches, return the 10 most relevant results to the user's preferences.",
             "Remember: the quality of the results is important.",
         ],


### PR DESCRIPTION
## Summary

This PR fixes two bugs reported in issue #950.

### Bug 1: Researcher agent never invoked in local_travel_agent.py

The local variant defines a researcher agent with SerpApiTools but the button handler only called the planner directly. This meant:
- The SerpAPI key was collected but never used
- No web search was ever performed
- The itinerary came purely from the LLM training data

Fix: Mirrored the researcher-to-planner chaining pattern from the online variant (travel_agent.py).

### Bug 2: Missing comma in instructions list (both files)

In both local_travel_agent.py and travel_agent.py, a missing comma between two instruction strings caused Python to silently concatenate them into one run-on instruction.

Closes #950