### PR TITLE
Fix beifong OpenGraph typo (`ogg:`) and failure-path key mismatch (`originalUrl`)

### DIFF
--- a/advanced_ai_agents/multi_agent_apps/ai_news_and_podcast_agents/beifong/tools/browser_crawler.py
+++ b/advanced_ai_agents/multi_agent_apps/ai_news_and_podcast_agents/beifong/tools/browser_crawler.py
@@ -73,7 +73,7 @@ class PlaywrightScraper:
                     continue
                 else:
                     return {
-                        "originalUrl": url,
+                        "original_url": url,
                         "error": str(e),
                         "success": False,
                         "timestamp": datetime.now().isoformat(),
@@ -107,7 +107,7 @@ class PlaywrightScraper:
                     continue
                 else:
                     return {
-                        "originalUrl": url,
+                        "original_url": url,
                         "error": str(e),
                         "success": False,
                         "timestamp": datetime.now().isoformat(),

--- a/advanced_ai_agents/multi_agent_apps/ai_news_and_podcast_agents/beifong/utils/crawl_url.py
+++ b/advanced_ai_agents/multi_agent_apps/ai_news_and_podcast_agents/beifong/utils/crawl_url.py
@@ -48,7 +48,7 @@ def extract_meta_tags(soup: BeautifulSoup) -> MetadataDict:
         name = meta.get("name", "").lower()
         prop = meta.get("property", "").lower()
         content = meta.get("content", "")
-        if prop.startswith("ogg:"):
+        if prop.startswith("og:"):
             og_key = prop[3:]
             metadata["og"][og_key] = content
         elif prop.startswith("twitter:") or name.startswith("twitter:"):


### PR DESCRIPTION
Two functional bugs in the beifong podcast app.

### 1. OpenGraph parser checks `"ogg:"` → every article's `og` metadata is empty
`utils/crawl_url.py:51` tests `prop.startswith("ogg:")`, but real pages emit `og:...`. So `metadata["og"]` is always `{}`, and the description fallback in `ai_analysis_processor.py` is dead. The `prop[3:]` slice is already sized for the 3-char `"og:"` — the extra `g` is a typo. → `startswith("og:")`.

### 2. Crawler failure path returns `originalUrl`, callers read `original_url` → KeyError aborts the batch
`tools/browser_crawler.py:76,110` return `{"originalUrl": url, ...}` on failure, but the success path and all callers use `original_url` (e.g. `agents/scrape_agent.py:65` builds `{result["original_url"]: result ...}`). `max_retries = 0`, so one timed-out/404 URL raises `KeyError` in the comprehension and loses the **entire** scrape batch rather than just that URL falling back to its description. → return `original_url` in both failure branches.

Both files compile-check clean.

Fixes #1017