### PR TITLE
Fix broken retrieval/setup in four RAG tutorials

### DIFF
--- a/rag_tutorials/agentic_rag_math_agent/rag/query_router.py
+++ b/rag_tutorials/agentic_rag_math_agent/rag/query_router.py
@@ -83,6 +83,12 @@ Only include valid math steps — do not guess or make up answers.
     return response.text
 
 
+# query_kb returns a cosine similarity (higher = better); with OpenAI embeddings
+# almost any two English texts score well above 0, so `> 0.` accepted every query
+# and served an arbitrary KB answer as authoritative. Require a real match.
+KB_SIMILARITY_THRESHOLD = 0.80
+
+
 def answer_math_question(question: str):
     print(f"🔍 Query: {question}")
 
@@ -96,7 +102,7 @@ def answer_math_question(question: str):
         kb_answer, similarity = query_kb(question)
         print("🧪 KB raw answer:", kb_answer)
 
-        if similarity > 0.:
+        if similarity >= KB_SIMILARITY_THRESHOLD:
             print("✅ High similarity KB match, using GPT for step-by-step explanation...")
 
             prompt = f"""

--- a/rag_tutorials/ai_blog_search/app.py
+++ b/rag_tutorials/ai_blog_search/app.py
@@ -1,6 +1,7 @@
 from langchain_google_genai import GoogleGenerativeAIEmbeddings
 from langchain_qdrant import QdrantVectorStore
 from qdrant_client import QdrantClient
+from qdrant_client.models import Distance, VectorParams
 from uuid import uuid4
 from langchain_community.document_loaders import WebBaseLoader
 from langchain_text_splitters import RecursiveCharacterTextSplitter
@@ -72,6 +73,15 @@ def initialize_components():
             st.session_state.qdrant_host,
             api_key=st.session_state.qdrant_api_key
         )
+
+        # QdrantVectorStore validates the collection on construction and raises a
+        # 404 if it doesn't exist, so create it up front on a fresh instance.
+        # 768 = dimension of models/embedding-001.
+        if not client.collection_exists("qdrant_db"):
+            client.create_collection(
+                collection_name="qdrant_db",
+                vectors_config=VectorParams(size=768, distance=Distance.COSINE),
+            )
 
         # Initialize vector store
         db = QdrantVectorStore(

--- a/rag_tutorials/corrective_rag/corrective_rag.py
+++ b/rag_tutorials/corrective_rag/corrective_rag.py
@@ -20,6 +20,7 @@ from qdrant_client import QdrantClient
 from qdrant_client.models import Distance, VectorParams
 import tempfile
 import os
+from urllib.parse import urlparse
 from langchain_anthropic import ChatAnthropic
 from tenacity import retry, stop_after_attempt, wait_exponential
 
@@ -155,8 +156,13 @@ def web_search(state):
 def load_documents(file_or_url: str, is_url: bool = True) -> list:
     try:
         if is_url:
-            loader = WebBaseLoader(file_or_url)
-            loader.requests_per_second = 1
+            # A .pdf URL must be parsed as a PDF; WebBaseLoader would run an HTML
+            # parser over the binary body and embed decoded garbage.
+            if urlparse(file_or_url).path.lower().endswith(".pdf"):
+                loader = PyPDFLoader(file_or_url)
+            else:
+                loader = WebBaseLoader(file_or_url)
+                loader.requests_per_second = 1
         else:
             file_extension = os.path.splitext(file_or_url)[1].lower()
             if file_extension == '.pdf':
@@ -190,7 +196,12 @@ else:
         # Clean up the temporary file
         os.unlink(tmp_file.name)
 
-if docs:
+# Streamlit re-runs this whole script on every widget interaction (e.g. asking a
+# question), so ingest only when the source actually changes — otherwise every
+# question would delete the collection and re-embed the entire document.
+source_key = url if input_option == "URL" else (uploaded_file.name if uploaded_file else None)
+
+if docs and st.session_state.get("ingested_source") != source_key:
     text_splitter = RecursiveCharacterTextSplitter.from_tiktoken_encoder(
         chunk_size=500, chunk_overlap=100
     )
@@ -203,7 +214,7 @@ if docs:
         # Try to delete the collection if it exists
         client.delete_collection(collection_name)
     except Exception:
-        pass  
+        pass
 
     client.create_collection(
         collection_name=collection_name,
@@ -220,6 +231,10 @@ if docs:
     # Add documents to the vectorstore
     vectorstore.add_documents(all_splits)
     retriever = vectorstore.as_retriever()
+    st.session_state.ingested_source = source_key
+    st.session_state.retriever = retriever
+elif st.session_state.get("retriever") is not None:
+    retriever = st.session_state.retriever
 
 
 class GraphState(TypedDict):

--- a/rag_tutorials/knowledge_graph_rag_citations/knowledge_graph_rag.py
+++ b/rag_tutorials/knowledge_graph_rag_citations/knowledge_graph_rag.py
@@ -144,13 +144,16 @@ class KnowledgeGraphManager:
     
     def semantic_search(self, query: str) -> List[Dict]:
         """Search for relevant entities based on query."""
+        # CONTAINS on the whole question can never match an entity name/description,
+        # so match any term (case-insensitively) instead of the full raw query.
+        terms = re.findall(r"[A-Za-z0-9]{3,}", query) or [query]
         with self.driver.session() as session:
             # Simple text matching (in production, use vector embeddings)
             result = session.run(
                 """
                 MATCH (e:Entity)
