### PR TITLE
Fix six starter/advanced_llm Python apps that crash on startup or corrupt data

### DIFF
--- a/advanced_llm_apps/chat_with_X_tutorials/chat_with_research_papers/chat_arxiv_llama3.py
+++ b/advanced_llm_apps/chat_with_X_tutorials/chat_with_research_papers/chat_arxiv_llama3.py
@@ -11,7 +11,7 @@ st.caption("This app allows you to chat with arXiv research papers using Llama-3
 # Create an instance of the Assistant
 assistant = Agent(
 model=Ollama(
-    id="llama3.1:8b") , tools=[ArxivTools()], show_tool_calls=True
+    id="llama3.1:8b") , tools=[ArxivTools()]
 )
 
 # Get the search query from the user

--- a/advanced_llm_apps/cursor_ai_experiments/multi_agent_researcher.py
+++ b/advanced_llm_apps/cursor_ai_experiments/multi_agent_researcher.py
@@ -82,7 +82,7 @@ def create_article_crew(topic):
     crew = Crew(
         agents=[researcher, writer, editor],
         tasks=[research_task, writing_task, editing_task],
-        verbose=2,
+        verbose=True,
         process=Process.sequential
     )
 

--- a/advanced_llm_apps/llm_optimization_tools/toonify_token_optimization/toonify_app.py
+++ b/advanced_llm_apps/llm_optimization_tools/toonify_token_optimization/toonify_app.py
@@ -12,7 +12,12 @@ import pandas as pd
 
 def count_tokens(text: str, model: str = "gpt-4") -> int:
     """Count tokens in text."""
-    encoding = tiktoken.encoding_for_model(model)
+    try:
+        encoding = tiktoken.encoding_for_model(model)
+    except KeyError:
+        # tiktoken can't map non-OpenAI model names (e.g. claude-3-*); fall back
+        # to the modern OpenAI encoding so the token count still renders.
+        encoding = tiktoken.get_encoding("cl100k_base")
     return len(encoding.encode(text))
 
 

--- a/advanced_llm_apps/llm_optimization_tools/toonify_token_optimization/toonify_demo.py
+++ b/advanced_llm_apps/llm_optimization_tools/toonify_token_optimization/toonify_demo.py
@@ -13,7 +13,11 @@ import os
 
 def count_tokens(text: str, model: str = "gpt-4") -> int:
     """Count the number of tokens in a text string."""
-    encoding = tiktoken.encoding_for_model(model)
+    try:
+        encoding = tiktoken.encoding_for_model(model)
+    except KeyError:
+        # tiktoken can't map non-OpenAI model names (e.g. claude-3-*); fall back.
+        encoding = tiktoken.get_encoding("cl100k_base")
     return len(encoding.encode(text))
 
 

--- a/starter_ai_agents/ai_data_analysis_agent/ai_data_analyst.py
+++ b/starter_ai_agents/ai_data_analysis_agent/ai_data_analyst.py
@@ -19,10 +19,6 @@ def preprocess_and_save(file):
             st.error("Unsupported file format. Please upload a CSV or Excel file.")
             return None, None, None
         
-        # Ensure string columns are properly quoted
-        for col in df.select_dtypes(include=['object']):
-            df[col] = df[col].astype(str).replace({r'"': '""'}, regex=True)
-        
         # Parse dates and numeric columns
         for col in df.columns:
             if 'date' in col.lower():

--- a/starter_ai_agents/ai_data_visualisation_agent/ai_data_visualisation_agent.py
+++ b/starter_ai_agents/ai_data_visualisation_agent/ai_data_visualisation_agent.py
@@ -80,6 +80,10 @@ def upload_dataset(code_interpreter: Sandbox, uploaded_file) -> str:
     dataset_path = f"./{uploaded_file.name}"
     
     try:
+        # The Streamlit upload was already read to EOF by pd.read_csv earlier in
+        # the run, so rewind before uploading — otherwise a 0-byte file reaches the
+        # sandbox and every analysis reads an empty dataset.
+        uploaded_file.seek(0)
         code_interpreter.files.write(dataset_path, uploaded_file)
         return dataset_path
     except Exception as error:

--- a/starter_ai_agents/ai_music_generator_agent/music_generator_agent.py
+++ b/starter_ai_agents/ai_music_generator_agent/music_generator_agent.py
@@ -24,7 +24,6 @@ if openai_api_key and models_lab_api_key:
         name="ModelsLab Music Agent",
         agent_id="ml_music_agent",
         model=OpenAIChat(id="gpt-4o", api_key=openai_api_key),
-        show_tool_calls=True,
         tools=[ModelsLabTools(api_key=models_lab_api_key, wait_for_completion=True, file_type=FileType.MP3)],
         description="You are an AI agent that can generate music using the ModelsLabs API.",
         instructions=[


### PR DESCRIPTION
Six independent apps, disjoint files.

### 1–2. `Agent(show_tool_calls=True)` removed in agno 2.x → crash on startup
- `starter_ai_agents/ai_music_generator_agent/music_generator_agent.py` (`agno>=2.2.10`)
- `advanced_llm_apps/chat_with_X_tutorials/chat_with_research_papers/chat_arxiv_llama3.py` (bare `agno` → 2.x; the `Agent(...)` is at module top level, so it fails at import)

agno 2.x's `Agent.__init__` has no `show_tool_calls` and no `**kwargs` → `TypeError`. The sibling `chat_arxiv.py` already omits it. → drop the kwarg.

### 3. `multi_agent_researcher.py` — `Crew(verbose=2)` fails pydantic bool validation
`advanced_llm_apps/cursor_ai_experiments/multi_agent_researcher.py`. Current CrewAI's `Crew.verbose` is a strict `bool`; pydantic v2 rejects `2` (`bool_parsing`), so the crew never builds and no article is produced. → `verbose=True`.

### 4. `toonify_app.py` / `toonify_demo.py` — tiktoken crash on Claude models
`advanced_llm_apps/llm_optimization_tools/toonify_token_optimization/`. `tiktoken.encoding_for_model(model)` raises `KeyError` for the `claude-3-opus`/`claude-3-sonnet` options the sidebar offers, and tab1 calls it unguarded → the tab crashes. → `try/except KeyError → get_encoding("cl100k_base")`.

### 5. `ai_data_visualisation_agent.py` — empty CSV reaches the sandbox
`starter_ai_agents/ai_data_visualisation_agent/`. `upload_dataset` writes the Streamlit `UploadedFile` to the sandbox **after** `pd.read_csv(uploaded_file)` already consumed it to EOF, so 0 bytes are uploaded and every analysis reads an empty dataset. → `uploaded_file.seek(0)` before `files.write`.

### 6. `ai_data_analyst.py` — double-escaped quotes corrupt string cells
`starter_ai_agents/ai_data_analysis_agent/`. It manually replaces `"`→`""` **and** writes with `csv.QUOTE_ALL` (which already doubles quotes), so `He said "hi"` is stored/read back as `He said ""hi""`. → drop the manual replacement (QUOTE_ALL suffices). Verified round-trip: value now preserved exactly.

All seven files compile-check clean.