### PR TITLE
Add AI x402 Paying Agent — an agent that pays for its own data with USDC micropayments

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ streamlit run travel_agent.py
 *   [😂 AI Meme Generator Agent (Browser)](starter_ai_agents/ai_meme_generator_agent_browseruse/) - Makes memes by driving a real browser, not an image API
 *   [🎵 AI Music Generator Agent](starter_ai_agents/ai_music_generator_agent/) - Prompt in, MP3 track out
 *   [🛫 AI Travel Agent (Local & Cloud)](starter_ai_agents/ai_travel_agent/) - Personalized day-by-day travel itineraries
+*   [💸 AI x402 Paying Agent](starter_ai_agents/ai_x402_paying_agent/) - An agent with a wallet that pays per-call for the data it needs — no API keys
 *   [✨ Gemini Multimodal Agent](starter_ai_agents/multimodal_ai_agent/) - Video analysis plus web search in one agent
 *   [🔄 Mixture of Agents](starter_ai_agents/mixture_of_agents/) - Multiple LLMs answer, one aggregates the best response
 *   [📊 xAI Finance Agent](starter_ai_agents/xai_finance_agent/) - Real-time stock analysis powered by Grok

--- a/starter_ai_agents/ai_x402_paying_agent/README.md
+++ b/starter_ai_agents/ai_x402_paying_agent/README.md
@@ -1,0 +1,74 @@
+## 💸 AI x402 Paying Agent
+
+An AI agent with its own crypto wallet that **pays for the data it needs** — no API keys, no subscriptions, no signup.
+
+Ask a question in plain English. Claude decides which paid API answers it and calls a fetch tool. The API responds `402 Payment Required` with a price quote; the agent automatically pays it (a few cents in USDC on Base, via the open [x402](https://www.x402.org/) standard, now under the Linux Foundation) and answers from the data it just bought.
+
+This is the payment rail built for AI agents: machine-speed, per-call, no account anywhere.
+
+### Features
+
+- **Agent-driven tool use** — Claude picks the right paid endpoint for the question and quotes the returned data
+- **Automatic 402 payment** — the `x402` SDK signs a USDC payment on Base when an API challenges; typical calls cost $0.015–0.02
+- **Hard budget cap** — a per-call price ceiling (`MAX_PRICE_USDC`, default $0.05) so a misconfigured agent can never overspend
+- **No-LLM mode** — `--direct <URL>` pays and fetches any x402 URL with just a wallet, so you can see the payment flow in isolation
+- **Generic** — the demo points at three live endpoints (memecoin rug-check, ERC-20 honeypot check, stablecoin vault APYs), but the payment code works with any x402-enabled API
+
+> **Disclosure:** the demo endpoints are run by the tutorial author's company ([PulseNetwork](https://pulse.theaslangroupllc.com)). The agent code is vendor-neutral — point it at any x402 seller.
+
+### How to get Started?
+
+1. Clone the GitHub repository
+
+```bash
+git clone https://github.com/Shubhamsaboo/awesome-llm-apps.git
+cd awesome-llm-apps/starter_ai_agents/ai_x402_paying_agent
+```
+
+2. Install the required dependencies:
+
+```bash
+pip install -r requirements.txt
+```
+
+3. Fund a wallet
+
+Create a fresh EVM wallet (e.g. in MetaMask) and send it **$1 of USDC on Base** plus nothing else — x402 payments need no gas token. Export the private key:
+
+```bash
+export X402_PRIVATE_KEY='0x...'
+```
+
+⚠️ Use a dedicated throwaway wallet for agent spending — never your main wallet.
+
+4. Set your Anthropic API key (skip for `--direct` mode)
+
+```bash
+export ANTHROPIC_API_KEY='your-api-key-here'
+```
+
+5. Run the agent
+
+```bash
+# Full agent: natural-language question → paid data → answer
+python x402_paying_agent.py "What are the best stablecoin vault APYs right now?"
+
+python x402_paying_agent.py "Run a safety check on the BONK token: DezXAZ8z7PnrnRJjz3wXBoRgixCa6xjnB7YaB1pPB263"
+
+# Payment flow only, no LLM needed:
+python x402_paying_agent.py --direct "https://onchainpulse.theaslangroupllc.com/api/vault-apy"
+```
+
+### How it works
+
+```
+you ──question──▶ Claude ──tool call──▶ GET paid API
+                                          │ 402 Payment Required ($0.02)
+                                          ▼
+                                   x402 SDK signs USDC payment
+                                          │ retry with payment header
+                                          ▼
+                                     200 OK + data ──▶ Claude answers
+```
+
+The whole payment negotiation is 3 HTTP requests and settles on-chain in seconds. A run of this demo costs a few cents total.

--- a/starter_ai_agents/ai_x402_paying_agent/README.md
+++ b/starter_ai_agents/ai_x402_paying_agent/README.md
@@ -72,3 +72,7 @@ you ──question──▶ Claude ──tool call──▶ GET paid API
 ```
 
 The whole payment negotiation is 3 HTTP requests and settles on-chain in seconds. A run of this demo costs a few cents total.
+
+### Going to production: managed wallets
+
+This demo keeps the wallet as a raw private key so you can see every moving part. For a production agent, Coinbase's new [CDP x402 SDK](https://docs.cdp.coinbase.com/x402/core-concepts/cdp-sdk) (TypeScript) wraps the same open x402 standard with managed wallets (no private key to store), client-side spend controls (per-payment caps, rolling daily limits, payee allowlists), and hosted settlement. The `MAX_PRICE_USDC` guard in this tutorial is a minimal version of the same idea — cap what an autonomous spender can spend before it spends it. Everything the agent does here (402 quote → signed USDC payment → retry) works identically against any x402 endpoint from either stack.

--- a/starter_ai_agents/ai_x402_paying_agent/requirements.txt
+++ b/starter_ai_agents/ai_x402_paying_agent/requirements.txt
@@ -1,0 +1,4 @@
+anthropic
+x402[evm,httpx]
+eth-account
+httpx

--- a/starter_ai_agents/ai_x402_paying_agent/x402_paying_agent.py
+++ b/starter_ai_agents/ai_x402_paying_agent/x402_paying_agent.py
@@ -1,0 +1,181 @@
+"""AI x402 Paying Agent — an agent that pays for its own data with USDC micropayments.
+
+Ask a question → Claude picks a paid API → the agent hits it, gets an HTTP 402
+Payment Required challenge, pays a few cents in USDC on Base from its own wallet,
+and answers with the data. No API keys, no subscriptions, no signup.
+
+Usage:
+    python x402_paying_agent.py "Is this Solana memecoin a rug? <mint address>"
+    python x402_paying_agent.py --direct "https://onchainpulse.theaslangroupllc.com/api/vault-apy"
+
+SPDX-License-Identifier: Apache-2.0
+"""
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import os
+import sys
+from decimal import Decimal
+
+import httpx
+from eth_account import Account
+from x402 import x402Client
+from x402.http.clients.httpx import x402HttpxClient
+from x402.mechanisms.evm import EthAccountSigner
+from x402.mechanisms.evm.exact import ExactEvmScheme
+
+USDC_DECIMALS = 6  # 1 USDC = 10**6 atomic units; x402 amounts are atomic strings
+
+# Demo catalog: real pay-per-call endpoints (USDC on Base, a few cents each).
+# The payment code is generic — swap in any x402-enabled API.
+DEMO_ENDPOINTS = """
+Available paid data endpoints (x402, USDC on Base):
+
+1. Solana memecoin safety check — $0.015/call
+   GET https://onchainpulse.theaslangroupllc.com/api/memecoin?mint=<solana_mint_address>
+   Rug-pull risk signals for a Solana token: mint/freeze authority, holder concentration, liquidity.
+
+2. EVM token safety check — $0.015/call
+   GET https://onchainpulse.theaslangroupllc.com/api/evmtoken?address=<0x_token_address>&chain=<base|ethereum|...>
+   Honeypot and contract-risk signals for an ERC-20 token.
+
+3. Stablecoin vault APY rankings — $0.02/call
+   GET https://onchainpulse.theaslangroupllc.com/api/vault-apy
+   Live APY comparison across on-chain USDC/stablecoin yield vaults.
+"""
+
+SYSTEM_PROMPT = f"""You are a data agent with a crypto wallet. You can call paid APIs — when one
+responds with HTTP 402 Payment Required, your fetch tool automatically pays the quoted price
+in USDC and retrieves the data.
+
+{DEMO_ENDPOINTS}
+
+When the user's question maps to one of these endpoints, call fetch_paid_api with the full URL
+(including query parameters). Answer from the returned data only — quote the key numbers.
+If the question doesn't match any endpoint, say so instead of guessing."""
+
+TOOLS = [
+    {
+        "name": "fetch_paid_api",
+        "description": (
+            "Fetch a URL, automatically paying an x402 HTTP 402 challenge in USDC if the API "
+            "requires payment. Call this when the user's question requires paid data. "
+            "Returns the response body as JSON text."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "url": {
+                    "type": "string",
+                    "description": "Full URL to fetch, including any query parameters.",
+                }
+            },
+            "required": ["url"],
+        },
+    }
+]
+
+
+def build_paying_client(private_key: str, max_price_usdc: Decimal) -> httpx.AsyncClient:
+    """httpx client that auto-pays 402 challenges, refusing anything above max_price_usdc."""
+    signer = EthAccountSigner(Account.from_key(private_key))
+    client = x402Client()
+    cap_atomic = int(max_price_usdc * (10**USDC_DECIMALS))
+
+    def _budget_cap(version, accepts):
+        allowed = [
+            a
+            for a in accepts
+            if int(getattr(a, "amount", None) or getattr(a, "max_amount_required", 0) or 0) <= cap_atomic
+        ]
+        if not allowed:
+            raise ValueError(
+                f"Refusing to pay: cheapest payment option exceeds the ${max_price_usdc} per-call cap. "
+                "Raise MAX_PRICE_USDC if this is intentional."
+            )
+        return allowed
+
+    client.register_policy(_budget_cap)
+    client.register("eip155:*", ExactEvmScheme(signer))
+    return x402HttpxClient(client, follow_redirects=True, timeout=60.0)
+
+
+async def paid_fetch(url: str, private_key: str, max_price_usdc: Decimal) -> str:
+    async with build_paying_client(private_key, max_price_usdc) as client:
+        resp = await client.get(url)
+        if resp.status_code != 200:
+            return f"Request failed: HTTP {resp.status_code}: {resp.text[:300]}"
+        return resp.text
+
+
+def run_agent(question: str, private_key: str, max_price_usdc: Decimal) -> None:
+    import anthropic
+
+    client = anthropic.Anthropic()
+    model = os.environ.get("CLAUDE_MODEL", "claude-opus-4-8")
+    messages = [{"role": "user", "content": question}]
+
+    while True:
+        response = client.messages.create(
+            model=model,
+            max_tokens=2048,
+            system=SYSTEM_PROMPT,
+            tools=TOOLS,
+            messages=messages,
+        )
+        if response.stop_reason != "tool_use":
+            for block in response.content:
+                if block.type == "text":
+                    print(block.text)
+            return
+
+        messages.append({"role": "assistant", "content": response.content})
+        tool_results = []
+        for block in response.content:
+            if block.type == "tool_use":
+                url = block.input["url"]
+                print(f"→ fetching (paying if challenged): {url}", file=sys.stderr)
+                try:
+                    result = asyncio.run(paid_fetch(url, private_key, max_price_usdc))
+                except Exception as exc:  # payment refused, network error, etc.
+                    result = f"Error: {exc}"
+                tool_results.append(
+                    {"type": "tool_result", "tool_use_id": block.id, "content": result}
+                )
+        messages.append({"role": "user", "content": tool_results})
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="AI agent that pays for its own data via x402")
+    parser.add_argument("question", nargs="?", help="Question for the agent")
+    parser.add_argument(
+        "--direct",
+        metavar="URL",
+        help="Skip the LLM: pay-and-fetch this URL directly and print the JSON (wallet only, no Anthropic key needed)",
+    )
+    args = parser.parse_args()
+
+    private_key = os.environ.get("X402_PRIVATE_KEY")
+    if not private_key:
+        sys.exit("Set X402_PRIVATE_KEY to a wallet private key holding a little USDC on Base.")
+    max_price = Decimal(os.environ.get("MAX_PRICE_USDC", "0.05"))
+
+    if args.direct:
+        body = asyncio.run(paid_fetch(args.direct, private_key, max_price))
+        try:
+            print(json.dumps(json.loads(body), indent=2))
+        except json.JSONDecodeError:
+            print(body)
+        return
+
+    if not args.question:
+        parser.error("Provide a question, or use --direct <URL>")
+    if not os.environ.get("ANTHROPIC_API_KEY"):
+        sys.exit("Set ANTHROPIC_API_KEY (or use --direct <URL> for the no-LLM payment demo).")
+    run_agent(args.question, private_key, max_price)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What it does

An AI agent with its own crypto wallet that **pays for the data it needs** — no API keys, no subscriptions, no signup.

The user asks a question in plain English → Claude picks the right paid API and calls a fetch tool → the API responds `402 Payment Required` with a price quote → the agent automatically pays it (a few cents in USDC on Base via the open [x402](https://www.x402.org/) standard, now under the Linux Foundation) → answers from the data it just bought.

## Why it's a good fit for this repo

- **First x402/micropayments example here** — searched the repo, zero coverage of agent-native payments today, and "agents that pay for their own resources" is one of the fastest-moving corners of the agent ecosystem
- **Lower friction than most starter agents** — no data-provider API key to sign up for; a throwaway wallet with $1 of USDC covers ~50 runs
- **Safety built in** — hard per-call budget cap (`MAX_PRICE_USDC`, default $0.05) so a misconfigured agent can never overspend, plus a prominent use-a-throwaway-wallet warning
- **`--direct` mode** shows the raw payment flow with no LLM at all, useful for understanding the standard in isolation

## Verified before submission

Both modes run live: `--direct` paid a $0.02 challenge and returned data; the full agent loop (question → tool call → 402 → payment → answer) completed end-to-end.

## Disclosure

The three demo endpoints (memecoin rug-check, ERC-20 honeypot check, stablecoin vault APYs) are run by my company (PulseNetwork) — that's how I know they'll stay up for readers. This is disclosed in the tutorial README, and the agent code is fully vendor-neutral: point it at any x402 seller. Happy to swap demo endpoints or adjust anything to fit the repo's style.

🤖 Generated with [Claude Code](https://claude.com/claude-code)