### PR TITLE
fix: use exa-py instead of unrelated exa package in RAG tutorials

### DIFF
--- a/rag_tutorials/deepseek_local_rag_agent/requirements.txt
+++ b/rag_tutorials/deepseek_local_rag_agent/requirements.txt
@@ -1,5 +1,5 @@
 agno
-exa==0.5.26
+exa-py
 qdrant-client==1.12.1
 langchain-qdrant==0.2.0
 langchain-community==0.3.13

--- a/rag_tutorials/gemini_agentic_rag/requirements.txt
+++ b/rag_tutorials/gemini_agentic_rag/requirements.txt
@@ -1,5 +1,5 @@
 agno
-exa==0.5.26
+exa-py
 qdrant-client==1.12.1
 langchain-qdrant==0.2.0
 langchain-community==0.3.13

--- a/rag_tutorials/qwen_local_rag/requirements.txt
+++ b/rag_tutorials/qwen_local_rag/requirements.txt
@@ -1,6 +1,6 @@
 agno>=2.2.10
 pypdf
-exa
+exa-py
 qdrant-client
 langchain-qdrant
 langchain-community


### PR DESCRIPTION
## Summary
Three RAG tutorials incorrectly list the PyPI package `exa` instead of the official Exa AI Python SDK `exa-py`.

- PyPI [`exa`](https://pypi.org/project/exa/) is an unrelated **Exa Analytics** data-engineering package.
- PyPI [`exa-py`](https://pypi.org/project/exa-py/) is the official **Exa AI** SDK (`from exa_py import Exa`).
- These apps use Agno’s `ExaTools`, which imports `exa_py`. With the wrong requirement, install can succeed, but Exa web search fails.

This PR replaces the wrong dependency in:

- `rag_tutorials/gemini_agentic_rag/requirements.txt` (`exa==0.5.26` → `exa-py`)
- `rag_tutorials/deepseek_local_rag_agent/requirements.txt` (`exa==0.5.26` → `exa-py`)
- `rag_tutorials/qwen_local_rag/requirements.txt` (`exa` → `exa-py`)

Same pattern already exists in-repo: `advanced_ai_agents/multi_agent_apps/ai_email_gtm_outreach_agent/requirements.txt` uses `exa_py`.

Fixes #995

## Why this matters
`pip install -r requirements.txt` does **not** always fail. It can install the wrong `exa` package successfully. The breakage shows up when using Exa web search / `ExaTools`:

```text
ImportError: `exa_py` not installed. Please install using `pip install exa_py`
```

Local RAG without web search may still work. This PR only fixes the Exa package name and does not change app logic.

## How to verify (for maintainers)

```bash
cd rag_tutorials/gemini_agentic_rag
python -m venv .venv-verify
# activate the venv

# Before this PR (or on main):
pip install "exa==0.5.26"
pip show exa
# Summary should be something like: "A framework for data engineering and science"

pip show exa-py
# Package not found

python -c "from agno.tools.exa import ExaTools"
# ImportError: `exa_py` not installed...

# After this PR:
pip uninstall exa -y
pip install -r requirements.txt
pip show exa-py
python -c "from exa_py import Exa; from agno.tools.exa import ExaTools; print('OK')"
```

Repeat the same install check for the other two tutorial folders if desired.

## Test plan
- [x] Reproduced wrong package install (`exa` = Exa Analytics, not Exa AI)
- [x] Reproduced `ModuleNotFoundError: No module named 'exa_py'`
- [x] Reproduced Agno `ExaTools` `ImportError` asking for `exa_py`
- [x] Confirmed fix installs `exa-py` and restores `ExaTools` import
- [ ] Maintainer confirmation on one of the three tutorials

## Notes
- Scoped to dependency rename only.
- Intentionally does **not** include other missing deps observed while running Streamlit (e.g. `google-generativeai`, `beautifulsoup4`); those are separate from this Exa package mix-up.