### PR TITLE
Add Private Mind on-device AI app

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,12 @@ streamlit run travel_agent.py
 *   [🔊 Voice RAG Agent (OpenAI SDK)](voice_ai_agents/voice_rag_openaisdk/) - Ask your PDFs questions, hear the answers
 *   [🎙️ OpenSource Voice Dictation Agent (Wispr Flow clone)](https://github.com/akshayaggarwal99/jarvis-ai-assistant) <sub>↗ external</sub> - Open-source dictation that types where you talk
 
+### 📱 On-Device AI Apps
+
+*AI apps that run models locally on your phone or computer - private by design, no cloud required.*
+
+*   [🧠 Private Mind](on_device_ai_apps/private_mind/) - Chat with LLMs 100% on-device on iOS and Android, offline and free
+
 ### 🖼️ Generative UI and Agentic Frontends
 
 *Agents that render interactive UI components, not just text: forms, cards, charts, editable plans.*

--- a/on_device_ai_apps/private_mind/README.md
+++ b/on_device_ai_apps/private_mind/README.md
@@ -1,0 +1,43 @@
+# Private Mind - local AI chat on your phone
+
+Private Mind is an open-source mobile app that runs LLMs entirely on your phone. There is no cloud backend: models execute locally through [React Native ExecuTorch](https://github.com/software-mansion/react-native-executorch), so conversations never leave the device. No account, no subscription, no data collection.
+
+Built by [Software Mansion](https://swmansion.com), the team behind React Native ExecuTorch, Reanimated, and Gesture Handler.
+
+- Official repo: [software-mansion-labs/private-mind](https://github.com/software-mansion-labs/private-mind)
+- [App Store](https://apps.apple.com/us/app/private-mind/id6746713439) | [Google Play](https://play.google.com/store/apps/details?id=com.swmansion.privatemind)
+
+## Features
+
+- Chat with LLMs fully offline. After a model is downloaded, the app works with no internet connection at all.
+- Pick from the built-in model catalog or load your own ExecuTorch-exported model.
+- Benchmark models on your own hardware to compare speed before committing to one.
+- Everything is stored locally on the device. Nothing is collected or shared.
+- Work with images and documents without sharing them with providers.
+
+## How it works
+
+The app is written in TypeScript with Expo (React Native). Inference runs through [react-native-executorch](https://github.com/software-mansion/react-native-executorch), a declarative API over PyTorch's [ExecuTorch](https://pytorch.org/executorch/) runtime, which executes quantized models directly on the phone's hardware. This is the same stack you would use to add on-device AI to your own React Native app, and Private Mind doubles as a full reference implementation for it.
+
+## Run from source
+
+If you just want to use the app, install it from the [App Store](https://apps.apple.com/us/app/private-mind/id6746713439) or [Google Play](https://play.google.com/store/apps/details?id=com.swmansion.privatemind). To build it yourself:
+
+Prerequisites: Node.js, Yarn, and a working React Native environment (Xcode for iOS, Android Studio for Android).
+
+```bash
+git clone https://github.com/software-mansion-labs/private-mind.git
+cd private-mind
+
+# fetch the bundled model assets
+node -e "require('./scripts/download-models.js').ensureModelAssets()"
+
+yarn
+
+# then either
+yarn expo run:ios
+# or
+yarn expo run:android
+```
+
+The app is licensed under MIT. Issues and contributions go through the [official repo](https://github.com/software-mansion-labs/private-mind).


### PR DESCRIPTION
## What this adds

A new **On-Device AI Apps** category with its first entry: [Private Mind](https://github.com/software-mansion-labs/private-mind), an open-source mobile app (iOS and Android) that runs LLMs entirely on the phone via [react-native-executorch](https://github.com/software-mansion/react-native-executorch). No cloud backend, no account, no data collection - models execute locally through PyTorch's ExecuTorch runtime.

## Changes

- `on_device_ai_apps/private_mind/README.md` - what the app is, features, tech stack, App Store / Google Play links, and run-from-source instructions
- Root `README.md` - new "On-Device AI Apps" section with the Private Mind entry

The repo has plenty of local-model apps for desktop, but nothing yet for running models on a phone. This category gives mobile on-device apps a home. MIT licensed, links verified.