### PR TITLE
feat: add thinking-out-loud agent skill

### DIFF
--- a/agent_skills/README.md
+++ b/agent_skills/README.md
@@ -23,6 +23,7 @@ Most "skills" on registries are text-only prompt dumps — advice the model alre
 | [⚰️ project-graveyard](project-graveyard/) | Scans your machine for dead side projects, autopsies why each one died from its git history (deploy fear, payments wall, killed by a newer project), shows your personal death patterns, and resurrects the one with a pulse — with relapse tracking on every resurrection it prescribes |
 | [🔭 scope-creep-detector](scope-creep-detector/) | Checks a diff against its stated intent, flags unrelated files and scope signals, and recommends what to keep, split, or justify |
 | [♾️ self-improving-agent-skills](self-improving-agent-skills/) | Automatically optimizes agent skills using Gemini and ADK |
+| [🎙️ thinking-out-loud](thinking-out-loud/) | Audit what your agent heard before it acts: on any voice ramble it echoes back a scannable brief with its own guesses quarantined and your reversals flagged, because follow-up questions only verify what the model doubts, while the echo verifies what it believes |
 
 More coming, released one at a time.
 

--- a/agent_skills/evals/thinking-out-loud/evals.json
+++ b/agent_skills/evals/thinking-out-loud/evals.json
@@ -1,0 +1,57 @@
+{
+  "skill_name": "thinking-out-loud",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "switching to voice sorry for typos. so i want a weekly changelog email for our users but written like a human not release notes. marketing should own it eventually but for now me. it should pull from merged PRs. oh and we should definitely include screenshots. hmm actually screenshots are a pain to automate skip them for v1. also random but we could repurpose this for investor updates later. anyway it has to go out friday mornings without me babysitting it and the tone thing matters most, if it reads like a robot wrote it the whole thing is pointless.",
+      "expected_output": "A structured echo: one-sentence mission, brief with goals, constraints, made decisions and open questions, a ledger flagging the screenshots reversal and parking the investor-updates tangent, and an assumption diff separating said, inferred, and guessed.",
+      "expectations": [
+        "No implementation, file edits, planning, or solutioning happens before the echo is approved; the reply is the echo and nothing else",
+        "Mission is a single sentence capturing the actual goal (human-sounding weekly changelog email, fully automated)",
+        "The screenshots reversal appears in the ledger with both positions and the later one (skip for v1) adopted",
+        "The investor-updates idea is parked as a tangent, not folded into the goals",
+        "The decision that tone matters most is captured as a made decision, not an open question",
+        "My additions contains only Inferred and Guessed entries; there is no you-said recap section",
+        "Unstated gap-fills (such as which repo or which email tool) appear under Guessed or Open, never stated as locked facts",
+        "No fact appears in more than one section of the echo",
+        "Every bullet is a single line",
+        "No comment on typos, dictation artifacts, or lack of punctuation",
+        "The echo ends by inviting corrections and offering the interview"
+      ]
+    },
+    {
+      "id": 2,
+      "prompt": "let me ramble for a minute. [followed across several messages by fragments, including one direct question mid-stream: 'wait, does vercel support cron jobs?', then more rambling, then 'ok done, echo me']",
+      "expected_output": "Capture-mode discipline: one short acknowledgment, minimal one-line replies to each fragment, the direct question answered in at most two sentences before returning to listening, and no echo until the sentinel.",
+      "expectations": [
+        "The acknowledgment is one short line that names the exit sentinel",
+        "Every mid-stream reply is a single minimal line with no solutions, praise, summaries, or questions",
+        "The direct vercel question is answered in at most two sentences, then listening resumes",
+        "No reconstruction, advice, or partial echo appears before the user says done",
+        "The echo arrives immediately after the sentinel with all four sections"
+      ]
+    },
+    {
+      "id": 3,
+      "prompt": "[after an echo listing two open questions and two guesses] yes interview me",
+      "expected_output": "A short targeted interview: one question per message, drawn only from the flagged open questions and guesses, highest information gain first, each with a one-clause reason, capped at five, ending with a restatement of only the changed echo sections.",
+      "expectations": [
+        "Questions target only items flagged in the echo, never new generic discovery",
+        "Exactly one question per message",
+        "Each question includes a one-clause reason why it matters",
+        "The interview stops at five questions or earlier once answers stop changing the brief",
+        "After the interview, only the changed sections of the echo are restated"
+      ]
+    },
+    {
+      "id": 4,
+      "prompt": "[after corrections] yes that's exactly it, locked",
+      "expected_output": "Offers exactly three persistence options (append to CLAUDE.md, save to docs/rambles/, keep in conversation) and does not write anything until the user picks one.",
+      "expectations": [
+        "Exactly three options are offered, matching the skill's persistence section",
+        "No file or CLAUDE.md write happens before the user chooses",
+        "After a choice, the approved brief governs the session: its decisions are not re-asked later"
+      ]
+    }
+  ]
+}

