### PR TITLE
Add Engram MCP Server to MCP AI Agents section

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,7 @@ streamlit run travel_agent.py
 *   [📑 Notion MCP Agent](mcp_ai_agents/notion_mcp_agent) - Talk to your Notion pages from the terminal
 *   [🌍 AI Travel Planner MCP Agent](mcp_ai_agents/ai_travel_planner_mcp_agent_team) - Itineraries built on live Airbnb and Google Maps data
 *   [🔀 Multi-MCP Agent Router](mcp_ai_agents/multi_mcp_agent_router/) - Specialist agents, each wired to its own MCP server
+*   [🧠 Engram MCP Server](https://github.com/lalithbuilds/engram-mcp) <sub>↗ external</sub> - Zero-dependency persistent memory for AI agents via SQLite FTS5
 
 ### 📀 RAG (Retrieval Augmented Generation)
 


### PR DESCRIPTION
Adding `engram-mcp`: A pure Python stdlib MCP server for persistent AI agent memory. Local-first, zero dependency. Thank you for this awesome list!