### PR TITLE
Finish phidata->agno migration for recruitment and teaching agent teams

### DIFF
--- a/advanced_ai_agents/multi_agent_apps/agent_teams/ai_recruitment_agent_team/requirements.txt
+++ b/advanced_ai_agents/multi_agent_apps/agent_teams/ai_recruitment_agent_team/requirements.txt
@@ -1,5 +1,4 @@
 # Core dependencies
-phidata
 agno>=2.2.10
 streamlit==1.40.2
 PyPDF2==3.0.1

--- a/advanced_ai_agents/multi_agent_apps/agent_teams/ai_teaching_agent_team/requirements.txt
+++ b/advanced_ai_agents/multi_agent_apps/agent_teams/ai_teaching_agent_team/requirements.txt
@@ -3,7 +3,7 @@ openai==1.58.1
 duckduckgo-search>=6.4.2,<9
 typing-extensions>=4.5.0
 agno>=2.2.10
-composio-phidata==0.6.9
+composio-agno==0.7.20
 composio_core
 composio==0.1.1
 google-search-results==2.4.2

--- a/advanced_ai_agents/multi_agent_apps/agent_teams/ai_teaching_agent_team/teaching_agent_team.py
+++ b/advanced_ai_agents/multi_agent_apps/agent_teams/ai_teaching_agent_team/teaching_agent_team.py
@@ -2,7 +2,7 @@ import streamlit as st
 from agno.agent import Agent
 from agno.run.agent import RunOutput
 from agno.models.openai import OpenAIChat
-from composio_phidata import Action, ComposioToolSet
+from composio_agno import Action, ComposioToolSet
 import os
 from agno.tools.arxiv import ArxivTools
 from agno.utils.pprint import pprint_run_response


### PR DESCRIPTION
## Summary
- `ai_recruitment_agent_team/requirements.txt` pinned both `phidata` and `agno>=2.2.10`; drops the stray leftover `phidata` line
- `ai_teaching_agent_team/requirements.txt` still pinned `composio-phidata==0.6.9` from before the repo-wide Phidata→Agno migration; switches to `composio-agno==0.7.20`
- `ai_teaching_agent_team/teaching_agent_team.py` imported from `composio_phidata`; updated to `composio_agno` (same `Action`/`ComposioToolSet` API) so the code actually matches the new dependency

## Test plan
- [ ] `pip install -r requirements.txt` succeeds for both `ai_recruitment_agent_team` and `ai_teaching_agent_team`
- [ ] `ai_teaching_agent_team/teaching_agent_team.py` imports cleanly with `composio-agno` installed