### PR TITLE
Fix three broken multi-agent apps (devpulse import/key, financial-coach CSV guard, design-team agno kwarg)

### DIFF
--- a/advanced_ai_agents/multi_agent_apps/agent_teams/multimodal_design_agent_team/design_agent_team.py
+++ b/advanced_ai_agents/multi_agent_apps/agent_teams/multimodal_design_agent_team/design_agent_team.py
@@ -190,7 +190,7 @@ if st.session_state.api_key_input:
                                 """
                                 
                                 response: RunOutput = vision_agent.run(
-                                    message=vision_prompt,
+                                    vision_prompt,
                                     images=all_images
                                 )
                                 
@@ -211,7 +211,7 @@ if st.session_state.api_key_input:
                                 """
                                 
                                 response: RunOutput = ux_agent.run(
-                                    message=ux_prompt,
+                                    ux_prompt,
                                     images=all_images
                                 )
                                 
@@ -232,7 +232,7 @@ if st.session_state.api_key_input:
                             """
                             
                             response: RunOutput = market_agent.run(
-                                message=market_prompt,
+                                market_prompt,
                                 images=all_images
                             )
                             

--- a/advanced_ai_agents/multi_agent_apps/ai_financial_coach_agent/ai_financial_coach_agent.py
+++ b/advanced_ai_agents/multi_agent_apps/ai_financial_coach_agent/ai_financial_coach_agent.py
@@ -884,7 +884,7 @@ def main():
             )
         
         if analyze_button:
-            if expense_option == "Upload CSV Transactions" and transactions_df is None:
+            if expense_option == "📤 Upload CSV Transactions" and transactions_df is None:
                 st.error("Please upload a valid transaction CSV file or choose manual entry.")
                 return
             if use_manual_expenses and (not manual_expenses or not any(manual_expenses.values())):

--- a/advanced_ai_agents/multi_agent_apps/devpulse_ai/streamlit_app.py
+++ b/advanced_ai_agents/multi_agent_apps/devpulse_ai/streamlit_app.py
@@ -5,7 +5,7 @@ from typing import List, Dict, Any
 # Import pipeline components from main.py and agents
 from main import collect_signals, DEFAULT_SIGNAL_LIMIT
 from agents import (
-    SignalCollectorAgent,
+    SignalCollector,
     RelevanceAgent,
     RiskAgent,
     SynthesisAgent
@@ -73,10 +73,11 @@ scores them for relevance, identifies potential risks, and synthesizes a final i
 st.sidebar.header("⚙️ Pipeline Configuration")
 
 # API Key
-api_key = st.sidebar.text_input("Gemini API Key (optional)", type="password", help="Provide a Google Gemini API key. If not provided, agents will use fallback heuristic logic.")
+api_key = st.sidebar.text_input("OpenAI API Key (optional)", type="password", help="Provide an OpenAI API key. If not provided, agents will use fallback heuristic logic.")
 if api_key:
-    # Agno's GoogleGemini looks for GOOGLE_API_KEY
-    os.environ["GOOGLE_API_KEY"] = api_key
+    # RelevanceAgent / RiskAgent / SynthesisAgent all use agno's OpenAIChat,
+    # which reads OPENAI_API_KEY.
+    os.environ["OPENAI_API_KEY"] = api_key
 
 # Source Selection
 sources = st.sidebar.multiselect(
@@ -102,7 +103,7 @@ if run_button:
         st.warning("Please select at least one signal source.")
     else:
         # Initialize Agents
-        collector = SignalCollectorAgent()
+        collector = SignalCollector()
         relevance = RelevanceAgent()
         risk = RiskAgent()
         synthesis = SynthesisAgent()


### PR DESCRIPTION
Three independent apps under `advanced_ai_agents/multi_agent_apps/`, each with a functional bug. Disjoint files.

### 1. `devpulse_ai` — ImportError on startup + inert API-key field
`devpulse_ai/streamlit_app.py` imports and instantiates `SignalCollectorAgent`, but the class is `SignalCollector` (see `agents/__init__.py` `__all__`), so `streamlit run streamlit_app.py` dies with `ImportError: cannot import name 'SignalCollectorAgent'` before rendering anything. Separately, the sidebar asks for a **Gemini** key and sets `GOOGLE_API_KEY`, but all three agents use agno's `OpenAIChat` (reads `OPENAI_API_KEY`), so the field never enables the LLM path. → fix the class name; switch the field to OpenAI.

### 2. `ai_financial_coach_agent` — dead CSV guard → ZeroDivisionError
The guard compares against `"Upload CSV Transactions"` while the radio option (and the render guard at line 706) is the emoji-prefixed `"📤 Upload CSV Transactions"`. So clicking Analyze with no CSV skips the intended error and falls through to an empty-data path that crashes with `division by zero`. → match the emoji label.

### 3. `multimodal_design_agent_team` — pre-2.0 agno `run(message=...)`
`requirements.txt` pins `agno>=2.2.10`, where `Agent.run`'s first param was renamed `message`→`input`; the three `run(message=...)` calls raise a (swallowed) `TypeError`, so every analysis shows the generic error box. The sibling `multimodal_coding_agent_team` already uses the positional form. → pass the prompt positionally (valid under old and new agno).

All three files compile-check clean.

Fixes #1015