### PR TITLE
Fix trust-layer privilege escalation, deep-research report button, artifact versioning

### DIFF
--- a/advanced_ai_agents/multi_agent_apps/agent_teams/multimodal_uiux_feedback_agent_team/tools.py
+++ b/advanced_ai_agents/multi_agent_apps/agent_teams/multimodal_uiux_feedback_agent_team/tools.py
@@ -179,7 +179,10 @@ Make the improvements look natural and professional.
                 
                 try:
                     # Save the edited image as an artifact
-                    version = await tool_context.save_artifact(
+                    # Do NOT rebind `version` from save_artifact()'s return value:
+                    # that is ADK's per-filename artifact revision, not our asset
+                    # version counter (already set by get_next_version_number above).
+                    await tool_context.save_artifact(
                         filename=edited_artifact_filename, 
                         artifact=edited_image_part
                     )
@@ -321,7 +324,10 @@ Create a professional UI/UX design that would be magazine-quality.
                 image_part = types.Part(inline_data=inline_data)
                 
                 try:
-                    version = await tool_context.save_artifact(
+                    # Do NOT rebind `version` from save_artifact()'s return value:
+                    # that is ADK's per-filename artifact revision, not our asset
+                    # version counter (already set by get_next_version_number above).
+                    await tool_context.save_artifact(
                         filename=artifact_filename, 
                         artifact=image_part
                     )

--- a/advanced_ai_agents/multi_agent_apps/ai_domain_deep_research_agent/ai_domain_deep_research_agent.py
+++ b/advanced_ai_agents/multi_agent_apps/ai_domain_deep_research_agent/ai_domain_deep_research_agent.py
@@ -215,18 +215,22 @@ if together_api_key and composio_api_key:
         
         # Store the answers
         st.session_state.question_answers = question_answers
-        
-        # Compile report button
-        if st.button("Compile Final Report", key="compile_report"):
-            report_content = compile_report(llm, composio_tools, topic, domain, question_answers)
-            
-            # Display the report content
-            st.header("Final Report")
-            st.success("Your report has been compiled and a Google Doc has been created.")
-            
-            # Show the full report content
-            with st.expander("View Full Report Content", expanded=True):
-                st.markdown(report_content)
+
+    # Compile report button — must live OUTSIDE the "Start Research" block. Clicking
+    # it reruns the script, at which point "Start Research" is False and a nested
+    # button would never be rendered (so it could never fire).
+    if st.session_state.question_answers and st.button("Compile Final Report", key="compile_report"):
+        report_content = compile_report(
+            llm, composio_tools, topic, domain, st.session_state.question_answers
+        )
+
+        # Display the report content
+        st.header("Final Report")
+        st.success("Your report has been compiled and a Google Doc has been created.")
+
+        # Show the full report content
+        with st.expander("View Full Report Content", expanded=True):
+            st.markdown(report_content)
     
     # Display previous results if available
     if len(st.session_state.question_answers) > 0 and not st.session_state.research_complete:

--- a/advanced_ai_agents/multi_agent_apps/ai_home_renovation_agent/tools.py
+++ b/advanced_ai_agents/multi_agent_apps/ai_home_renovation_agent/tools.py
@@ -264,8 +264,10 @@ async def generate_renovation_rendering(tool_context: ToolContext, inputs: Gener
                 image_part = types.Part(inline_data=inline_data)
                 
                 try:
-                    # Save the image as an artifact
-                    version = await tool_context.save_artifact(
+                    # Save the image as an artifact. Do NOT rebind `version` from
+                    # the return value: that is ADK's per-filename artifact revision,
+                    # not our asset version counter (already set by get_next_version_number).
+                    await tool_context.save_artifact(
                         filename=artifact_filename, 
                         artifact=image_part
                     )
@@ -449,9 +451,11 @@ async def edit_renovation_rendering(tool_context: ToolContext, inputs: EditRenov
                 edited_image_part = types.Part(inline_data=inline_data)
                 
                 try:
-                    # Save the edited image as an artifact
-                    version = await tool_context.save_artifact(
-                        filename=edited_artifact_filename, 
+                    # Save the edited image as an artifact. Do NOT rebind `version`
+                    # from the return value (ADK's per-filename revision); keep the
+                    # asset version from get_next_version_number above.
+                    await tool_context.save_artifact(
+                        filename=edited_artifact_filename,
                         artifact=edited_image_part
                     )
                     

--- a/advanced_ai_agents/multi_agent_apps/multi_agent_trust_layer/multi_agent_trust_layer.py
+++ b/advanced_ai_agents/multi_agent_apps/multi_agent_trust_layer/multi_agent_trust_layer.py
@@ -99,7 +99,7 @@ class TrustScore:
 @dataclass
 class DelegationScope:
     """Defines what an agent can do under a delegation"""
-    allowed_actions: Set[str]
+    allowed_actions: Optional[Set[str]] = None  # None means "every action allowed"
     denied_actions: Set[str] = field(default_factory=set)
     allowed_domains: Set[str] = field(default_factory=set)
     max_tokens: int = 10000
@@ -111,14 +111,23 @@ class DelegationScope:
         """Check if an action is allowed under this scope"""
         if action in self.denied_actions:
             return False
-        if not self.allowed_actions:  # Empty means all allowed
+        if self.allowed_actions is None:  # None means all allowed
             return True
         return action in self.allowed_actions
-    
+
     def narrow(self, child_scope: "DelegationScope") -> "DelegationScope":
         """Create a narrowed scope for sub-delegation"""
+        # None ("all") on either side is the identity for intersection; only a
+        # real set ∩ real set narrows. Previously an empty intersection collapsed
+        # to an empty set, which allows_action() then read as "all allowed".
+        if self.allowed_actions is None:
+            narrowed_actions = child_scope.allowed_actions
+        elif child_scope.allowed_actions is None:
+            narrowed_actions = self.allowed_actions
+        else:
+            narrowed_actions = self.allowed_actions & child_scope.allowed_actions
         return DelegationScope(
-            allowed_actions=self.allowed_actions & child_scope.allowed_actions,
+            allowed_actions=narrowed_actions,
             denied_actions=self.denied_actions | child_scope.denied_actions,
             allowed_domains=self.allowed_domains & child_scope.allowed_domains if self.allowed_domains else child_scope.allowed_domains,
             max_tokens=min(self.max_tokens, child_scope.max_tokens),
@@ -482,7 +491,9 @@ class TrustLayer:
         """Create a delegation from one agent to another"""
         
         delegation_scope = DelegationScope(
-            allowed_actions=set(scope.get("allowed_actions", [])),
+            # An empty/absent allowed_actions means "anything not explicitly denied"
+            # (see the demo policies), which the None sentinel now represents.
+            allowed_actions=set(scope["allowed_actions"]) if scope.get("allowed_actions") else None,
             denied_actions=set(scope.get("denied_actions", [])),
             allowed_domains=set(scope.get("allowed_domains", [])),
             max_tokens=scope.get("max_tokens", 10000),


### PR DESCRIPTION
Three independent apps under `advanced_ai_agents/multi_agent_apps/`. Disjoint files.

### 1. `multi_agent_trust_layer` — sub-delegation can escalate to *unrestricted*
`DelegationScope.allows_action` treats an **empty** `allowed_actions` set as "all allowed", and `narrow()` computes `self.allowed_actions & child_scope.allowed_actions`. So a sub-delegation whose requested scope doesn't overlap the parent's collapses to an empty set — and is then read as permitting **everything**, the opposite of narrowing. → use `None` as the explicit "all allowed" sentinel; a real∩real intersection (possibly empty) now means exactly those actions.
```
parent{web_search,summarize}.narrow(child{read_document}).allows_action('delete_file')
  before: True   (escalation)   after: False
```

### 2. `ai_domain_deep_research_agent` — final report is unreachable
`ai_domain_deep_research_agent.py`: the "Compile Final Report" button is nested **inside** the `if st.button('Start Research')` block. `st.button` is only True on the rerun right after its own click, so clicking Compile reruns with Start Research False and the nested button is never even rendered — it can never fire. → hoist it out of the block, gate on `st.session_state.question_answers`.

### 3. `ai_home_renovation_agent` + `multimodal_uiux_feedback_agent_team` — renders overwrite each other
`tools.py` computes an asset version via `get_next_version_number`, then **rebinds** `version` to `await tool_context.save_artifact(...)`'s return — which is ADK's per-filename artifact revision, not the asset counter. Since each generation targets a fresh filename, that return is a constant, so the counter never advances and repeated renders for one asset collide on the same filename. → don't rebind `version`; keep the value from `get_next_version_number`.

All four files compile-check clean.