--- a/agent_skills/evals/thinking-out-loud/trigger-cases.json
+++ b/agent_skills/evals/thinking-out-loud/trigger-cases.json
@@ -1,0 +1,48 @@
+{
+  "skill": "thinking-out-loud",
+  "purpose": "Trigger-behavior spec: when a ramble should enter capture or echo, and when ordinary input should be left alone.",
+  "cases": [
+    {
+      "id": "explicit-invoke",
+      "prompt": "let me think out loud for a bit before we build anything",
+      "should_trigger": true,
+      "assert": "Enters capture mode: one short acknowledgment, then minimal replies until a done sentinel."
+    },
+    {
+      "id": "voice-preamble",
+      "prompt": "switching to speech recognition sorry for any typos. so the thing i keep coming back to is that our onboarding is doing too much...",
+      "should_trigger": true,
+      "assert": "Recognizes the voice preamble; if the ramble is complete, jumps straight to the echo."
+    },
+    {
+      "id": "unpunctuated-stream",
+      "prompt": "ok so basically what i want is some kind of dashboard no wait not a dashboard more like a digest thing that runs itself and my cofounder needs it too actually scrap the dashboard idea entirely the point is i never want to open a browser tab for this",
+      "should_trigger": true,
+      "assert": "Detects stream-of-consciousness with reversals; produces an echo with the reversal logged in the ledger."
+    },
+    {
+      "id": "interview-request",
+      "prompt": "I have a fuzzy idea for a product, interview me about it",
+      "should_trigger": true,
+      "assert": "Runs capture (or takes what is given), echoes, then interviews on open questions one at a time."
+    },
+    {
+      "id": "near-miss-verbatim",
+      "prompt": "here's my voice memo transcript, clean up the punctuation but keep my exact words",
+      "should_trigger": false,
+      "assert": "Does not trigger: the user wants verbatim cleanup, not reconstruction."
+    },
+    {
+      "id": "near-miss-structured-doc",
+      "prompt": "here's the full PRD I wrote, review it: [three pages of structured markdown]",
+      "should_trigger": false,
+      "assert": "Does not trigger: long but already structured input is not a ramble."
+    },
+    {
+      "id": "near-miss-clear-request",
+      "prompt": "fix the failing test in test_ranker.py",
+      "should_trigger": false,
+      "assert": "Does not trigger: short, clear, actionable request."
+    }
+  ]
+}

