### PR TITLE
Fix AI travel agent setup path

### DIFF
--- a/starter_ai_agents/ai_travel_agent/README.MD
+++ b/starter_ai_agents/ai_travel_agent/README.MD
@@ -14,7 +14,7 @@ This Streamlit app is an AI-powered travel Agent that generates personalized tra
 
 ```bash
 git clone https://github.com/Shubhamsaboo/awesome-llm-apps.git
-cd awesome-llm-apps/ai_agent_tutorials/ai_travel_agent
+cd awesome-llm-apps/starter_ai_agents/ai_travel_agent
 ```
 2. Install the required dependencies:
 


### PR DESCRIPTION
  ## Summary

  Fixes the setup path in the AI Travel Agent README.

  The README previously pointed to `ai_agent_tutorials/ai_travel_agent`, but the project now lives under
  `starter_ai_agents/ai_travel_agent`.

  ## Testing

  Documentation-only change.