### PR TITLE
Add MiniMax AI Agent starter app

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ streamlit run travel_agent.py
 *   [🎵 AI Music Generator Agent](starter_ai_agents/ai_music_generator_agent/) - Prompt in, MP3 track out
 *   [🛫 AI Travel Agent (Local & Cloud)](starter_ai_agents/ai_travel_agent/) - Personalized day-by-day travel itineraries
 *   [✨ Gemini Multimodal Agent](starter_ai_agents/multimodal_ai_agent/) - Video analysis plus web search in one agent
+*   [🤖 MiniMax AI Agent](starter_ai_agents/minimax_ai_agent/) - Chat with MiniMax-M3 and MiniMax-M2.7 across regions and API surfaces
 *   [🔄 Mixture of Agents](starter_ai_agents/mixture_of_agents/) - Multiple LLMs answer, one aggregates the best response
 *   [📊 xAI Finance Agent](starter_ai_agents/xai_finance_agent/) - Real-time stock analysis powered by Grok
 *   [🔍 OpenAI Research Agent](starter_ai_agents/openai_research_agent/) - Multi-agent topic research with the OpenAI Agents SDK

--- a/starter_ai_agents/minimax_ai_agent/README.md
+++ b/starter_ai_agents/minimax_ai_agent/README.md
@@ -1,0 +1,62 @@
+## 🤖 MiniMax AI Agent
+
+A Streamlit demo that chats with [MiniMax](https://platform.minimax.io/docs) models.
+It is a self-contained provider integration: pick a model, a region and an API
+surface, and the app talks to MiniMax directly over HTTP.
+
+### Features
+
+- **Models**
+  - `MiniMax-M3` (default) — 1,000,000-token context window; accepts **text, image, and video** input; supports `adaptive` and `disabled` thinking modes.
+  - `MiniMax-M2.7` — 204,800-token context window; text input; `always_on` thinking.
+- **Regions** — Global (`api.minimax.io`) and Mainland China (`api.minimaxi.com`).
+- **API surfaces** — the Chat Completions API (`/v1/chat/completions`) and the Messages API (`/anthropic/v1/messages`). Every region exposes both.
+- **Multimodal input** — MiniMax-M3 can take an optional image URL alongside your prompt.
+
+### How to get started
+
+1. Clone the repository
+
+```bash
+git clone https://github.com/Shubhamsaboo/awesome-llm-apps.git
+cd awesome-llm-apps/starter_ai_agents/minimax_ai_agent
+```
+
+2. Install the dependencies
+
+```bash
+pip install -r requirements.txt
+```
+
+3. Get your MiniMax API key
+
+Sign up on the [MiniMax platform](https://platform.minimax.io/docs) (or the
+[Mainland China platform](https://platform.minimaxi.com/docs)) and create an API key.
+
+4. Run the app
+
+```bash
+streamlit run minimax_ai_agent.py
+```
+
+### How it works
+
+`minimax_provider.py` holds a small `MiniMaxClient`. You choose a **region**
+(which host to reach) and an **API surface** (Chat Completions or Messages), and
+the client builds the correct URL, headers and request body for that combination:
+
+| Region | Chat Completions base URL | Messages base URL |
+| --- | --- | --- |
+| Global | `https://api.minimax.io/v1` | `https://api.minimax.io/anthropic` |
+| Mainland China | `https://api.minimaxi.com/v1` | `https://api.minimaxi.com/anthropic` |
+
+The API key is sent as a Bearer token. When you give MiniMax-M3 an image URL, the
+client attaches it as a multimodal content part on the Chat Completions surface.
+
+### Tests
+
+Offline tests stub the HTTP layer, so they run without a key or network access:
+
+```bash
+python -m unittest test_minimax_provider
+```

--- a/starter_ai_agents/minimax_ai_agent/minimax_ai_agent.py
+++ b/starter_ai_agents/minimax_ai_agent/minimax_ai_agent.py
@@ -1,0 +1,78 @@
+"""MiniMax AI Agent.
+
+A single-file Streamlit demo that chats with MiniMax models. You can pick the
+model (MiniMax-M3 or MiniMax-M2.7), the region (Global or Mainland China) and
+the API surface (Chat Completions or Messages). MiniMax-M3 also accepts an
+optional image URL to showcase its multimodal input.
+"""
+
+import streamlit as st
+
+from minimax_provider import (
+    DEFAULT_MODEL,
+    MODELS,
+    REGIONS,
+    MiniMaxClient,
+)
+
+st.set_page_config(page_title="MiniMax AI Agent", page_icon="🤖", layout="wide")
+
+st.title("🤖 MiniMax AI Agent")
+st.caption("Chat with MiniMax models across regions and API surfaces.")
+
+with st.sidebar:
+    st.header("Settings")
+    api_key = st.text_input("MiniMax API Key", type="password")
+
+    region_key = st.selectbox(
+        "Region",
+        options=list(REGIONS),
+        format_func=lambda key: REGIONS[key]["label"],
+    )
+
+    protocol_label_to_value = {
+        "Chat Completions API": "chat_completions",
+        "Messages API": "messages",
+    }
+    protocol_label = st.radio("API surface", list(protocol_label_to_value))
+    protocol = protocol_label_to_value[protocol_label]
+
+    model_ids = list(MODELS)
+    model_id = st.selectbox(
+        "Model",
+        options=model_ids,
+        index=model_ids.index(DEFAULT_MODEL),
+    )
+
+    model = MODELS[model_id]
+    st.markdown(
+        f"**Context window:** {model.context_window:,} tokens\n\n"
+        f"**Input:** {', '.join(model.input_modalities)}\n\n"
+        f"**Thinking:** {', '.join(model.thinking)}"
+    )
+
+    region = REGIONS[region_key]
+    base_url = (
+        region["chat_completions_base_url"]
+        if protocol == "chat_completions"
+        else region["messages_base_url"]
+    )
+    st.caption(f"Endpoint: {base_url}")
+    st.caption(f"Docs: {region['docs_root']}")
+
+image_url = None
+if "image" in model.input_modalities:
+    image_url = st.text_input(
+        "Optional image URL (MiniMax-M3 multimodal input)"
+    ) or None
+
+prompt = st.text_area("Your message", height=140)
+
+if st.button("Send", type="primary", disabled=not (api_key and prompt)):
+    client = MiniMaxClient(api_key=api_key, region=region_key, protocol=protocol)
+    with st.spinner(f"Asking {model_id}..."):
+        try:
+            reply = client.complete(prompt, model=model_id, image_url=image_url)
+            st.markdown(reply)
+        except Exception as exc:  # surface API/network errors to the user
+            st.error(f"Request failed: {exc}")

--- a/starter_ai_agents/minimax_ai_agent/minimax_provider.py
+++ b/starter_ai_agents/minimax_ai_agent/minimax_provider.py
@@ -1,0 +1,212 @@
+"""MiniMax provider client.
+
+A small, dependency-light client for the MiniMax models. It talks to MiniMax
+through either of the two API compatibility surfaces that MiniMax exposes:
+
+* the Chat Completions API (``/v1/chat/completions``), and
+* the Messages API (``/anthropic/v1/messages``).
+
+Both surfaces are available on the global host (``api.minimax.io``) and on the
+mainland-China host (``api.minimaxi.com``). The client keeps the region and the
+protocol as explicit, swappable settings so a caller can reach every endpoint
+combination that MiniMax offers.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
+
+import requests
+
+# --- Regional endpoints -----------------------------------------------------
+# Each region publishes both compatibility surfaces on its own host.
+REGIONS: Dict[str, Dict[str, str]] = {
+    "global": {
+        "label": "Global",
+        "chat_completions_base_url": "https://api.minimax.io/v1",
+        "messages_base_url": "https://api.minimax.io/anthropic",
+        "docs_root": "https://platform.minimax.io/docs",
+    },
+    "china": {
+        "label": "Mainland China",
+        "chat_completions_base_url": "https://api.minimaxi.com/v1",
+        "messages_base_url": "https://api.minimaxi.com/anthropic",
+        "docs_root": "https://platform.minimaxi.com/docs",
+    },
+}
+
+
+# --- Models -----------------------------------------------------------------
+# ``context_window`` is the maximum number of tokens the model can attend to,
+# ``input_modalities`` is what the model accepts as input, and ``thinking`` is
+# the set of reasoning modes the model supports.
+@dataclass(frozen=True)
+class Model:
+    model_id: str
+    context_window: int
+    input_modalities: List[str]
+    thinking: List[str]
+
+
+MODELS: Dict[str, Model] = {
+    "MiniMax-M3": Model(
+        model_id="MiniMax-M3",
+        context_window=1_000_000,
+        input_modalities=["text", "image", "video"],
+        thinking=["adaptive", "disabled"],
+    ),
+    "MiniMax-M2.7": Model(
+        model_id="MiniMax-M2.7",
+        context_window=204_800,
+        input_modalities=["text"],
+        thinking=["always_on"],
+    ),
+}
+
+DEFAULT_MODEL = "MiniMax-M3"
+DEFAULT_REGION = "global"
+DEFAULT_PROTOCOL = "chat_completions"
+
+# Version header required by the Messages API compatibility surface.
+MESSAGES_API_VERSION = "2023-06-01"
+
+
+@dataclass
+class MiniMaxClient:
+    """Minimal client for MiniMax models.
+
+    Parameters
+    ----------
+    api_key:
+        MiniMax API key (sent as a Bearer token).
+    region:
+        ``"global"`` or ``"china"`` -- selects the host, see :data:`REGIONS`.
+    protocol:
+        ``"chat_completions"`` or ``"messages"`` -- selects the API surface.
+    timeout:
+        Per-request timeout in seconds.
+    """
+
+    api_key: str
+    region: str = DEFAULT_REGION
+    protocol: str = DEFAULT_PROTOCOL
+    timeout: int = 60
+    session: requests.Session = field(default_factory=requests.Session)
+
+    def __post_init__(self) -> None:
+        if self.region not in REGIONS:
+            raise ValueError(
+                f"Unknown region {self.region!r}; expected one of {sorted(REGIONS)}"
+            )
+        if self.protocol not in ("chat_completions", "messages"):
+            raise ValueError(
+                f"Unknown protocol {self.protocol!r}; "
+                "expected 'chat_completions' or 'messages'"
+            )
+
+    # -- URL / header helpers ------------------------------------------------
+    def _endpoint(self) -> str:
+        region = REGIONS[self.region]
+        if self.protocol == "chat_completions":
+            return f"{region['chat_completions_base_url']}/chat/completions"
+        return f"{region['messages_base_url']}/v1/messages"
+
+    def _headers(self) -> Dict[str, str]:
+        headers = {
+            "Authorization": f"Bearer {self.api_key}",
+            "Content-Type": "application/json",
+        }
+        if self.protocol == "messages":
+            headers["anthropic-version"] = MESSAGES_API_VERSION
+        return headers
+
+    # -- Content helpers -----------------------------------------------------
+    @staticmethod
+    def build_user_content(text: str, image_url: Optional[str] = None) -> Any:
+        """Build a user-message payload.
+
+        With an ``image_url`` this returns the multimodal content-part list that
+        MiniMax-M3 accepts on the Chat Completions API; otherwise a plain string.
+        """
+        if not image_url:
+            return text
+        return [
+            {"type": "text", "text": text},
+            {"type": "image_url", "image_url": {"url": image_url}},
+        ]
+
+    # -- Request -------------------------------------------------------------
+    def complete(
+        self,
+        prompt: str,
+        *,
+        model: str = DEFAULT_MODEL,
+        system: Optional[str] = None,
+        image_url: Optional[str] = None,
+        max_tokens: int = 1024,
+    ) -> str:
+        """Send a single-turn prompt and return the model's text reply.
+
+        ``image_url`` demonstrates MiniMax-M3's image input and is only sent on
+        the Chat Completions surface, which uses inline content parts.
+        """
+        if model not in MODELS:
+            raise ValueError(
+                f"Unknown model {model!r}; expected one of {sorted(MODELS)}"
+            )
+
+        if self.protocol == "chat_completions":
+            payload = self._chat_completions_payload(
+                prompt, model, system, image_url, max_tokens
+            )
+        else:
+            payload = self._messages_payload(prompt, model, system, max_tokens)
+
+        response = self.session.post(
+            self._endpoint(),
+            headers=self._headers(),
+            json=payload,
+            timeout=self.timeout,
+        )
+        response.raise_for_status()
+        return self._parse_reply(response.json())
+
+    def _chat_completions_payload(
+        self,
+        prompt: str,
+        model: str,
+        system: Optional[str],
+        image_url: Optional[str],
+        max_tokens: int,
+    ) -> Dict[str, Any]:
+        messages: List[Dict[str, Any]] = []
+        if system:
+            messages.append({"role": "system", "content": system})
+        messages.append(
+            {"role": "user", "content": self.build_user_content(prompt, image_url)}
+        )
+        return {"model": model, "messages": messages, "max_tokens": max_tokens}
+
+    def _messages_payload(
+        self,
+        prompt: str,
+        model: str,
+        system: Optional[str],
+        max_tokens: int,
+    ) -> Dict[str, Any]:
+        payload: Dict[str, Any] = {
+            "model": model,
+            "max_tokens": max_tokens,
+            "messages": [{"role": "user", "content": prompt}],
+        }
+        if system:
+            payload["system"] = system
+        return payload
+
+    def _parse_reply(self, data: Dict[str, Any]) -> str:
+        if self.protocol == "chat_completions":
+            return data["choices"][0]["message"]["content"]
+        # Messages API returns a list of content blocks.
+        blocks = data.get("content", [])
+        return "".join(block.get("text", "") for block in blocks)

--- a/starter_ai_agents/minimax_ai_agent/requirements.txt
+++ b/starter_ai_agents/minimax_ai_agent/requirements.txt
@@ -1,0 +1,2 @@
+streamlit
+requests

--- a/starter_ai_agents/minimax_ai_agent/test_minimax_provider.py
+++ b/starter_ai_agents/minimax_ai_agent/test_minimax_provider.py
@@ -1,0 +1,132 @@
+"""Offline tests for the MiniMax provider client.
+
+These stub the HTTP layer so they run without network access or an API key.
+Run with: python -m unittest test_minimax_provider
+"""
+
+import unittest
+from unittest.mock import MagicMock
+
+from minimax_provider import (
+    DEFAULT_MODEL,
+    MODELS,
+    REGIONS,
+    MiniMaxClient,
+)
+
+
+def _fake_session(payload):
+    """A session whose .post returns a response yielding ``payload``."""
+    session = MagicMock()
+    response = MagicMock()
+    response.json.return_value = payload
+    response.raise_for_status.return_value = None
+    session.post.return_value = response
+    return session
+
+
+class ModelCatalogTests(unittest.TestCase):
+    def test_default_model_is_m3(self):
+        self.assertEqual(DEFAULT_MODEL, "MiniMax-M3")
+
+    def test_both_models_present(self):
+        self.assertEqual(set(MODELS), {"MiniMax-M3", "MiniMax-M2.7"})
+
+    def test_m3_capabilities(self):
+        m3 = MODELS["MiniMax-M3"]
+        self.assertEqual(m3.context_window, 1_000_000)
+        self.assertEqual(m3.input_modalities, ["text", "image", "video"])
+        self.assertEqual(m3.thinking, ["adaptive", "disabled"])
+
+    def test_m27_capabilities(self):
+        m27 = MODELS["MiniMax-M2.7"]
+        self.assertEqual(m27.context_window, 204_800)
+        self.assertEqual(m27.input_modalities, ["text"])
+        self.assertEqual(m27.thinking, ["always_on"])
+
+
+class EndpointTests(unittest.TestCase):
+    def test_regions_cover_global_and_china(self):
+        self.assertEqual(set(REGIONS), {"global", "china"})
+
+    def test_chat_completions_urls(self):
+        self.assertEqual(
+            MiniMaxClient("k", region="global", protocol="chat_completions")._endpoint(),
+            "https://api.minimax.io/v1/chat/completions",
+        )
+        self.assertEqual(
+            MiniMaxClient("k", region="china", protocol="chat_completions")._endpoint(),
+            "https://api.minimaxi.com/v1/chat/completions",
+        )
+
+    def test_messages_urls(self):
+        self.assertEqual(
+            MiniMaxClient("k", region="global", protocol="messages")._endpoint(),
+            "https://api.minimax.io/anthropic/v1/messages",
+        )
+        self.assertEqual(
+            MiniMaxClient("k", region="china", protocol="messages")._endpoint(),
+            "https://api.minimaxi.com/anthropic/v1/messages",
+        )
+
+    def test_invalid_region_and_protocol(self):
+        with self.assertRaises(ValueError):
+            MiniMaxClient("k", region="mars")
+        with self.assertRaises(ValueError):
+            MiniMaxClient("k", protocol="carrier-pigeon")
+
+
+class RequestTests(unittest.TestCase):
+    def test_chat_completions_request_and_parse(self):
+        session = _fake_session(
+            {"choices": [{"message": {"content": "hello from M3"}}]}
+        )
+        client = MiniMaxClient("secret", protocol="chat_completions", session=session)
+        reply = client.complete("hi", model="MiniMax-M3")
+
+        self.assertEqual(reply, "hello from M3")
+        url = session.post.call_args.args[0]
+        kwargs = session.post.call_args.kwargs
+        self.assertEqual(url, "https://api.minimax.io/v1/chat/completions")
+        self.assertEqual(kwargs["headers"]["Authorization"], "Bearer secret")
+        self.assertNotIn("anthropic-version", kwargs["headers"])
+        self.assertEqual(kwargs["json"]["model"], "MiniMax-M3")
+        self.assertEqual(kwargs["json"]["messages"][-1]["content"], "hi")
+
+    def test_messages_request_and_parse(self):
+        session = _fake_session({"content": [{"text": "hello from "}, {"text": "M2.7"}]})
+        client = MiniMaxClient(
+            "secret", region="china", protocol="messages", session=session
+        )
+        reply = client.complete("hi", model="MiniMax-M2.7", system="be brief")
+
+        self.assertEqual(reply, "hello from M2.7")
+        kwargs = session.post.call_args.kwargs
+        self.assertEqual(
+            session.post.call_args.args[0],
+            "https://api.minimaxi.com/anthropic/v1/messages",
+        )
+        self.assertEqual(kwargs["headers"]["anthropic-version"], "2023-06-01")
+        self.assertEqual(kwargs["json"]["system"], "be brief")
+        self.assertEqual(kwargs["json"]["model"], "MiniMax-M2.7")
+
+    def test_image_input_builds_multimodal_content(self):
+        session = _fake_session({"choices": [{"message": {"content": "ok"}}]})
+        client = MiniMaxClient("secret", session=session)
+        client.complete("describe", image_url="https://example.com/a.png")
+
+        content = session.post.call_args.kwargs["json"]["messages"][-1]["content"]
+        self.assertEqual(content[0], {"type": "text", "text": "describe"})
+        self.assertEqual(
+            content[1],
+            {"type": "image_url", "image_url": {"url": "https://example.com/a.png"}},
+        )
+
+    def test_unknown_model_rejected(self):
+        client = MiniMaxClient("secret", session=_fake_session({}))
+        with self.assertRaises(ValueError):
+            client.complete("hi", model="MiniMax-M99")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Reason: The default branch has no MiniMax provider; this adds a complete MiniMax starter app covering both current models, both regional hosts, and both API surfaces.

## What this adds

A new self-contained starter app at `starter_ai_agents/minimax_ai_agent/` that integrates MiniMax as a provider:

- **Models** — `MiniMax-M3` (default, 1,000,000-token context, text/image/video input, `adaptive`/`disabled` thinking) and `MiniMax-M2.7` (204,800-token context, text input, `always_on` thinking).
- **Regions** — Global (`api.minimax.io`) and Mainland China (`api.minimaxi.com`).
- **API surfaces** — Chat Completions (`/v1/chat/completions`) and Messages (`/anthropic/v1/messages`); every region exposes both.
- **Multimodal input** — MiniMax-M3 accepts an optional image URL alongside the text prompt.

## Files

- `minimax_provider.py` — importable `MiniMaxClient` with the region/model/endpoint configuration.
- `minimax_ai_agent.py` — Streamlit UI to select model, region and API surface and chat.
- `test_minimax_provider.py` — offline unit tests (HTTP layer stubbed).
- `requirements.txt`, `README.md`, and a README index entry.

## Checks

- `python -m py_compile` on all modules — passes.
- `python -m unittest test_minimax_provider` — 12 tests pass, no network or API key required.
