### PR TITLE
Add HeyGen LiveAvatar agent under new video_ai_agents category

### DIFF
--- a/video_ai_agents/heygen_avatar_agent/.env.example
+++ b/video_ai_agents/heygen_avatar_agent/.env.example
@@ -1,3 +1,4 @@
-# Get your HeyGen API key at https://app.heygen.com/settings?nav=API
-# LiveAvatar docs: https://docs.liveavatar.com
+# LiveAvatar API key (HeyGen product) — get it at:
+# https://app.liveavatar.com/developers
+# Docs: https://docs.liveavatar.com
 HEYGEN_API_KEY=your_heygen_api_key_here

--- a/video_ai_agents/heygen_avatar_agent/.env.example
+++ b/video_ai_agents/heygen_avatar_agent/.env.example
@@ -1,0 +1,3 @@
+# Get your HeyGen API key at https://app.heygen.com/settings?nav=API
+# LiveAvatar docs: https://docs.liveavatar.com
+HEYGEN_API_KEY=your_heygen_api_key_here

--- a/video_ai_agents/heygen_avatar_agent/README.md
+++ b/video_ai_agents/heygen_avatar_agent/README.md
@@ -1,0 +1,86 @@
+# 🤖 HeyGen Avatar Agent
+
+A real-time conversational video avatar you can customize for any use case — customer support, sales, tutoring, or your own idea. Powered by HeyGen LiveAvatar.
+
+## Features
+
+- Real-time lip-synced video avatar that speaks and listens in your browser
+- HeyGen manages all speech recognition, LLM reasoning, and voice synthesis
+- Four built-in persona templates (Customer Support, Sales, Tutor, Personal Assistant)
+- Fully customizable system prompt — adapt the avatar to any role or use case
+- Custom opening line — the avatar greets users in your brand's voice
+- Sandbox mode for free testing (no credits, no paid plan required)
+- Choose an avatar face in production (public LiveAvatar catalog, or your own ID)
+- Zero WebRTC or audio encoding code needed — HeyGen's embed handles it
+
+## How to get Started
+
+1. **Clone the repo**
+   ```bash
+   git clone https://github.com/Shubhamsaboo/awesome-llm-apps.git
+   cd awesome-llm-apps/video_ai_agents/heygen_avatar_agent
+   ```
+
+2. **Create and activate a virtual environment**
+   ```bash
+   # macOS / Linux
+   python -m venv venv
+   source venv/bin/activate
+
+   # Windows
+   python -m venv venv
+   .\venv\Scripts\activate
+   ```
+
+3. **Install dependencies**
+   ```bash
+   pip install -r requirements.txt
+   ```
+
+4. **Get your HeyGen API key**
+   - Sign up at https://app.heygen.com
+   - Go to Settings → API → copy your key
+   - Create a `.env` file:
+   ```bash
+   HEYGEN_API_KEY=your_heygen_api_key_here
+   ```
+   (Or paste it directly in the sidebar — no .env file needed for quick testing)
+
+5. **Run the app**
+   ```bash
+   streamlit run avatar_agent.py
+   ```
+
+6. **Configure and launch**
+   - Set your persona in the sidebar
+   - Use the **Sandbox (free)** tab to use Wayne, or **Choose Avatar Face** to pick another face
+   - Click **Launch Avatar** — the live embed opens; use **Back to config** to return
+
+## Project structure
+
+The agent is split into small, single-responsibility modules so it stays easy to read and extend:
+
+```
+heygen_avatar_agent/
+├── avatar_agent.py       # App flow — state, sidebar, launch (run this)
+├── ui_helpers.py         # Layout CSS, previews, Sandbox / Faces / Live views
+├── config.py             # Settings + API key resolution
+├── personas.py           # Built-in persona presets (pure data)
+├── liveavatar_client.py  # UI-agnostic LiveAvatar API client
+├── requirements.txt
+└── .env.example
+```
+
+- **Add a persona** — append a `Persona` to `PERSONAS` in `personas.py`; the sidebar picks it up automatically.
+- **Tweak the UI** — gallery layout and preview cards live in `ui_helpers.py`.
+- **Reuse the API** — `LiveAvatarClient` has no Streamlit dependency, so you can call it from any script or test.
+
+## How it works
+
+1. **Persona creation** — Your system prompt is sent to the LiveAvatar Contexts API, which stores the avatar's role, behavior, and knowledge boundaries. The opening line sets what the avatar says first when the session starts.
+
+2. **Embed generation** — A single API call to `/v2/embeddings` provisions a fully managed session and returns an iframe URL. HeyGen handles WebRTC, room management, and all infrastructure behind the scenes.
+
+3. **Live conversation** — The iframe runs in your browser. HeyGen's pipeline processes your speech (ASR), generates a response using the LLM with your system prompt as context, converts it to speech (TTS), and drives the avatar's lip-sync in real time. No client-side audio code required.
+
+4. **Sandbox vs Production** — Sandbox mode uses a single free test face (**Wayne**, `dd73ea75-1218-4ef3-92ce-606d5f7fbc0a`) and sessions last ~1 minute. For production: uncheck Sandbox Mode, pick a face from the public avatar list (or paste your own avatar ID from the LiveAvatar dashboard), and sessions run at 2 credits/minute.