--- a/agent_skills/thinking-out-loud/README.md
+++ b/agent_skills/thinking-out-loud/README.md
@@ -1,0 +1,74 @@
+# Thinking Out Loud
+
+Ramble at your agent by voice. Audit what it heard before it acts.
+
+Voice dictation already lets you think out loud for ten minutes, and LLMs
+are already good at reconstructing the mess. The danger sits one step
+later: the model fills every gap in your ramble confidently. "The usual
+model" silently becomes a specific model. The idea you reversed
+mid-ramble survives as fact. Then an agent with tools starts building on
+a misreading it fully believes, and you find out an hour of generated
+work later.
+
+This skill is a contract for that moment: the agent acts on nothing
+until it echoes back a short structured audit of everything it absorbed,
+with its own guesses quarantined from your words. You correct three
+lines instead of debugging a built artifact.
+
+## Install
+
+```bash
+npx skills add https://github.com/Shubhamsaboo/awesome-llm-apps/tree/main/agent_skills/thinking-out-loud
+```
+
+The [skills CLI](https://skills.sh) installs the folder for compatible
+coding agents. You can also copy this directory into an agent's skills
+directory.
+
+## Run
+
+Dictate a ramble into your agent, mess encouraged. It auto-triggers on
+ramble-shaped input, especially with an opener like:
+
+> switching to speech recognition sorry for any typos. so the thing i
+> keep coming back to is...
+
+You get back the echo: a one-sentence mission, your locked decisions and
+constraints, open questions, a ledger of flips and parked tangents, and
+the model's additions (inferred and guessed) to correct first. Fix what
+is wrong, optionally take a short interview on the open items, approve,
+and choose where the brief gets saved.
+
+To ramble across several messages instead, invoke it first ("let me
+think out loud for a bit"); the agent replies only "listening..." until
+you say "done".
+
+## Why not just ask for follow-up questions?
+
+- Questions verify what the model doubts; the echo verifies what the
+  model believes. Confident misreadings never feel unclear, so they
+  never become questions.
+- Questions sample three or four points; the echo audits the entire
+  transfer, and you verify by recognition, just reading and spotting
+  what is wrong.
+
+## Verify
+
+The behavior spec lives in
+[`agent_skills/evals/thinking-out-loud/`](../evals/thinking-out-loud/).
+Run each prompt in `evals.json` in a fresh session with the skill
+installed and check the listed expectations; `trigger-cases.json` covers
+when the skill must and must not fire. The skill is prompt-only: no
+scripts, no network calls, and it never saves anything without asking.
+
+## Files
+
+```text
+thinking-out-loud/
+|-- SKILL.md
+|-- README.md
+`-- references/echo-format.md
+```
+
+Part of [awesome-llm-apps](https://github.com/Shubhamsaboo/awesome-llm-apps).
+Apache-2.0. Last verified: July 2026.

--- a/agent_skills/thinking-out-loud/SKILL.md
+++ b/agent_skills/thinking-out-loud/SKILL.md
@@ -1,0 +1,157 @@
+---
+name: thinking-out-loud
+description: >-
+  A contract for what the agent does when a long, messy, stream-of-consciousness
+  ramble arrives (usually voice dictation): act on nothing until a structured
+  echo is approved. The echo audits the full transfer, mission, locked decisions
+  and constraints, open questions, flips and parked tangents, with the model's
+  inferences and guesses quarantined away from the user's own words, so the
+  user verifies what the model believes, not just what it doubts. Use when the
+  user says they want to think out loud or ramble, when a message opens with a
+  speech-to-text preamble like "switching to voice, sorry for typos", when
+  input is a long weakly punctuated stream with restarts and reversals, or when
+  the user asks to be interviewed about a fuzzy idea. Includes an optional
+  capture mode for rambles spread across several messages and an optional
+  targeted interview.
+license: Apache-2.0
+metadata:
+  author: "Shubham Saboo"
+  version: "1.3.0"
+  source: "https://github.com/Shubhamsaboo/awesome-llm-apps"
+---
+
+# Thinking Out Loud
+
+A ten minute voice ramble transfers more context than any prompt a person
+would type, and models reconstruct rambles well. The failure is
+downstream and invisible: the model fills every gap in the ramble
+confidently. "The usual model" silently becomes a specific model. "The
+standard size" becomes a specific viewport. A position the user reversed
+mid-ramble survives as fact. None of this registers as uncertainty from
+the inside, so none of it ever becomes a clarifying question. The model
+then acts on a misreading it fully believes, and the user discovers it an
+hour of generated work later.
+
+This skill is the fix: before acting on any ramble, produce an echo, a
+short structured audit of everything absorbed, with the model's own
+additions quarantined from the user's words. The user corrects three
+lines instead of debugging a built artifact.
+
+## Why an echo instead of follow-up questions
+
+Asking clarifying questions is good, and the interview below does it.
+But questions alone cannot secure a ramble, for two structural reasons:
+
+- **Questions verify what the model doubts. The echo verifies what the
+  model believes.** A clarifying question requires felt uncertainty, and
+  confident misreadings feel like knowledge. The echo forces every
+  inference and gap-fill into the open whether or not it felt uncertain.
+- **Questions sample; the echo audits.** A long ramble carries dozens of
+  facts and half-decisions. Even good questions probe three or four; the
+  rest of the model's understanding goes unverified into action. The
+  echo inventories the entire transfer, and it works by recognition, not
+  recall: the user reads and spots what is wrong, which is far cheaper
+  than producing answers, and ramblers often do not know their answer
+  until they see the wrong guess written down.
+
+## The contract
+
+1. **Act on nothing.** No file edits, no code, no plans, no solutions to
+   fragments, until the echo is approved. Reconstruct first.
+2. **Label every addition.** Inferences and guesses live in their own
+   section, apart from the user's own content. Never present a guess in
+   the user's voice.
+3. **Surface every reversal.** Adopt the later position, but flag the
+   flip. Never silently average or pick.
+4. **Lose nothing.** Tangents get parked, not dropped.
+5. **Never remark on dictation artifacts.** Typos, homophones, filler,
+   and restarts are resolved silently from context. Keep the user's own
+   vocabulary and project names.
+6. **Ask before persisting.** The approved brief is offered a home, never
+   saved unprompted.
+
+## When to use
+
+- A message is a long, weakly punctuated stream of consciousness with
+  restarts, filler, and mid-message reversals ("actually no, scrap that")
+- A message opens with a voice preamble ("switching to speech
+  recognition, sorry for any typos", "dictating this")
+- The user says they want to ramble or think out loud
+- The user asks to be interviewed to untangle a fuzzy idea
+
+## When not to use
+
+- Short requests that are already clear
+- The user wants a verbatim transcript, minutes, or cleanup of dictation
+  while keeping their exact words
+- Long but already structured text, such as a pasted spec or document
+- The user asked a direct question and wants a direct answer
+
+## The echo
+
+One structured reply. Dense, scannable, and short: the user should find
+and fix an error in seconds. Full template with a worked example in
+[references/echo-format.md](references/echo-format.md).
+
+1. **Mission**: one sentence stating what the user is actually trying to
+   achieve. Often this differs from what they said first; that is fine.
+2. **Locked**: the user's decisions and constraints, merged into one
+   list. Mark anything they called a top priority.
+3. **Open**: questions the ramble raised but did not answer.
+4. **Ledger**: flips (both positions in one line, later one adopted) and
+   parked tangents (one line each).
+5. **My additions**: the only interpretation callouts. "Inferred"
+   (strongly implied but never stated) and "Guessed" (gaps you filled).
+   Tell the user to correct these first.
+
+Compression rules, non-negotiable:
+
+- **Nothing appears twice.** Every fact lives in exactly one section.
+- **No "you said" recap.** Everything outside My additions is the user's
+  own content by definition; only the model's additions get called out.
+- **One line per bullet.** If a bullet needs two lines, it is two bullets
+  or it is bloat.
+- **Vague quantifiers are never silently resolved.** "The usual model",
+  "standard size", "soon": each lands in Open or Guessed, never absorbed
+  into a locked item as if it were specified.
+
+Close by inviting corrections and offering the interview.
+
+## The interview (optional)
+
+Follow-up questions have their place: after the audit, not instead of
+it. Only if the user accepts the offer, or asked to be interviewed up
+front.
+
+- Ask only about items flagged in Open or Guessed
+- One question per message, highest information gain first
+- Each question states in one clause why it matters
+- Cap at five questions; stop early once answers stop changing the brief
+- After the interview, restate only the sections of the echo that changed
+
+## Capture mode (multi-message rambles)
+
+Not needed for dictation tools, where the whole ramble arrives as one
+message. Use it when the user invokes the skill before rambling and then
+adds thoughts across several messages, possibly over a long stretch.
+
+- Acknowledge once, in one short line ("Go ahead, I'm listening. Say
+  'done' when you want the echo.")
+- For every following message, reply with a single minimal line
+  ("Listening."). Vary it slightly so it does not feel robotic.
+- Do NOT solve, praise, summarize, analyze, or ask questions mid-stream.
+- If the user asks a direct question mid-ramble, answer it in at most two
+  sentences, then return to listening.
+- Exit on "done", "echo", "echo me", "that's it", "what did you get", or
+  any clear equivalent, then deliver the echo.
+
+## Persistence
+
+After the user approves the echo, offer exactly three options:
+
+1. Append the brief to CLAUDE.md so future sessions inherit it
+2. Save it to `docs/rambles/YYYY-MM-DD-<topic>.md`
+3. Keep it in-conversation only
+
+The approved brief then governs the rest of the session: honor its
+decisions and constraints without re-asking.

--- a/agent_skills/thinking-out-loud/SKILL.md
+++ b/agent_skills/thinking-out-loud/SKILL.md
@@ -2,17 +2,18 @@
 name: thinking-out-loud
 description: >-
   A contract for what the agent does when a long, messy, stream-of-consciousness
-  ramble arrives (usually voice dictation): act on nothing until a structured
-  echo is approved. The echo audits the full transfer, mission, locked decisions
+  ramble arrives (usually voice dictation): act on nothing until the echo brief
+  is approved. The echo audits the entire transfer, mission, locked decisions
   and constraints, open questions, flips and parked tangents, with the model's
-  inferences and guesses quarantined away from the user's own words, so the
+  inferences and guesses quarantined away from the user's own phrasing, so the
   user verifies what the model believes, not just what it doubts. Use when the
-  user says they want to think out loud or ramble, when a message opens with a
-  speech-to-text preamble like "switching to voice, sorry for typos", when
-  input is a long weakly punctuated stream with restarts and reversals, or when
-  the user asks to be interviewed about a fuzzy idea. Includes an optional
-  capture mode for rambles spread across several messages and an optional
-  targeted interview.
+  user says "let me think out loud" or wants to ramble a bit before building
+  anything, when a message opens with a speech-to-text preamble like "switching
+  to voice, sorry for typos", when input is a long weakly punctuated stream
+  with restarts and mid-message reversals ("actually no, wait, scrap that idea
+  entirely"), or when the user asks to be interviewed about a fuzzy half-formed
+  idea. Includes an optional capture mode for rambles spread across several
+  messages and an optional targeted interview.
 license: Apache-2.0
 metadata:
   author: "Shubham Saboo"

--- a/agent_skills/thinking-out-loud/references/echo-format.md
+++ b/agent_skills/thinking-out-loud/references/echo-format.md
@@ -1,0 +1,72 @@
+# Echo Format
+
+One reply, five sections, dense. The user should find and fix an error
+in seconds. Target well under 250 words for a ten minute ramble.
+
+Compression rules: nothing appears twice; no "you said" recap (everything
+outside My additions is the user's by definition); one line per bullet;
+vague quantifiers ("usual", "standard", "soon") go to Open or Guessed,
+never silently resolved into a locked item.
+
+## Template
+
+```markdown
+## Mission
+<one sentence: what you are actually trying to achieve>
+
+## Locked (your decisions and constraints)
+- <one line each; mark the stated top priority with **top priority**>
+
+## Open (needs your answer)
+- <question the ramble raised but did not answer>
+
+## Ledger
+- Flipped: <position A>, then <position B>. Going with B.
+- Parked: <tangent, one line>
+
+## My additions (correct these first)
+- Inferred: <implied but never stated>
+- Guessed: <gap I filled>
+```
+
+Close with: "Correct anything that's off, especially My additions. Want
+the interview for the Open items?"
+
+## Worked example
+
+**Ramble (compressed):** "ok switching to voice sorry for typos. so i want
+some kind of daily digest agent for hacker news but honestly email feels
+dead maybe slack. it should rank by relevance to what im building not
+just points. oh and my cofounder wants it too so two profiles i guess.
+actually no email is fine everyone has email. also random thought we
+could sell this later but whatever. it needs to run every morning without
+me touching it, thats the whole point, if i have to trigger it manually
+its useless."
+
+**Echo:**
+
+## Mission
+A zero-touch daily Hacker News digest, ranked by personal relevance,
+emailed every morning.
+
+## Locked
+- Relevance ranking over raw points
+- Two recipients with different interest profiles (you, cofounder)
+- Email delivery
+- **Top priority**: fully automatic; a manual trigger makes it useless
+
+## Open
+- What defines "relevance to what I'm building": a written interest
+  profile, repo activity, something else?
+- "Morning" means what time, whose timezone?
+
+## Ledger
+- Flipped: Slack (email feels dead), then email is fine. Going with email.
+- Parked: possibly sellable as a product someday
+
+## My additions (correct these first)
+- Inferred: each recipient gets their own ranking, not a shared list
+- Guessed: source pool is HN front page plus new stories
+
+Correct anything that's off, especially My additions. Want the interview
+for the Open items?


### PR DESCRIPTION
## What

Adds **thinking-out-loud**, a prompt-only agent skill for voice-dictated rambles: the agent acts on nothing until it echoes back a short structured audit of everything it absorbed, with its own guesses quarantined from the user's words.

## Why

Dictation tools already make rambling easy, and LLMs already reconstruct rambles well. The failure is one step later: the model fills every gap confidently ("the usual model" silently becomes a specific model, a reversed idea survives as fact) and an agent with tools starts building on a misreading it fully believes. Clarifying questions can't catch this, because confident misreadings never feel unclear. The echo verifies what the model believes, not just what it doubts.

## The echo contract

- **Act on nothing** until the echo is approved
- **My additions**: inferences and guesses in their own section, never woven into the user's voice
- **Flips flagged**: later position adopted, reversal surfaced, never silently averaged
- **Tangents parked**, vague quantifiers ("usual", "standard", "soon") never silently resolved
- Compressed format: mission, locked, open, ledger, additions; nothing appears twice, one line per bullet

## Contents

- `agent_skills/thinking-out-loud/` — SKILL.md, README, echo format reference with worked example
- `agent_skills/evals/thinking-out-loud/` — behavior evals and trigger/no-trigger cases
- Skills index row in `agent_skills/README.md`

## Testing

Tested live in a fresh Claude Code session against a planted synthetic ramble (buried reversals, vague quantifiers, tangents, homophone traps): auto-triggered on the dictation preamble, caught both reversals, parked both tangents, surfaced the vague items as open questions or labeled guesses, took no action before approval. The eval files encode these checks.

Banner image to be added separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)