### PR TITLE
Fix release_radar version extraction and customer-support voice model

### DIFF
--- a/always_on_agents/release_radar_agent/radar.py
+++ b/always_on_agents/release_radar_agent/radar.py
@@ -64,7 +64,9 @@ def _normalize_name(name: str) -> str:
 
 def _extract_version(specifier: str) -> str | None:
     matches = VERSION_PATTERN.findall(specifier)
-    return matches[-1] if matches else None
+    # Specifiers put the pinned/lower bound first ("==1.2.3", ">=1.2.3,<2.0.0"),
+    # so the last match is the exclusive upper bound, not the installed version.
+    return matches[0] if matches else None
 
 
 def _github_repo_from_spec(specifier: str) -> str | None:

--- a/voice_ai_agents/customer_support_voice_agent/customer_support_voice_agent.py
+++ b/voice_ai_agents/customer_support_voice_agent/customer_support_voice_agent.py
@@ -237,7 +237,7 @@ def setup_agents(openai_api_key: str):
         4. Keep the tone professional but friendly
         5. Use appropriate pauses for better comprehension
         6. Ensure the speech is clear and well-articulated""",
-        model="gpt-4o-mini-tts"
+        model="gpt-4o"
     )
     
     return processor_agent, tts_agent


### PR DESCRIPTION
Two functional bugs.

### 1. `release_radar_agent` reads the version-range **upper** bound as the installed version
`radar.py:67` returns `matches[-1]` from `_extract_version`. For a bounded range the last token is the exclusive upper bound:
```
>=1.10.0,<2.0.0     -> '2.0.0'   (should be 1.10.0)
>=0.100.0,<0.115.0  -> '0.115.0' (should be 0.100.0)
```
so `build_release_candidates` sees `version_delta=="same"` and drops real releases — the brief always says "No breaking … changes found." → `matches[0]` (pinned/lower bound). Exact pins and release tags yield a single match, so both agree; **the 5 shipped unit tests still pass** (verified).

### 2. `customer_support_voice_agent` builds a chat agent with a TTS-only model
`customer_support_voice_agent.py:240` sets `model="gpt-4o-mini-tts"` on an `Agent` invoked via `Runner.run` (the chat/Responses endpoint). That model is served only by `/v1/audio/speech`, so every query errors out. The same file uses the id correctly for the real speech call (line 288), and the sibling `voice_rag_openaisdk` uses `gpt-4o` for the same agent. → `model="gpt-4o"`.

Both files compile-check clean; radar unit tests pass.

Fixes #1019