--- a/video_ai_agents/heygen_avatar_agent/README.md
+++ b/video_ai_agents/heygen_avatar_agent/README.md
@@ -37,9 +37,9 @@ A real-time conversational video avatar you can customize for any use case — c
    pip install -r requirements.txt
    ```
 
-4. **Get your HeyGen API key**
-   - Sign up at https://app.heygen.com
-   - Go to Settings → API → copy your key
+4. **Get your HeyGen (LiveAvatar) API key**
+   - Open [LiveAvatar Developers](https://app.liveavatar.com/developers) (LiveAvatar is a HeyGen product)
+   - Copy your API key
    - Create a `.env` file:
    ```bash
    HEYGEN_API_KEY=your_heygen_api_key_here

--- a/video_ai_agents/heygen_avatar_agent/avatar_agent.py
+++ b/video_ai_agents/heygen_avatar_agent/avatar_agent.py
@@ -1,0 +1,123 @@
+"""Streamlit entry point for the HeyGen Avatar Agent.
+
+Owns app flow only: session state, sidebar config, launch, and view switching.
+Presentation details live in `ui_helpers.py`.
+
+Run with: streamlit run avatar_agent.py
+"""
+
+import streamlit as st
+
+from config import SANDBOX_AVATAR_ID, resolve_api_key
+from liveavatar_client import LiveAvatarClient, LiveAvatarError
+from personas import get_persona, persona_names
+from ui_helpers import apply_compact_layout, render_config, render_live
+
+
+def init_state():
+    """Seed session defaults on first load."""
+    if "role" not in st.session_state:
+        apply_persona(persona_names()[0])
+    if "selected_avatar_id" not in st.session_state:
+        st.session_state.selected_avatar_id = SANDBOX_AVATAR_ID
+    if "launch_mode" not in st.session_state:
+        st.session_state.launch_mode = "sandbox"
+
+
+def apply_persona(name):
+    """Fill the editable prompt fields from the chosen persona preset."""
+    persona = get_persona(name)
+    st.session_state.role = name
+    st.session_state.prompt_text = persona.prompt
+    st.session_state.opening_text = persona.opening_text
+
+
+def render_sidebar():
+    """Config sidebar — API key, persona, launch mode summary, and Launch."""
+    with st.sidebar:
+        st.header("Configuration")
+        api_key_input = st.text_input(
+            "HeyGen API Key",
+            type="password",
+            help="Get your key at liveavatar.com. Overrides HEYGEN_API_KEY env var.",
+        )
+        api_key = resolve_api_key(api_key_input)
+
+        st.divider()
+
+        st.header("Avatar Persona")
+        selected = st.selectbox("Role Template", persona_names())
+        if selected != st.session_state.role:
+            apply_persona(selected)
+
+        st.text_area("System Prompt", key="prompt_text", height=140)
+        st.text_input("Opening Line", key="opening_text")
+
+        st.divider()
+
+        if st.session_state.launch_mode == "sandbox":
+            st.caption("Ready to launch: **Sandbox — Wayne (free)**")
+        else:
+            st.caption(
+                f"Ready to launch: **Production**\n\n"
+                f"`{st.session_state.selected_avatar_id}`"
+            )
+
+        launch = st.button("Launch Avatar", type="primary", use_container_width=True)
+
+    return api_key, launch
+
+
+def handle_launch(api_key):
+    """Validate input, create persona + session, then show the live embed."""
+    is_sandbox = st.session_state.launch_mode == "sandbox"
+    avatar_id = (
+        SANDBOX_AVATAR_ID if is_sandbox else st.session_state.selected_avatar_id
+    )
+
+    if not api_key:
+        st.warning("Please add your HeyGen API key in the sidebar to continue.")
+        return
+    if not is_sandbox and not avatar_id:
+        st.warning("Open Choose Avatar Face and select a face first.")
+        return
+    if not st.session_state.prompt_text.strip():
+        st.warning("Please add a system prompt so the avatar knows how to behave.")
+        return
+
+    client = LiveAvatarClient(api_key)
+    with st.spinner("Setting up your avatar..."):
+        try:
+            context_id = client.ensure_context(
+                st.session_state.role,
+                st.session_state.prompt_text,
+                st.session_state.opening_text,
+            )
+            st.session_state.embed_url = client.create_embed(
+                avatar_id, context_id, is_sandbox
+            )
+        except LiveAvatarError as exc:
+            st.error(f"Could not start the avatar session. Details: {exc}")
+            return
+
+    st.rerun()
+
+
+def main():
+    st.set_page_config(
+        page_title="HeyGen Avatar Agent", page_icon="🤖", layout="wide"
+    )
+    apply_compact_layout()
+    init_state()
+    api_key, launch = render_sidebar()
+
+    if launch:
+        handle_launch(api_key)
+    elif "embed_url" in st.session_state:
+        render_live()
+    else:
+        render_config(api_key)
+
+
+if __name__ == "__main__":
+    main()

