### PR TITLE
Fix GTM email campaign success-report + journalist agno 2.x Team API

### DIFF
--- a/advanced_ai_agents/single_agent_apps/ai_email_gtm_reachout_agent/ai_email_gtm_reachout.py
+++ b/advanced_ai_agents/single_agent_apps/ai_email_gtm_reachout_agent/ai_email_gtm_reachout.py
@@ -866,7 +866,7 @@ def main():
                     use_cache=True
                 ):
                     # Update progress bar and status
-                    if 'progress' in result:
+                    if 'email' not in result:
                         progress_bar.progress(result['progress'])
                         status_text.text(f"🔄 {result['status']} - {result['step']}")
                     else:

--- a/advanced_ai_agents/single_agent_apps/ai_journalist_agent/journalist_agent.py
+++ b/advanced_ai_agents/single_agent_apps/ai_journalist_agent/journalist_agent.py
@@ -1,6 +1,7 @@
 # Import the required libraries
 from textwrap import dedent
 from agno.agent import Agent
+from agno.team import Team
 from agno.run.agent import RunOutput
 from agno.tools.serpapi import SerpApiTools
 from agno.tools.newspaper4k import Newspaper4kTools
@@ -63,10 +64,10 @@ if openai_api_key and serp_api_key:
         markdown=True,
     )
 
-    editor = Agent(
+    editor = Team(
         name="Editor",
         model=OpenAIChat(id="gpt-4o", api_key=openai_api_key),
-        team=[searcher, writer],
+        members=[searcher, writer],
         description="You are a senior NYT editor. Given a topic, your goal is to write a NYT worthy article.",
         instructions=[
             "Given a topic, ask the search journalist to search for the most relevant URLs for that topic.",


### PR DESCRIPTION
Two functional bugs in `advanced_ai_agents/single_agent_apps/`.

### 1. `ai_email_gtm_reachout_agent` — successful campaign says "No emails were generated"
The completed-email branch is gated by `if 'progress' in result:` (line 869), but **every** yielded dict carries `progress` — the status updates and the completed-email yield alike. So the `else` branch never runs, `results_count` stays `0`, cards render `✅ Email #0`, and the post-loop `if results_count > 0` is false → the app shows the "No emails were generated" error and troubleshooting panel over the emails it just displayed (the success summary + balloons are dead code). Only the completed yield has an `email` key. → discriminate on `if 'email' not in result:`.

### 2. `ai_journalist_agent` — crashes on startup (agno 2.x removed `Agent(team=...)`)
`journalist_agent.py:69` uses `Agent(..., team=[searcher, writer])`. With the pinned `agno>=2.2.10`, `Agent.__init__` has no `team` param, so entering both keys raises `TypeError: ... unexpected keyword argument 'team'`. The sibling `ai_movie_production_agent` already uses `Team(members=[...])`. → build the editor as a `Team`.

Both files compile-check clean.

Fixes #1021