### PR TITLE
Fix consultant tool schema, customer-support memory, and governance approval bypass

### DIFF
--- a/advanced_ai_agents/single_agent_apps/ai_agent_governance/ai_agent_governance.py
+++ b/advanced_ai_agents/single_agent_apps/ai_agent_governance/ai_agent_governance.py
@@ -242,12 +242,25 @@ class PolicyEngine:
     
     def evaluate(self, action: Action) -> PolicyResult:
         """Evaluate an action against all policy rules"""
+        allow_result = None
         for rule in self.rules:
             result = rule.evaluate(action)
-            if result and result.is_terminal:
-                self._log_audit(action, result)
-                return result
-        
+            if not result or not result.is_terminal:
+                continue
+            if result.decision == Decision.ALLOW:
+                # An allow is not final: a later rule may still deny the action
+                # or require approval for it. Remember the first allow but keep
+                # evaluating so deny/approval rules can override it.
+                if allow_result is None:
+                    allow_result = result
+                continue
+            self._log_audit(action, result)
+            return result
+
+        if allow_result is not None:
+            self._log_audit(action, allow_result)
+            return allow_result
+
         # Default allow if no rule blocks
         result = PolicyResult(
             decision=Decision.ALLOW,

--- a/advanced_ai_agents/single_agent_apps/ai_consultant_agent/ai_consultant_agent.py
+++ b/advanced_ai_agents/single_agent_apps/ai_consultant_agent/ai_consultant_agent.py
@@ -1,6 +1,7 @@
 import logging
 from typing import Dict, Any, List, Union
 from dataclasses import dataclass
+from functools import wraps
 import base64
 import requests
 import os
@@ -58,6 +59,7 @@ def safe_tool_wrapper(tool_func):
     Returns:
         Wrapped function that sanitizes output
     """
+    @wraps(tool_func)
     def wrapped_tool(*args, **kwargs):
         try:
             result = tool_func(*args, **kwargs)
@@ -69,10 +71,9 @@ def safe_tool_wrapper(tool_func):
                 "tool": tool_func.__name__,
                 "status": "error"
             }
-    
-    # Preserve function metadata
-    wrapped_tool.__name__ = tool_func.__name__
-    wrapped_tool.__doc__ = tool_func.__doc__
+
+    # @wraps copies __wrapped__ so ADK's inspect.signature() sees the real
+    # parameters (a bare *args/**kwargs wrapper is declared to Gemini with none).
     return wrapped_tool
 
 @dataclass

--- a/advanced_ai_agents/single_agent_apps/ai_customer_support_agent/customer_support_agent.py
+++ b/advanced_ai_agents/single_agent_apps/ai_customer_support_agent/customer_support_agent.py
@@ -26,6 +26,9 @@ if openai_api_key:
                         "port": 6333,
                     }
                 },
+                # mem0 defaults to v1.0, whose search()/get_all() return a bare
+                # list; the code below expects the v1.1 {"results": [...]} shape.
+                "version": "v1.1",
             }
             try:
                 self.memory = Memory.from_config(config)


### PR DESCRIPTION
Three independent single-agent apps, each with a functional bug. Disjoint files.

### 1. `ai_consultant_agent` — ADK tools declared to Gemini with zero parameters
`ai_consultant_agent/ai_consultant_agent.py` wraps each tool with `def wrapped_tool(*args, **kwargs)` and only copies `__name__`/`__doc__`. ADK builds the function declaration from `inspect.signature()`, which sees only `*args`/`**kwargs` (both skipped), so Gemini is told the tools take **no arguments** — every call returns `Tool execution failed: … missing 1 required positional argument`, and the advertised Perplexity web research never runs. → `@functools.wraps(tool_func)` sets `__wrapped__`, which `inspect.signature()` follows, restoring the real signature.

### 2. `ai_customer_support_agent` — memory is never read
`ai_customer_support_agent/customer_support_agent.py` builds the mem0 config without `version`. mem0 defaults to `v1.0`, whose `search()`/`get_all()` return a **bare list**, but the code does `if relevant_memories and "results" in relevant_memories` — an element-membership test on a list of dicts that is always False. So no past interaction is ever fed to the model (silently), and "View Memory Info" shows nothing. → add `"version": "v1.1"` (the `{"results": [...]}` shape the code expects).

### 3. `ai_agent_governance` — approval policy bypassed for allow-listed paths
`ai_agent_governance/ai_agent_governance.py` `PolicyEngine.evaluate` returns on the first `is_terminal` result. `FilesystemPolicy` returns an **ALLOW** with the default `is_terminal=True`, so for a path under an allowed directory it short-circuits before `ApprovalRequiredPolicy` — `delete_file` (listed under `require_approval_for` in the demo's own YAML) runs with **no approval**, logged as a clean ALLOW. → an explicit ALLOW no longer ends evaluation; a later deny/approval rule wins.

**Verification** (governance, against the demo's own policy YAML):
```
             before → after
delete_file  ALLOW  → REQUIRE_APPROVAL   ✅ fixed
execute_shell REQUIRE_APPROVAL → REQUIRE_APPROVAL  (unchanged)
read_file    ALLOW  → ALLOW              (legit allow preserved)
```
All three files compile-check clean.