### PR TITLE
Fix project-graveyard `--redact` corrupting state + faking 'no longer found' relapse

### DIFF
--- a/agent_skills/project-graveyard/scripts/graveyard.py
+++ b/agent_skills/project-graveyard/scripts/graveyard.py
@@ -390,6 +390,11 @@ def main(argv=None):
 
     if args.redact:
         for i, r in enumerate(sorted(repos, key=lambda r: r["first"]), 1):
+            # Keep the real identifiers so relapse-watch matching and the local
+            # --state resume file stay correct; only the shareable report is
+            # redacted (see by_path / --state / --json below).
+            r["real_name"] = r["name"]
+            r["real_path"] = r["path"]
             r["name"] = "project-%d" % i
             r["path"] = "(redacted)"
 
@@ -482,7 +487,7 @@ def main(argv=None):
 
     # ---- relapse watch: hold past resurrections to their promise ----
     if state["resurrections"]:
-        by_path = {r["path"]: r for r in repos}
+        by_path = {r.get("real_path", r["path"]): r for r in repos}
         lines = []
         for res in state["resurrections"]:
             r = by_path.get(res["path"])
@@ -519,19 +524,26 @@ def main(argv=None):
                        "days_threshold": args.days,
                        "alive": [{k: r[k] for k in ("name", "path", "last", "commits")} for r in alive],
                        "finished": [{k: r[k] for k in ("name", "path", "last", "commits")} for r in finished],
-                       "unversioned": [{"name": u.name, "path": str(u)} for u in unversioned],
-                       "dead": [{k: r[k] for k in r if k not in ("messages", "gaps", "last_touched")}
+                       "unversioned": [{"name": "unversioned-%d" % i, "path": "(redacted)"}
+                                       if args.redact else {"name": u.name, "path": str(u)}
+                                       for i, u in enumerate(unversioned, 1)],
+                       "dead": [{k: r[k] for k in r
+                                 if k not in ("messages", "gaps", "last_touched", "real_name", "real_path")}
                                 for r in dead]}, f, indent=1)
         print("full report: %s" % args.json)
 
     if args.state:
+        # The state file is a local resume artifact, not the shared report, so it
+        # always records the real names/paths even under --redact.
         state["last_scan"] = {
             "date": datetime.now().strftime("%Y-%m-%d"),
             "roots": [str(r) for r in roots],
-            "dead": [{"name": r["name"], "path": r["path"], "cause": r["causes"][0][0],
-                      "pulse": r["pulse"]} for r in dead],
-            "alive": [{"name": r["name"], "path": r["path"]} for r in alive],
-            "finished": [{"name": r["name"], "path": r["path"]} for r in finished],
+            "dead": [{"name": r.get("real_name", r["name"]), "path": r.get("real_path", r["path"]),
+                      "cause": r["causes"][0][0], "pulse": r["pulse"]} for r in dead],
+            "alive": [{"name": r.get("real_name", r["name"]), "path": r.get("real_path", r["path"])}
+                      for r in alive],
+            "finished": [{"name": r.get("real_name", r["name"]), "path": r.get("real_path", r["path"])}
+                         for r in finished],
             "unversioned": [{"name": u.name, "path": str(u)} for u in unversioned],
         }
         with open(args.state, "w") as f:


### PR DESCRIPTION
`--redact` overwrites each repo's `name`/`path` in place, and everything downstream reads the redacted data:

1. **False relapse + corrupted state.** With `--redact --state` together (the SKILL doc's recommended share flow), the relapse map is keyed on `"(redacted)"`, so a resurrected repo that's present on disk prints `"resurrected …, no longer found on disk."`; and `--state` persists `"(redacted)"` paths, destroying the real names/paths Necromancer mode greps. The bundled eval never runs `--redact` and `--state` in one invocation, so it misses this.
2. **JSON leak.** Under `--redact` the `--json` report still wrote real `unversioned` names/absolute paths while the console redacted them.

### Fix
Save `real_name`/`real_path` when redacting; use them for relapse matching and the local `--state` resume file (always real), while the shareable console + `--json` stay fully redacted (unversioned included), and `real_*` are excluded from the JSON `dead` payload.

### Verification
- All four `skill-evals` CI jobs pass (deterministic evals incl. `test_graveyard.py` 16/16, strict lint, security scan, trigger-routing).
- A regression probe reproduces the false 'no longer found on disk' relapse and the state-path corruption on the current code (exit 1) and confirms both fixed (exit 0).

Fixes #1025