### PR TITLE
Fix vision_rag cohere `.float` field and deepseek agno 2.x migration

### DIFF
--- a/rag_tutorials/deepseek_local_rag_agent/deepseek_rag_agent.py
+++ b/rag_tutorials/deepseek_local_rag_agent/deepseek_rag_agent.py
@@ -13,7 +13,7 @@ from qdrant_client import QdrantClient
 from qdrant_client.models import Distance, VectorParams
 from langchain_core.embeddings import Embeddings
 from agno.tools.exa import ExaTools
-from agno.embedder.ollama import OllamaEmbedder
+from agno.knowledge.embedder.ollama import OllamaEmbedder
 
 
 class OllamaEmbedderr(Embeddings):
@@ -271,7 +271,7 @@ def get_web_search_agent() -> Agent:
         2. Compile and summarize the most relevant information
         3. Include sources in your response
         """,
-        show_tool_calls=True,
+        debug_mode=True,
         markdown=True,
     )
 
@@ -296,7 +296,7 @@ def get_rag_agent() -> Agent:
         
         Always maintain high accuracy and clarity in your responses.
         """,
-        show_tool_calls=True,
+        debug_mode=True,
         markdown=True,
     )
 

--- a/rag_tutorials/deepseek_local_rag_agent/requirements.txt
+++ b/rag_tutorials/deepseek_local_rag_agent/requirements.txt
@@ -1,4 +1,5 @@
-agno
+agno>=2.2.10
+pypdf
 exa-py
 qdrant-client==1.12.1
 langchain-qdrant==0.2.0

--- a/rag_tutorials/vision_rag/vision_rag.py
+++ b/rag_tutorials/vision_rag/vision_rag.py
@@ -135,8 +135,8 @@ def compute_image_embedding(base64_img: str, _cohere_client) -> np.ndarray | Non
             images=[base64_img],
         )
         
-        if api_response.embeddings and api_response.embeddings.float:
-            return np.asarray(api_response.embeddings.float[0])
+        if api_response.embeddings and api_response.embeddings.float_:
+            return np.asarray(api_response.embeddings.float_[0])
         else:
             st.warning("Could not get embedding. API response might be empty.")
             return None
@@ -320,11 +320,11 @@ def search(question: str, co_client: cohere.Client, embeddings: np.ndarray, imag
             texts=[question],
         )
 
-        if not api_response.embeddings or not api_response.embeddings.float:
+        if not api_response.embeddings or not api_response.embeddings.float_:
             st.error("Failed to get query embedding.")
             return None
 
-        query_emb = np.asarray(api_response.embeddings.float[0])
+        query_emb = np.asarray(api_response.embeddings.float_[0])
 
         # Ensure query embedding has the correct shape for dot product
         if query_emb.shape[0] != embeddings.shape[1]:


### PR DESCRIPTION
Two RAG apps are non-functional as shipped.

### 1. `vision_rag` — reads a nonexistent Cohere field `.float`
`vision_rag/vision_rag.py:138-139,323,327`. Cohere's `EmbedByTypeResponseEmbeddings` field is `float_` (the `alias="float"` only affects (de)serialization), so `.float` raises `AttributeError` — verified against installed `cohere`. It's swallowed by `except Exception`, so every embedding returns `None` and the app shows "Failed to load sample images" / "Failed to get query embedding." → use `.float_`.

### 2. `deepseek_local_rag_agent` — imports a removed module + removed kwarg (agno 2.x)
`deepseek_rag_agent.py:16` imports `agno.embedder.ollama`; agno 2.x moved it to `agno.knowledge.embedder`, so a fresh install (bare `agno`→2.x) fails with `ModuleNotFoundError`. Lines 274/299 pass `show_tool_calls=True`, which 2.x `Agent` no longer accepts (`TypeError`). The sibling `qwen_local_rag` is already migrated. → mirror it: new import path, `debug_mode=True`, `agno>=2.2.10`, and `pypdf` (`PyPDFLoader` is used at line 172).

Both files compile-check clean.

Fixes #1023