### PR TITLE
Add Darkmoon (GPL-3.0 autonomous pentest platform / MCP host)

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ streamlit run travel_agent.py
 *   [🧬 AI Self-Evolving Agent](advanced_ai_agents/multi_agent_apps/ai_self_evolving_agent/) - Agents that rewrite their own workflows with EvoAgentX
 *   [👨🏻‍💼 AI Sales Intelligence Agent Team](advanced_ai_agents/multi_agent_apps/agent_teams/ai_sales_intelligence_agent_team) - Generates competitive sales battle cards in real time
 *   [🎧 AI Social Media News and Podcast Agent](advanced_ai_agents/multi_agent_apps/ai_news_and_podcast_agents/) - Curates your trusted sources into briefs and generated podcasts
+* [Darkmoon](https://github.com/ASCIT31/Dark-Moon) - Open source (GPL-3.0) autonomous AI penetration testing platform and MCP host covering web, API, Active Directory and Kubernetes, with proof of exploitation and a local privacy gateway so the model never sees real IPs, hosts or credentials.
 *   [🌐 Openwork - Open Browser Automation Agent](https://github.com/accomplish-ai/openwork) <sub>↗ external</sub> - Open-source agent that operates a real browser
 *   [🛡️ Trust-Gated Multi-Agent Research Team](advanced_ai_agents/multi_agent_apps/trust_gated_agent_team/) - Every agent verified, every action in a hash-chained audit trail
 


### PR DESCRIPTION
Hi, thanks for maintaining this list.

Adding **Darkmoon**, a GPL-3.0 autonomous penetration testing platform and MCP host. It covers Active Directory and Kubernetes alongside web and APIs, and its privacy gateway keeps target data away from the LLM (real values are reinjected locally just before a tool runs). Repo: https://github.com/ASCIT31/Dark-Moon

Full disclosure: this is our project. Happy to adjust wording/placement or close it if it is not a fit.