### PR TITLE
Fix three crash-course example scripts that crash on run

### DIFF
--- a/ai_agent_framework_crash_course/google_adk_crash_course/5_memory_agent/5_2_persistent_conversation_agent/agent.py
+++ b/ai_agent_framework_crash_course/google_adk_crash_course/5_memory_agent/5_2_persistent_conversation_agent/agent.py
@@ -71,9 +71,9 @@ async def chat(user_id: str, message: str) -> str:
 # Test the persistent memory
 if __name__ == "__main__":
     async def test():
-        # Initialize database
-        await session_service.initialize()
-        print("✅ Database initialized")
+        # DatabaseSessionService creates its tables in the constructor;
+        # no explicit initialization call is needed.
+        print("✅ Database ready")
         
         user_id = "test_user"
         messages = ["My name is Bob", "What's my name?", "I love coding", "What do I love?"]

--- a/ai_agent_framework_crash_course/openai_sdk_crash_course/11_voice/static/agent.py
+++ b/ai_agent_framework_crash_course/openai_sdk_crash_course/11_voice/static/agent.py
@@ -12,7 +12,10 @@ from agents.voice import (
     VoicePipeline,
 )
 
-from .util import AudioPlayer, record_audio
+try:
+    from .util import AudioPlayer, record_audio
+except ImportError:  # running directly as a script: `python agent.py`
+    from util import AudioPlayer, record_audio
 
 """
 This is a simple example that uses a recorded audio buffer. Run it via:

--- a/ai_agent_framework_crash_course/openai_sdk_crash_course/11_voice/streamed/agent.py
+++ b/ai_agent_framework_crash_course/openai_sdk_crash_course/11_voice/streamed/agent.py
@@ -14,7 +14,10 @@ from agents.voice import (
     VoicePipeline,
 )
 
-from .util import AudioPlayer, StreamedAudioRecorder, create_silence
+try:
+    from .util import AudioPlayer, StreamedAudioRecorder, create_silence
+except ImportError:  # running directly as a script: `python agent.py`
+    from util import AudioPlayer, StreamedAudioRecorder, create_silence
 
 """
 This is a streaming voice example that processes audio in real-time. Run it via:

--- a/ai_agent_framework_crash_course/openai_sdk_crash_course/4_running_agents/4_3_run_configuration/agent.py
+++ b/ai_agent_framework_crash_course/openai_sdk_crash_course/4_running_agents/4_3_run_configuration/agent.py
@@ -1,4 +1,4 @@
-from agents import Agent, Runner, RunConfig
+from agents import Agent, Runner, RunConfig, ModelSettings
 
 # Create an agent for demonstrating run configuration
 root_agent = Agent(
@@ -12,19 +12,16 @@ async def model_config_example():
     
     run_config = RunConfig(
         model="gpt-4o",  # Override agent's default model
-        model_settings={
-            "temperature": 0.1,  # Low temperature for consistent responses
-            "top_p": 0.9
-        },
-        max_turns=5,  # Limit conversation turns
+        model_settings=ModelSettings(temperature=0.1, top_p=0.9),
         workflow_name="demo_workflow",  # For tracing
         trace_metadata={"experiment": "config_demo"}
     )
-    
+
     result = await Runner.run(
-        root_agent, 
+        root_agent,
         "Explain the weather in exactly 3 sentences.",
-        run_config=run_config
+        run_config=run_config,
+        max_turns=5,  # max_turns is a Runner.run() argument, not a RunConfig field
     )
     
     return result.final_output

--- a/ai_agent_framework_crash_course/openai_sdk_crash_course/4_running_agents/agent_runner.py
+++ b/ai_agent_framework_crash_course/openai_sdk_crash_course/4_running_agents/agent_runner.py
@@ -3,7 +3,7 @@ import asyncio
 import time
 import json
 from datetime import datetime
-from agents import Agent, Runner, RunConfig, SQLiteSession
+from agents import Agent, Runner, RunConfig, SQLiteSession, ModelSettings
 from agents.exceptions import (
     AgentsException,
     MaxTurnsExceeded,
@@ -356,16 +356,15 @@ def render_run_configuration(agent, model_choice, temperature, max_turns):
                     try:
                         run_config = RunConfig(
                             model=model_choice,
-                            model_settings={
-                                "temperature": config_temperature,
-                                "top_p": config_top_p
-                            },
-                            max_turns=config_max_turns,
+                            model_settings=ModelSettings(
+                                temperature=config_temperature,
+                                top_p=config_top_p
+                            ),
                             workflow_name="basic_config_demo"
                         )
-                        
+
                         start_time = time.time()
-                        result = asyncio.run(Runner.run(agent, config_input, run_config=run_config))
+                        result = asyncio.run(Runner.run(agent, config_input, run_config=run_config, max_turns=config_max_turns))
                         execution_time = time.time() - start_time
                         
                         st.success(f"✅ Completed in {execution_time:.2f}s")
@@ -599,8 +598,8 @@ def render_exception_handling(agent, model_choice, temperature, max_turns):
             
             if maxturns_submitted and maxturns_input:
                 try:
-                    run_config = RunConfig(max_turns=max_turns_test)
-                    result = asyncio.run(Runner.run(agent, maxturns_input, run_config=run_config))
+                    run_config = RunConfig()
+                    result = asyncio.run(Runner.run(agent, maxturns_input, run_config=run_config, max_turns=max_turns_test))
                     st.success("✅ Completed without hitting max turns")
                     st.write(f"**Response:** {result.final_output}")
                     


### PR DESCRIPTION
Three tutorial scripts in `ai_agent_framework_crash_course/` crash the moment they run (independent of API keys). Verified against installed `openai-agents==0.18.3` and `google-adk`.

### 1. `RunConfig(max_turns=...)` — not a RunConfig field → `TypeError` on construction
`openai_sdk_crash_course/4_running_agents/4_3_run_configuration/agent.py` and `agent_runner.py` (Run Configuration + Exception-Handling demos).
`max_turns` is a `Runner.run()` argument, not a `RunConfig` field; and `model_settings` must be a `ModelSettings`, not a plain dict:
```
RunConfig(max_turns=5) -> TypeError: RunConfig.__init__() got an unexpected keyword argument 'max_turns'
```
Fix: pass `max_turns` to `Runner.run(...)` and build `ModelSettings(temperature=..., top_p=...)`. (The `agent_runner.py` case is even labelled "Trigger MaxTurnsExceeded" — it instead raised `TypeError`.)

### 2. Voice examples can't start with the documented `python agent.py`
`openai_sdk_crash_course/11_voice/{static,streamed}/agent.py` use `from .util import ...`. The READMEs document `python agent.py`, which raises `ImportError: attempted relative import with no known parent package` before any demo code runs. Fix: `try/except ImportError` → absolute import (keeps `python -m ...` working too).

### 3. `DatabaseSessionService.initialize()` does not exist
`google_adk_crash_course/5_memory_agent/5_2_persistent_conversation_agent/agent.py` — the `__main__` test's first statement is `await session_service.initialize()`; `DatabaseSessionService` has no such method (tables are created in the constructor), so it `AttributeError`s immediately. Fix: drop the call.

All five files compile-check clean.

Fixes #1013