### PR TITLE
Add Skill-Router G6 — self-learning MCP skill router for AI agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ streamlit run travel_agent.py
 *   [🧠 Advisor Orchestrator Worker](agent_skills/advisor-orchestrator-worker/) - Meta Loop with Claude Flabe 5 as advisor, GPT-5.6 as orchestrator, and Gemini 3.5 Flash as worker
 *   [♾️ Self-Improving Agent Skills](agent_skills/self-improving-agent-skills/) - Automatically optimize agent skills using Gemini and ADK
 
+*   [🎯 Skill-Router G6](https://github.com/ForYourHelpAI101/skill-router-g6) - Self-learning MCP skill router for AI coding agents. Routes prompts to the best 5 skills using Thompson sampling + RAG + DPP diversity. 805-skill handbook, ~65ms per route, 5-layer anti-hallucination
 ### 🌱 Starter AI Agents
 
 *Single-file agents that run with just an API key - a great place to start.*


### PR DESCRIPTION
Adds [Skill-Router G6](https://github.com/ForYourHelpAI101/skill-router-g6) — a self-learning MCP skill router for AI coding agents.

- 6-stage pipeline: RAG history + BM25 body retrieval + Thompson sampling + DPP diversity
- 767-skill handbook with Beta posteriors from task outcomes
- 5-layer anti-hallucination defense
- ~65ms per route, ~440ms end-to-end
- Model-agnostic, Python, MCP server
- 7 papers implemented (SkillRouter, SkillOrchestra, CoEvoSkills, Skill-R1, etc.)
- Fits in the Agent Skills section — it's a meta-skill that makes all other skills discoverable