-                WHERE e.name CONTAINS $query 
-                   OR e.description CONTAINS $query
+                WHERE any(t IN $terms WHERE toLower(e.name) CONTAINS toLower(t)
+                                         OR toLower(e.description) CONTAINS toLower(t))
                 RETURN e.name as name,
                        e.description as description,
                        e.source_doc as source,
@@ -158,7 +161,7 @@ class KnowledgeGraphManager:
                        e.type as type
                 LIMIT 10
                 """,
-                query=query
+                terms=terms
             )
             return [dict(record) for record in result]
 


### PR DESCRIPTION
Four independent RAG apps under `rag_tutorials/`, each non-functional or serving wrong results. Disjoint files.

### 1. `corrective_rag` — default PDF URL parsed as HTML + full re-embed on every rerun
`corrective_rag/corrective_rag.py`. Two bugs:
- `load_documents(is_url=True)` always used `WebBaseLoader`, so the app's own default `https://arxiv.org/pdf/2307.09288.pdf` was run through an HTML parser and **decoded binary was embedded as the corpus**. → route `.pdf` URLs to `PyPDFLoader`.
- The ingest block (`delete_collection` → `create_collection` → `add_documents`) ran on **every Streamlit rerun** — i.e. every question re-downloaded the doc and re-embedded the whole corpus (and wiped any prior upload). → ingest only when the source key changes; cache the retriever in `session_state`.

### 2. `agentic_rag_math_agent` — KB gate accepts everything
`agentic_rag_math_agent/rag/query_router.py` gated on `if similarity > 0.`. `query_kb` returns a cosine similarity (OpenAI embeddings score ~any two English texts well above 0), so an **arbitrary** JEEBench Q/A was injected as "the correct answer … do not recalculate" for out-of-corpus questions. → require `>= 0.80` (low-similarity falls through to the web path, which already exists).

### 3. `knowledge_graph_rag_citations` — retrieval never matches
`knowledge_graph_rag_citations/knowledge_graph_rag.py` `semantic_search` did Neo4j `CONTAINS $query` on the **whole question**, which can't match any entity name/description, so the app always returned "couldn't find relevant information." → tokenize the query and match any term case-insensitively (mirrors the existing `find_related_entities` style).

### 4. `ai_blog_search` — collection never created
`ai_blog_search/app.py` constructs `QdrantVectorStore` (which validates the collection and 404s if absent) without ever creating `qdrant_db`, so init always fails on a fresh Qdrant. → `create_collection` (size 768, cosine) when it doesn't exist.

All four compile-check clean.