### PR TITLE
Fix unsatisfiable `openai-agents>=1.0.0` pin in OpenAI SDK crash course

### DIFF
--- a/ai_agent_framework_crash_course/openai_sdk_crash_course/10_tracing_observability/requirements.txt
+++ b/ai_agent_framework_crash_course/openai_sdk_crash_course/10_tracing_observability/requirements.txt
@@ -1,3 +1,3 @@
-openai-agents>=1.0.0
+openai-agents>=0.2.0
 streamlit>=1.28.0
 python-dotenv>=1.0.0

--- a/ai_agent_framework_crash_course/openai_sdk_crash_course/11_voice/realtime/requirements.txt
+++ b/ai_agent_framework_crash_course/openai_sdk_crash_course/11_voice/realtime/requirements.txt
@@ -1,2 +1,2 @@
-openai-agents>=1.0.0
+openai-agents>=0.2.0
 python-dotenv>=1.0.0

--- a/ai_agent_framework_crash_course/openai_sdk_crash_course/11_voice/static/requirements.txt
+++ b/ai_agent_framework_crash_course/openai_sdk_crash_course/11_voice/static/requirements.txt
@@ -1,4 +1,4 @@
-openai-agents[voice]>=1.0.0
+openai-agents[voice]>=0.2.0
 sounddevice>=0.4.0
 numpy>=1.21.0
 soundfile>=0.12.0

--- a/ai_agent_framework_crash_course/openai_sdk_crash_course/11_voice/streamed/requirements.txt
+++ b/ai_agent_framework_crash_course/openai_sdk_crash_course/11_voice/streamed/requirements.txt
@@ -1,4 +1,4 @@
-openai-agents[voice]>=1.0.0
+openai-agents[voice]>=0.2.0
 sounddevice>=0.4.0
 numpy>=1.21.0
 soundfile>=0.12.0

--- a/ai_agent_framework_crash_course/openai_sdk_crash_course/1_starter_agent/requirements.txt
+++ b/ai_agent_framework_crash_course/openai_sdk_crash_course/1_starter_agent/requirements.txt
@@ -1,3 +1,3 @@
-openai-agents>=1.0.0
+openai-agents>=0.2.0
 streamlit>=1.28.0
 python-dotenv>=1.0.0

--- a/ai_agent_framework_crash_course/openai_sdk_crash_course/2_structured_output_agent/requirements.txt
+++ b/ai_agent_framework_crash_course/openai_sdk_crash_course/2_structured_output_agent/requirements.txt
@@ -1,4 +1,4 @@
-openai-agents>=1.0.0
+openai-agents>=0.2.0
 streamlit>=1.28.0
 python-dotenv>=1.0.0
 pydantic>=2.0.0

--- a/ai_agent_framework_crash_course/openai_sdk_crash_course/4_running_agents/requirements.txt
+++ b/ai_agent_framework_crash_course/openai_sdk_crash_course/4_running_agents/requirements.txt
@@ -1,3 +1,3 @@
-openai-agents>=1.0.0
+openai-agents>=0.2.0
 streamlit>=1.28.0
 python-dotenv>=1.0.0

--- a/ai_agent_framework_crash_course/openai_sdk_crash_course/7_sessions/requirements.txt
+++ b/ai_agent_framework_crash_course/openai_sdk_crash_course/7_sessions/requirements.txt
@@ -1,3 +1,3 @@
-openai-agents>=1.0.0
+openai-agents>=0.2.0
 streamlit>=1.28.0
 python-dotenv>=1.0.0

--- a/ai_agent_framework_crash_course/openai_sdk_crash_course/8_handoffs_delegation/requirements.txt
+++ b/ai_agent_framework_crash_course/openai_sdk_crash_course/8_handoffs_delegation/requirements.txt
@@ -1,4 +1,4 @@
-openai-agents>=1.0.0
+openai-agents>=0.2.0
 streamlit>=1.28.0
 python-dotenv>=1.0.0
 pydantic>=2.0.0

--- a/ai_agent_framework_crash_course/openai_sdk_crash_course/9_multi_agent_orchestration/requirements.txt
+++ b/ai_agent_framework_crash_course/openai_sdk_crash_course/9_multi_agent_orchestration/requirements.txt
@@ -1,3 +1,3 @@
-openai-agents>=1.0.0
+openai-agents>=0.2.0
 streamlit>=1.28.0
 python-dotenv>=1.0.0


### PR DESCRIPTION
## Problem

Every `requirements.txt` in `ai_agent_framework_crash_course/openai_sdk_crash_course/` pins `openai-agents>=1.0.0` (`[voice]` variant in the two `11_voice` static/streamed folders). The newest release on PyPI is **0.18.3** — no 1.x exists — so the documented `pip install -r requirements.txt` is unsatisfiable and aborts (taking streamlit/python-dotenv down with it). None of tutorials 1–11 can be installed as written.

```
× No solution found when resolving dependencies:
╰─▶ Because only openai-agents<=0.18.3 is available and you require
    openai-agents>=1.0.0, we can conclude that your requirements are unsatisfiable.
```

## Fix

Lower the floor to `>=0.2.0` across all 10 files (`[voice]` extra preserved). That version is published and already exports every symbol the course imports (`SQLiteSession`, `RunConfig`, `trace`/`custom_span`, the realtime/voice modules); `>=` still pulls the latest release on a fresh install. Verified importable against the installed SDK.

Fixes #1011