### PR TITLE
Fix beifong X-scraper name capture, engagement 500, and dropped sentiment queue

### DIFF
--- a/advanced_ai_agents/multi_agent_apps/ai_news_and_podcast_agents/beifong/services/social_media_service.py
+++ b/advanced_ai_agents/multi_agent_apps/ai_news_and_podcast_agents/beifong/services/social_media_service.py
@@ -566,6 +566,14 @@ class SocialMediaService:
             if not result:
                 return {"avg_engagement": 0, "total_posts": 0, "unique_authors": 0}
             result_dict = dict(result)
+            # AVG()/MAX() over zero matching rows return NULL (the inner COALESCE
+            # only guards per-row NULLs, not an empty set), while COUNT(*) is 0 —
+            # so the `if not result` guard above never fires and summing None would
+            # 500. Coalesce the aggregates to 0 for an empty range.
+            for _key in ("avg_replies", "avg_retweets", "avg_likes", "avg_bookmarks", "avg_views",
+                         "max_replies", "max_retweets", "max_likes", "max_bookmarks", "max_views"):
+                if result_dict.get(_key) is None:
+                    result_dict[_key] = 0
             result_dict["avg_engagement"] = (
                 result_dict["avg_replies"] + result_dict["avg_retweets"] + result_dict["avg_likes"] + result_dict["avg_bookmarks"]
             )

--- a/advanced_ai_agents/multi_agent_apps/ai_news_and_podcast_agents/beifong/tools/social/x_post_extractor.py
+++ b/advanced_ai_agents/multi_agent_apps/ai_news_and_podcast_agents/beifong/tools/social/x_post_extractor.py
@@ -34,13 +34,16 @@ def x_post_extractor(html_content):
     data["is_ad"] = check_ad(soup)
     user_element = soup.find("div", {"data-testid": "User-Name"})
     if user_element:
-        display_name_element = user_element.find(lambda tag: tag.name and (tag.name == "span" or tag.name == "div") and "Henrik" in tag.text)
+        # The display name is the first profile anchor without an "@" (the handle
+        # anchor carries the "@"). The name was previously hardcoded to "Henrik",
+        # so it was never captured for any other author.
+        display_name_element = user_element.find(lambda tag: tag.name == "a" and "@" not in tag.text and tag.get_text(strip=True))
         if display_name_element:
-            data["user_display_name"] = display_name_element.text.strip()
+            data["user_display_name"] = display_name_element.get_text(strip=True)
         username_element = user_element.find(lambda tag: tag.name == "a" and "@" in tag.text)
         if username_element:
             data["user_handle"] = username_element.text.strip()
-        profile_pic = soup.select_one("[data-testid='UserAvatar-Container-HenrikTaro'] img")
+        profile_pic = soup.select_one("[data-testid^='UserAvatar-Container-'] img")
         if profile_pic and profile_pic.has_attr("src"):
             data["user_profile_pic_url"] = profile_pic["src"]
 

--- a/advanced_ai_agents/multi_agent_apps/ai_news_and_podcast_agents/beifong/tools/social/x_scraper.py
+++ b/advanced_ai_agents/multi_agent_apps/ai_news_and_podcast_agents/beifong/tools/social/x_scraper.py
@@ -76,13 +76,16 @@ def crawl_x_profile(profile_url, db_file="x_posts.db"):
                     break
 
         except KeyboardInterrupt:
-            if analysis_queue:
-                try:
-                    analysis_results = analyze_posts_sentiment(analysis_queue)
-                    update_posts_with_analysis(conn, queue_post_ids, analysis_results)
-                except Exception:
-                    pass
+            pass
 
-            conn.close()
-            return post_count
+        # Flush any posts still queued (a partial final batch on a normal exit, or
+        # whatever was pending at a KeyboardInterrupt) so they are analyzed instead
+        # of being left with NULL sentiment/categories forever; also close the conn.
+        if analysis_queue:
+            try:
+                analysis_results = analyze_posts_sentiment(analysis_queue)
+                update_posts_with_analysis(conn, queue_post_ids, analysis_results)
+            except Exception:
+                pass
+        conn.close()
         return post_count


### PR DESCRIPTION
Three functional bugs in the beifong podcast app (`advanced_ai_agents/multi_agent_apps/ai_news_and_podcast_agents/beifong/`). Disjoint files.

### 1. X post extractor hardcodes the developer's name
`tools/social/x_post_extractor.py` matched the display name with a lambda requiring `"Henrik" in tag.text`, and the avatar with `data-testid='UserAvatar-Container-HenrikTaro'`. For every other author, `user_display_name`/`user_profile_pic_url` were never captured (persisted NULL), so `get_top_users`/`get_user_sentiment` and the UI show blank names/avatars and `social_media_search`'s name filter can't match. → generic selectors (first profile anchor without `@`; `UserAvatar-Container-` prefix).

### 2. `get_engagement_stats` → HTTP 500 on an empty date range
`services/social_media_service.py`. `AVG()`/`MAX()` over zero matching rows return NULL (the inner `COALESCE` only guards per-row NULLs, not an empty set) while `COUNT(*)` is 0, so the `if not result` guard never fires and `avg_replies + …` sums `None` → `TypeError` → 500. Hit by the dashboard's default range on a fresh install. → coalesce the aggregate fields to 0.

### 3. X scraper drops its final sentiment batch on a normal exit
`tools/social/x_scraper.py`. The pending analysis queue was flushed **only** in the `except KeyboardInterrupt` branch, so a partial final batch (1–4 posts when the count isn't a multiple of `batch_size`) on a normal exit was never analyzed — those rows stay with NULL `sentiment`/`categories` forever (no re-analysis pass exists) and are invisible to search; the connection also leaked. → flush after the loop on every exit path (matching the sibling `fb_scraper`).

All three compile-check clean.