### PR TITLE
Fix wrong Streamlit entrypoints in voice and competitor agent READMEs

### DIFF
--- a/advanced_ai_agents/multi_agent_apps/agent_teams/ai_competitor_intelligence_agent_team/README.md
+++ b/advanced_ai_agents/multi_agent_apps/agent_teams/ai_competitor_intelligence_agent_team/README.md
@@ -66,7 +66,7 @@ Follow these steps to set up and run the application:
 
 4. **Run the Streamlit app**:
     ```bash
-    streamlit run ai_competitor_analyser.py
+    streamlit run competitor_agent_team.py
     ```
 
 ## Usage

--- a/voice_ai_agents/customer_support_voice_agent/README.md
+++ b/voice_ai_agents/customer_support_voice_agent/README.md
@@ -43,7 +43,7 @@ An OpenAI SDK powered customer support agent application that delivers voice-pow
 
 3. **Run the Application**
    ```bash
-   streamlit run ai_voice_agent_docs.py
+   streamlit run customer_support_voice_agent.py
    ```
 
 4. **Use the Interface**


### PR DESCRIPTION
## What

Two READMEs documented `streamlit run` scripts that do not exist on disk, so the first-run commands failed.

### Diff

- `voice_ai_agents/customer_support_voice_agent/README.md`: `ai_voice_agent_docs.py` → `customer_support_voice_agent.py`
- `advanced_ai_agents/.../ai_competitor_intelligence_agent_team/README.md`: `ai_competitor_analyser.py` → `competitor_agent_team.py`

### Not touched

No application code changes — docs only, scoped to correcting entrypoint filenames.