### PR TITLE
Add Lumify Sports Intelligence Agent (MCP)

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,7 @@ streamlit run travel_agent.py
 *   [📑 Notion MCP Agent](mcp_ai_agents/notion_mcp_agent) - Talk to your Notion pages from the terminal
 *   [🌍 AI Travel Planner MCP Agent](mcp_ai_agents/ai_travel_planner_mcp_agent_team) - Itineraries built on live Airbnb and Google Maps data
 *   [🔀 Multi-MCP Agent Router](mcp_ai_agents/multi_mcp_agent_router/) - Specialist agents, each wired to its own MCP server
+*   [🏆 Lumify Sports Intelligence Agent](mcp_ai_agents/lumify_sports_intelligence_agent/) - Schedules, odds, and explainable bet confidence via the Lumify MCP server
 
 ### 📀 RAG (Retrieval Augmented Generation)
 

--- a/mcp_ai_agents/lumify_sports_intelligence_agent/README.md
+++ b/mcp_ai_agents/lumify_sports_intelligence_agent/README.md
@@ -1,0 +1,74 @@
+# 🏆 Lumify Sports Intelligence Agent
+
+A terminal-based sports betting research agent that talks to the [Lumify](https://lumify.ai) MCP server using natural language - schedules, live scores, odds, line movement, public betting splits, and explainable AI bet confidence across MLB, NFL, NCAAF, NCAAB, NBA, NHL, tennis, and soccer.
+
+## Features
+
+- Ask for schedules, live scores, odds, and line movement in plain English
+- Get explainable bet-confidence intelligence for a specific matchup (not a black-box pick - the reasoning behind it)
+- Free cost estimation before spending credits (`estimate_cost` is always free)
+- Remembers conversation context for multi-turn research sessions
+- Connects to Lumify's hosted MCP server over Streamable HTTP - no local server to install
+
+## Prerequisites
+
+- Python 3.10+
+- An OpenAI API key
+- A Lumify API key
+
+## Getting a Lumify API key
+
+- **Fastest:** a free instant trial key, no signup - <https://lumify.ai/docs/ai> (100 credits, 14-day expiry)
+- **Persistent:** create a free account for 1,000 starter credits - <https://lumify.ai/api-keys>
+
+## Installation
+
+1. Clone this repository:
+   ```bash
+   git clone https://github.com/Shubhamsaboo/awesome-llm-apps.git
+   cd awesome-llm-apps/mcp_ai_agents/lumify_sports_intelligence_agent
+   ```
+
+2. Install the required Python packages:
+   ```bash
+   pip install -r requirements.txt
+   ```
+
+## Configuration
+
+Set these as environment variables (or in a `.env` file in this folder):
+
+- `LUMIFY_API_KEY`: Your Lumify API key
+- `OPENAI_API_KEY`: Your OpenAI API key
+- `LUMIFY_MCP_URL` (optional): Defaults to `https://lumify.ai/mcp`
+
+## Usage
+
+Run the agent interactively from the command line:
+
+```bash
+python lumify_sports_agent.py
+```
+
+Or pass a one-off question as arguments and get a single response:
+
+```bash
+python lumify_sports_agent.py "What NBA games are on tonight and what's the best bet?"
+```
+
+You can exit an interactive session at any time by typing `exit`, `quit`, or `bye`.
+
+## Example Queries
+
+- "What NHL games are scheduled today?"
+- "What's the live score of the Celtics game right now?"
+- "Give me the odds and line movement for tonight's Yankees game"
+- "What's Lumify's bet confidence on the Chiefs vs Bills game, and why?"
+- "How many credits would it cost to check odds and intelligence for 3 NFL games?"
+- "Show me the public betting split on the Lakers game"
+
+## How It Works
+
+The agent connects to Lumify's hosted MCP server (`https://lumify.ai/mcp`, Streamable HTTP) using [Agno](https://github.com/agno-agi/agno)'s `MCPTools`, authenticating with your API key as a Bearer token. All 18 Lumify tools (`list_events`, `get_odds`, `get_intelligence`, `get_live_score`, `estimate_cost`, and more) load automatically - there are no per-tool wrappers to write or keep in sync as Lumify adds new sports or endpoints.
+
+Each `tools/call` is metered the same as the equivalent REST call; `initialize`, `tools/list`, and `estimate_cost` are always free, and calls for data that isn't available yet (e.g. odds on a match that hasn't been priced) return `available: false` at no charge.

