### PR TITLE
fix: insert generated code into Trinket editor before execution

### DIFF
--- a/advanced_ai_agents/autonomous_game_playing_agent_apps/ai_3dpygame_r1/ai_3dpygame_r1.py
+++ b/advanced_ai_agents/autonomous_game_playing_agent_apps/ai_3dpygame_r1/ai_3dpygame_r1.py
@@ -146,8 +146,20 @@ elif generate_vis_btn:
                     browser_context=context
                 )
 
+                # FIX: The `code` parameter was previously never referenced inside
+                # any agent's task, so nothing actually told the browser agent
+                # what code to type into the editor. It's now interpolated
+                # directly into the coder agent's task, and the instruction is
+                # changed from "wait for the user to write the code" (passive)
+                # to an explicit action: click into the editor and type the code.
                 coder = Agent(
-                    task='Coder. Your job is to wait for the user for 10 seconds to write the code in the code editor.',
+                    task=(
+                        "Coder. Click into the Trinket code editor. Select all existing "
+                        "content (Ctrl+A) and delete it. Then paste the following Python "
+                        "code exactly as provided without modifying the formatting or "
+                        "indentation:\n\n"
+                        f"{code}"
+                    ),
                     llm=model,
                     browser_context=context
                 )


### PR DESCRIPTION
## Summary

This PR fixes the visualization workflow by ensuring the generated PyGame code is inserted into the Trinket editor before execution.

Previously, the `coder` agent never referenced the generated `code` parameter. As a result, the editor remained unchanged and the `executor` agent attempted to run the default or empty program.

## Changes

- Updated the `coder` agent to use the generated `code` parameter.
- Added instructions to:
  - focus the Trinket code editor,
  - clear any existing content,
  - insert the generated PyGame code before execution.

## Result

The browser automation now executes the generated PyGame program instead of attempting to run the editor's existing contents.