--- a/video_ai_agents/heygen_avatar_agent/avatar_agent.py
+++ b/video_ai_agents/heygen_avatar_agent/avatar_agent.py
@@ -39,7 +39,11 @@ def render_sidebar():
         api_key_input = st.text_input(
             "HeyGen API Key",
             type="password",
-            help="Get your key at liveavatar.com. Overrides HEYGEN_API_KEY env var.",
+            help=(
+                "LiveAvatar by HeyGen — get your key at "
+                "https://app.liveavatar.com/developers. "
+                "Overrides HEYGEN_API_KEY env var."
+            ),
         )
         api_key = resolve_api_key(api_key_input)
 

--- a/video_ai_agents/heygen_avatar_agent/config.py
+++ b/video_ai_agents/heygen_avatar_agent/config.py
@@ -21,9 +21,14 @@ EMBED_HEIGHT = 720
 
 
 def resolve_api_key(override=None):
-    """Return the HeyGen API key.
+    """Return the LiveAvatar (HeyGen) API key.
 
-    A non-empty override (e.g. the sidebar field) always wins over the
-    HEYGEN_API_KEY environment variable.
+    A non-empty override (e.g. the sidebar field) always wins. Otherwise
+    HEYGEN_API_KEY is used (LIVEAVATAR_API_KEY is accepted as a fallback).
+    Get a key at https://app.liveavatar.com/developers
     """
-    return (override or "").strip() or os.getenv("HEYGEN_API_KEY", "")
+    return (
+        (override or "").strip()
+        or os.getenv("HEYGEN_API_KEY", "")
+        or os.getenv("LIVEAVATAR_API_KEY", "")
+    )

--- a/video_ai_agents/heygen_avatar_agent/config.py
+++ b/video_ai_agents/heygen_avatar_agent/config.py
@@ -1,0 +1,29 @@
+"""Central configuration for the HeyGen Avatar Agent.
+
+Keeping settings in one place means the UI and API layers never hardcode
+endpoints or IDs, which makes the agent easy to point at a different
+environment or reuse in tests.
+"""
+
+import os
+
+from dotenv import load_dotenv
+
+load_dotenv()
+
+BASE_URL = "https://api.liveavatar.com"
+
+# Free sandbox test avatar: no credits consumed, sessions last ~1 minute.
+SANDBOX_AVATAR_ID = "dd73ea75-1218-4ef3-92ce-606d5f7fbc0a"
+
+# Height (px) of the embedded avatar iframe — tall enough to show the Chat button.
+EMBED_HEIGHT = 720
+
+
+def resolve_api_key(override=None):
+    """Return the HeyGen API key.
+
+    A non-empty override (e.g. the sidebar field) always wins over the
+    HEYGEN_API_KEY environment variable.
+    """
+    return (override or "").strip() or os.getenv("HEYGEN_API_KEY", "")

--- a/video_ai_agents/heygen_avatar_agent/liveavatar_client.py
+++ b/video_ai_agents/heygen_avatar_agent/liveavatar_client.py
@@ -1,0 +1,109 @@
+"""Client for the HeyGen LiveAvatar REST API.
+
+This layer owns every HTTP detail (base URL, auth header, error handling) and
+stays completely UI-agnostic: on failure it raises `LiveAvatarError` instead of
+calling Streamlit. That separation keeps the client reusable from any frontend,
+script, or test (Single Responsibility + Dependency Inversion).
+"""
+
+import requests
+
+from config import BASE_URL
+
+
+class LiveAvatarError(Exception):
+    """Raised when a LiveAvatar API call fails."""
+
+
+class LiveAvatarClient:
+    """Thin wrapper around the LiveAvatar endpoints this agent needs."""
+
+    def __init__(self, api_key, base_url=BASE_URL, timeout=30):
+        self._api_key = api_key
+        self._base_url = base_url.rstrip("/")
+        self._timeout = timeout
+
+    @property
+    def _headers(self):
+        return {"X-API-KEY": self._api_key, "Content-Type": "application/json"}
+
+    def _request(self, method, path, body=None):
+        """Send a request and return the `data` object, or raise LiveAvatarError."""
+        try:
+            response = requests.request(
+                method,
+                f"{self._base_url}{path}",
+                json=body,
+                headers=self._headers,
+                timeout=self._timeout,
+            )
+            response.raise_for_status()
+        except requests.RequestException as exc:
+            detail = getattr(exc.response, "text", None) or str(exc)
+            raise LiveAvatarError(detail) from exc
+        payload = response.json()
+        return payload.get("data")
+
+    def list_contexts(self, page=1, page_size=100):
+        """Return the list of contexts owned by this API key."""
+        data = self._request(
+            "GET", f"/v1/contexts?page={page}&page_size={page_size}"
+        )
+        return (data or {}).get("results", [])
+
+    def create_context(self, name, prompt, opening_text):
+        """Create an avatar persona (context) and return its id."""
+        body = {"name": name, "prompt": prompt, "opening_text": opening_text}
+        return self._request("POST", "/v1/contexts", body)["id"]
+
+    def update_context(self, context_id, name, prompt, opening_text):
+        """Update an existing context and return its id."""
+        body = {"name": name, "prompt": prompt, "opening_text": opening_text}
+        return self._request("PATCH", f"/v1/contexts/{context_id}", body)["id"]
+
+    def ensure_context(self, name, prompt, opening_text):
+        """Create or update a context by name so relaunches never collide.
+
+        LiveAvatar requires unique context names. Reusing the same role template
+        would fail on the second Launch; this upserts instead.
+        """
+        for context in self.list_contexts():
+            if context.get("name") == name:
+                return self.update_context(
+                    context["id"], name, prompt, opening_text
+                )
+        return self.create_context(name, prompt, opening_text)
+
+    def list_public_avatars(self, page=1, page_size=50):
+        """Return public avatars as [{id, name, preview_url}, ...]."""
+        data = self._request(
+            "GET", f"/v1/avatars/public?page={page}&page_size={page_size}"
+        )
+        results = (data or {}).get("results", [])
+        return [
+            {
+                "id": item["id"],
+                "name": item.get("name") or item["id"],
+                "preview_url": item.get("preview_url") or "",
+            }
+            for item in results
+            if item.get("status", "ACTIVE") == "ACTIVE" or "status" not in item
+        ]
+
+    def get_avatar(self, avatar_id):
+        """Fetch a single avatar by id (name + preview_url)."""
+        data = self._request("GET", f"/v1/avatars/{avatar_id}") or {}
+        return {
+            "id": data.get("id") or avatar_id,
+            "name": data.get("name") or "Wayne",
+            "preview_url": data.get("preview_url") or "",
+        }
+
+    def create_embed(self, avatar_id, context_id, is_sandbox):
+        """Provision a managed session and return the embed URL."""
+        body = {
+            "avatar_id": avatar_id,
+            "context_id": context_id,
+            "is_sandbox": is_sandbox,
+        }
+        return self._request("POST", "/v2/embeddings", body)["url"]

--- a/video_ai_agents/heygen_avatar_agent/personas.py
+++ b/video_ai_agents/heygen_avatar_agent/personas.py
@@ -1,0 +1,87 @@
+"""Built-in avatar persona presets.
+
+Personas are plain data. To add a new one, append a `Persona` to `PERSONAS`;
+the sidebar and API layers pick it up automatically, so no other file needs to
+change (Open/Closed principle). The "Custom" entry is intentionally blank so the
+user can write their own system prompt.
+"""
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class Persona:
+    """A reusable avatar role: what it does, how it behaves, and its greeting."""
+
+    name: str
+    description: str
+    prompt: str
+    opening_text: str
+
+
+PERSONAS = [
+    Persona(
+        name="Customer Support Agent",
+        description="Handles customer queries, resolves issues, and provides product guidance.",
+        prompt=(
+            "You are a friendly and professional customer support agent. Help users resolve "
+            "issues, answer product questions, and escalate when needed. Be empathetic, concise, "
+            "and solution-focused. Always greet the user warmly and confirm their issue before "
+            "responding."
+        ),
+        opening_text="Hi there! I'm your support agent. How can I help you today?",
+    ),
+    Persona(
+        name="Sales Representative",
+        description="Engages prospects, understands their needs, and presents solutions.",
+        prompt=(
+            "You are an experienced sales representative. Your goal is to understand "
+            "the prospect's pain points and present relevant solutions. Ask discovery questions, "
+            "listen actively, handle objections gracefully, and guide the conversation toward "
+            "a clear next step. Be consultative, not pushy."
+        ),
+        opening_text=(
+            "Hello! Great to connect with you. Tell me a bit about what you're "
+            "working on — I'd love to see how I can help."
+        ),
+    ),
+    Persona(
+        name="AI Tutor",
+        description="Teaches concepts, answers questions, and adapts to the learner's level.",
+        prompt=(
+            "You are a patient and knowledgeable tutor. Break down complex topics into "
+            "clear, digestible explanations. Ask questions to gauge understanding, give examples, "
+            "and encourage the learner. Adapt your teaching style to the learner's level. "
+            "Topics can range from coding to math to history."
+        ),
+        opening_text="Hey! I'm your tutor. What would you like to learn today?",
+    ),
+    Persona(
+        name="Personal Assistant",
+        description="Helps with tasks, planning, reminders, and general questions.",
+        prompt=(
+            "You are a helpful and proactive personal assistant. Help the user think "
+            "through tasks, organize their thoughts, draft messages, plan their day, or answer "
+            "general questions. Be concise, practical, and friendly."
+        ),
+        opening_text="Hi! I'm your personal assistant. What can I help you with today?",
+    ),
+    Persona(
+        name="Custom",
+        description="Write your own system prompt to adapt the avatar to any use case.",
+        prompt="",
+        opening_text="",
+    ),
+]
+
+_PERSONAS_BY_NAME = {persona.name: persona for persona in PERSONAS}
+
+
+def persona_names():
+    """Return persona names in display order for the sidebar selectbox."""
+    return [persona.name for persona in PERSONAS]
+
+
+def get_persona(name):
+    """Look up a persona by its display name."""
+    return _PERSONAS_BY_NAME[name]

--- a/video_ai_agents/heygen_avatar_agent/requirements.txt
+++ b/video_ai_agents/heygen_avatar_agent/requirements.txt
@@ -1,0 +1,3 @@
+streamlit
+requests
+python-dotenv

--- a/video_ai_agents/heygen_avatar_agent/ui_helpers.py
+++ b/video_ai_agents/heygen_avatar_agent/ui_helpers.py
@@ -1,0 +1,262 @@
+"""Reusable Streamlit presentation helpers for the HeyGen Avatar Agent.
+
+Owns layout CSS, avatar preview cards, and the Sandbox / Faces / Live views so
+`avatar_agent.py` can stay focused on app flow (state, sidebar, launch).
+"""
+
+from html import escape
+
+import streamlit as st
+import streamlit.components.v1 as components
+
+from config import EMBED_HEIGHT, SANDBOX_AVATAR_ID
+from liveavatar_client import LiveAvatarClient, LiveAvatarError
+
+GALLERY_COLS = 5
+PREVIEW_ASPECT = "1 / 1"
+PREVIEW_SIZE_PX = 132
+SANDBOX_PREVIEW_SIZE_PX = 160
+
+
+def apply_compact_layout():
+    """Tighten Streamlit chrome so the UI fits at normal browser zoom."""
+    st.markdown(
+        """
+        <style>
+          .block-container {
+            padding-top: 1.25rem;
+            padding-bottom: 1.5rem;
+            max-width: 1100px;
+          }
+          [data-testid="stSidebar"] [data-testid="stMarkdownContainer"] p,
+          [data-testid="stSidebar"] label {
+            font-size: 0.9rem;
+          }
+          h1 { font-size: 1.6rem !important; margin-bottom: 0.2rem !important; }
+          h2, h3 { font-size: 1.15rem !important; }
+          div[data-testid="stCaptionContainer"] { margin-bottom: 0.4rem; }
+        </style>
+        """,
+        unsafe_allow_html=True,
+    )
+
+
+def avatar_preview_html(preview_url, alt="Avatar", size_px=PREVIEW_SIZE_PX):
+    """Return HTML for a uniformly cropped, size-capped avatar preview."""
+    safe_alt = escape(alt or "Avatar")
+    if preview_url:
+        media = (
+            f'<img src="{escape(preview_url, quote=True)}" alt="{safe_alt}" '
+            f'style="width:100%;height:100%;object-fit:cover;display:block;" />'
+        )
+    else:
+        media = (
+            '<div style="width:100%;height:100%;display:flex;align-items:center;'
+            'justify-content:center;background:#e8eef5;color:#5b6b7c;'
+            'font-size:22px;">?</div>'
+        )
+    return (
+        f'<div style="width:{size_px}px;max-width:100%;aspect-ratio:{PREVIEW_ASPECT};'
+        f'overflow:hidden;border-radius:10px;background:#e8eef5;margin:0 auto;">'
+        f"{media}</div>"
+    )
+
+
+def load_public_avatars(api_key):
+    """Fetch public avatars once per API key and cache them in session state."""
+    if not api_key:
+        return []
+    cache_key = f"avatars_{api_key[-8:]}"
+    if st.session_state.get("avatars_cache_key") == cache_key:
+        return st.session_state.get("public_avatars", [])
+    try:
+        avatars = LiveAvatarClient(api_key).list_public_avatars(page_size=50)
+    except LiveAvatarError as exc:
+        st.warning(f"Could not load avatar faces. Details: {exc}")
+        avatars = []
+    st.session_state.avatars_cache_key = cache_key
+    st.session_state.public_avatars = avatars
+    return avatars
+
+
+def load_sandbox_avatar(api_key):
+    """Load Wayne's preview for the Sandbox tab (cached)."""
+    if "sandbox_avatar" in st.session_state:
+        return st.session_state.sandbox_avatar
+
+    fallback = {"id": SANDBOX_AVATAR_ID, "name": "Wayne", "preview_url": ""}
+    if not api_key:
+        st.session_state.sandbox_avatar = fallback
+        return fallback
+
+    try:
+        client = LiveAvatarClient(api_key)
+        try:
+            avatar = client.get_avatar(SANDBOX_AVATAR_ID)
+        except LiveAvatarError:
+            avatar = next(
+                (
+                    a
+                    for a in client.list_public_avatars(page_size=50)
+                    if a["id"] == SANDBOX_AVATAR_ID
+                ),
+                fallback,
+            )
+    except LiveAvatarError:
+        avatar = fallback
+
+    st.session_state.sandbox_avatar = avatar
+    return avatar
+
+
+def render_sandbox_tab(api_key):
+    """Friendly Sandbox tab with Wayne's portrait and a clear Use button."""
+    left, right = st.columns([1, 2])
+    avatar = load_sandbox_avatar(api_key)
+
+    with left:
+        st.markdown(
+            avatar_preview_html(
+                avatar.get("preview_url"),
+                avatar.get("name", "Wayne"),
+                size_px=SANDBOX_PREVIEW_SIZE_PX,
+            ),
+            unsafe_allow_html=True,
+        )
+
+    with right:
+        st.subheader(f"{avatar.get('name', 'Wayne')} — free sandbox avatar")
+        st.write(
+            "Try the agent at no cost. Sessions last about **1 minute** and "
+            "do not consume credits. Perfect for checking your prompt and mic setup."
+        )
+        st.caption(f"Avatar ID: `{SANDBOX_AVATAR_ID}`")
+
+        is_active = st.session_state.launch_mode == "sandbox"
+        if st.button(
+            "Using for launch" if is_active else "Use this free avatar",
+            type="primary" if is_active else "secondary",
+            disabled=is_active,
+            use_container_width=True,
+            key="use_sandbox_avatar",
+        ):
+            st.session_state.launch_mode = "sandbox"
+            st.session_state.selected_avatar_id = SANDBOX_AVATAR_ID
+            st.rerun()
+
+        if is_active:
+            st.success("Sandbox is selected. Click **Launch Avatar** in the sidebar.")
+        else:
+            st.info(
+                "Open **Choose Avatar Face** to pick a production face, or use Wayne here."
+            )
+
+
+def render_faces_tab(api_key):
+    """Clickable face gallery for production sessions."""
+    st.caption(
+        "Select a face below to use a production session (credits apply), "
+        "then click **Launch Avatar** in the sidebar."
+    )
+
+    if not api_key:
+        st.warning("Add your HeyGen API key in the sidebar to load avatar faces.")
+        return
+
+    avatars = load_public_avatars(api_key)
+    if not avatars:
+        custom = st.text_input(
+            "Avatar ID",
+            value=st.session_state.get("selected_avatar_id", ""),
+            help="Paste an avatar ID from https://app.liveavatar.com",
+        )
+        if st.button("Use this avatar ID") and custom.strip():
+            st.session_state.selected_avatar_id = custom.strip()
+            st.session_state.launch_mode = "production"
+            st.rerun()
+        return
+
+    selected_id = st.session_state.selected_avatar_id
+    known_ids = {a["id"] for a in avatars}
+    if (
+        st.session_state.launch_mode == "production"
+        and selected_id not in known_ids
+        and selected_id == SANDBOX_AVATAR_ID
+    ):
+        st.session_state.selected_avatar_id = avatars[0]["id"]
+        selected_id = st.session_state.selected_avatar_id
+
+    for start in range(0, len(avatars), GALLERY_COLS):
+        cols = st.columns(GALLERY_COLS)
+        for col, avatar in zip(cols, avatars[start : start + GALLERY_COLS]):
+            with col:
+                st.markdown(
+                    avatar_preview_html(
+                        avatar.get("preview_url"), avatar.get("name", "Avatar")
+                    ),
+                    unsafe_allow_html=True,
+                )
+                st.caption(avatar["name"])
+                is_selected = (
+                    st.session_state.launch_mode == "production"
+                    and avatar["id"] == selected_id
+                )
+                if st.button(
+                    "Selected" if is_selected else "Select",
+                    key=f"avatar_{avatar['id']}",
+                    use_container_width=True,
+                    type="primary" if is_selected else "secondary",
+                    disabled=is_selected,
+                ):
+                    st.session_state.selected_avatar_id = avatar["id"]
+                    st.session_state.launch_mode = "production"
+                    st.rerun()
+
+    with st.expander("Or paste a custom avatar ID"):
+        custom = st.text_input(
+            "Custom Avatar ID",
+            value=selected_id if selected_id not in known_ids else "",
+            help="Your production avatar ID from the LiveAvatar dashboard.",
+        )
+        if st.button("Use custom ID", use_container_width=True) and custom.strip():
+            st.session_state.selected_avatar_id = custom.strip()
+            st.session_state.launch_mode = "production"
+            st.rerun()
+
+    if st.session_state.launch_mode == "production":
+        st.caption(f"Selected avatar ID: `{st.session_state.selected_avatar_id}`")
+
+
+def render_config(api_key):
+    """Main config view with Sandbox / Choose Face tabs."""
+    st.title("HeyGen Avatar Agent")
+    st.caption(
+        "A real-time conversational video avatar — powered by HeyGen LiveAvatar"
+    )
+
+    sandbox_tab, faces_tab = st.tabs(["Sandbox (free)", "Choose Avatar Face"])
+    with sandbox_tab:
+        render_sandbox_tab(api_key)
+    with faces_tab:
+        render_faces_tab(api_key)
+
+
+def render_live():
+    """Embed-only live view with a back-to-config control."""
+    top_left, top_right = st.columns([4, 1])
+    with top_left:
+        st.title("HeyGen Avatar Agent")
+        st.caption("Allow microphone access when prompted.")
+    with top_right:
+        st.write("")
+        st.write("")
+        if st.button("Back to config", use_container_width=True):
+            st.session_state.pop("embed_url", None)
+            st.rerun()
+
+    components.html(
+        f'<iframe src="{st.session_state.embed_url}" allow="microphone" '
+        f'title="LiveAvatar Embed" style="width:100%;height:{EMBED_HEIGHT}px;'
+        f'border:0;"></iframe>',
+        height=EMBED_HEIGHT,
+    )


### PR DESCRIPTION
## Summary
- Adds a new top-level category `video_ai_agents` with the first agent: `heygen_avatar_agent`
- Streamlit app that launches a real-time lip-synced conversational avatar via HeyGen LiveAvatar Embed (no WebRTC/LiveKit client code)
- Includes Sandbox (free Wayne avatar) and Choose Avatar Face gallery, plus editable persona presets (Support, Sales, Tutor, Assistant, Custom)
- Modular layout: `avatar_agent.py` (flow), `ui_helpers.py` (UI), `liveavatar_client.py` (API), `config.py`, `personas.py`

## Test plan
- [ ] `cd video_ai_agents/heygen_avatar_agent && python -m venv venv && pip install -r requirements.txt`
- [ ] Set `HEYGEN_API_KEY` in `.env` (or paste in sidebar)
- [ ] `streamlit run avatar_agent.py`
- [ ] Launch from **Sandbox (free)** and confirm the avatar loads + mic prompt works
- [ ] Open **Choose Avatar Face**, select a face, launch, then use **Back to config**