--- a/mcp_ai_agents/lumify_sports_intelligence_agent/lumify_sports_agent.py
+++ b/mcp_ai_agents/lumify_sports_intelligence_agent/lumify_sports_agent.py
@@ -1,0 +1,99 @@
+import asyncio
+import os
+import sys
+import uuid
+from textwrap import dedent
+
+from agno.agent import Agent
+from agno.db.sqlite import SqliteDb
+from agno.models.openai import OpenAIChat
+from agno.tools.mcp import MCPTools, StreamableHTTPClientParams
+from dotenv import load_dotenv
+
+load_dotenv()
+
+LUMIFY_API_KEY = os.getenv("LUMIFY_API_KEY")
+OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
+LUMIFY_MCP_URL = os.getenv("LUMIFY_MCP_URL", "https://lumify.ai/mcp")
+
+
+async def main():
+    print("\n========================================")
+    print(" Lumify Sports Intelligence Agent")
+    print("========================================\n")
+
+    if not LUMIFY_API_KEY:
+        print("No LUMIFY_API_KEY set - grab a free instant key (no signup) at")
+        print("https://lumify.ai/docs/ai, or a persistent one at https://lumify.ai/api-keys")
+        print("Continuing without auth: discovery works, but tool calls will fail.\n")
+
+    user_id = f"user_{uuid.uuid4().hex[:8]}"
+    session_id = f"session_{uuid.uuid4().hex[:8]}"
+
+    print("Connecting to the Lumify MCP server...\n")
+
+    server_params = StreamableHTTPClientParams(
+        url=LUMIFY_MCP_URL,
+        headers={"Authorization": f"Bearer {LUMIFY_API_KEY}"} if LUMIFY_API_KEY else {},
+    )
+
+    async with MCPTools(server_params=server_params, transport="streamable-http") as mcp_tools:
+        print("Connected! Lumify's sports intelligence tools are ready.\n")
+        db = SqliteDb(db_file="agno.db")
+
+        agent = Agent(
+            name="LumifySportsAgent",
+            model=OpenAIChat(id="gpt-4o", api_key=OPENAI_API_KEY),
+            tools=[mcp_tools],
+            description="Agent that answers sports schedule, odds, and bet-confidence questions via the Lumify MCP server",
+            instructions=dedent("""
+                You are a sports intelligence assistant backed by the Lumify API
+                (schedules, live scores, odds, line movement, public betting splits,
+                and explainable AI bet confidence across MLB, NFL, NCAAF, NCAAB, NBA,
+                NHL, tennis, and soccer).
+
+                IMPORTANT INSTRUCTIONS:
+                1. Use the Lumify MCP tools directly - don't guess at scores, odds, or
+                   schedules.
+                2. Every `tools/call` other than `estimate_cost` costs Lumify credits.
+                   If a user asks "how much would this cost", call `estimate_cost`
+                   first - it is always free.
+                3. Calls for odds/intelligence/splits on a match that isn't priced yet
+                   return `available: false` at no charge - explain that plainly
+                   instead of treating it as an error.
+                4. `get_splits` only has data for MLB, NBA, NHL, and NFL.
+                5. When asked for "the best bet" or similar judgment calls, use
+                   `get_intelligence` and explain the confidence/reasoning it returns
+                   rather than inventing your own pick.
+                6. Be concise. Cite the sport, teams, and timeframe you actually
+                   queried so answers are easy to verify.
+            """),
+            markdown=True,
+            retries=3,
+            db=db,
+            add_history_to_context=True,
+            num_history_runs=5,
+        )
+
+        print("Lumify Sports Intelligence Agent is ready! Ask about schedules, odds,")
+        print("live scores, or bet confidence for any supported sport.\n")
+        print("Type 'exit', 'quit', or 'bye' to end the conversation.\n")
+
+        if len(sys.argv) > 1:
+            query = " ".join(sys.argv[1:])
+            await agent.aprint_response(input=query, stream=True, markdown=True)
+            return
+
+        await agent.acli_app(
+            user_id=user_id,
+            session_id=session_id,
+            user="You",
+            emoji="🏆",
+            stream=True,
+            markdown=True,
+            exit_on=["exit", "quit", "bye", "goodbye"],
+        )
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/mcp_ai_agents/lumify_sports_intelligence_agent/requirements.txt
+++ b/mcp_ai_agents/lumify_sports_intelligence_agent/requirements.txt
@@ -1,0 +1,5 @@
+agno>=2.2.10
+openai
+mcp
+python-dotenv
+sqlalchemy


### PR DESCRIPTION
## What

A new terminal agent under `mcp_ai_agents/lumify_sports_intelligence_agent/` that connects to [Lumify](https://lumify.ai)'s hosted MCP server for natural-language sports intelligence: schedules, live scores, odds, line movement, public betting splits, and explainable AI bet confidence across MLB, NFL, NCAAF, NCAAB, NBA, NHL, tennis, and soccer.

## Why this fits the MCP AI Agents section

Follows the same pattern as the existing Notion/GitHub MCP agents in this repo: an Agno `Agent` + `MCPTools` talking to a remote MCP server over Streamable HTTP, with SQLite-backed conversation memory. All 18 Lumify tools (`list_events`, `get_odds`, `get_intelligence`, `get_live_score`, `estimate_cost`, etc.) load automatically from the server - no per-tool wrappers needed.

## Verified

- Connected live to the production endpoint (`https://lumify.ai/mcp`) with Agno's `MCPTools` (Streamable HTTP transport) and confirmed all 18 tools are discovered.
- Ran the full script end-to-end (agent construction, memory setup, interactive CLI loop) against the live server.
- Free instant trial keys (no signup) are available at https://lumify.ai/docs/ai for anyone who wants to try it without creating an account, so reviewers/users can run this with zero setup friction.

## Files added

- `mcp_ai_agents/lumify_sports_intelligence_agent/lumify_sports_agent.py`
- `mcp_ai_agents/lumify_sports_intelligence_agent/requirements.txt`
- `mcp_ai_agents/lumify_sports_intelligence_agent/README.md`
- One-line addition to the root `README.md` MCP AI Agents list

## Disclosure

I'm affiliated with Lumify. Happy to adjust naming, structure, or scope per your conventions.

Made with [Cursor](https://cursor.com)