### PR TITLE
Fix three frontend bugs: children counter, cross-video seek race, poll-interval leak

### DIFF
--- a/advanced_ai_agents/multi_agent_apps/agent_teams/ai_travel_planner_agent_team/client/app/plan/page.tsx
+++ b/advanced_ai_agents/multi_agent_apps/agent_teams/ai_travel_planner_agent_team/client/app/plan/page.tsx
@@ -958,7 +958,7 @@ export default function Plan() {
                               <NumberInput
                                 value={field.value}
                                 onChange={field.onChange}
-                                min={1}
+                                min={0}
                               />
                             </FormControl>
                             <FormMessage />

--- a/advanced_ai_agents/multi_agent_apps/ai_negotiation_battle_simulator/frontend/src/app/page.tsx
+++ b/advanced_ai_agents/multi_agent_apps/ai_negotiation_battle_simulator/frontend/src/app/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
 import { useCoAgent, useCopilotAction } from "@copilotkit/react-core";
 import { motion, AnimatePresence } from "framer-motion";
 import {
@@ -362,10 +362,19 @@ export default function NegotiationBattle() {
     }
   };
 
+  const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  // Stop polling on unmount so we don't fetch/setState on an unmounted component
+  // or keep polling forever when a run never reaches deal/no_deal.
+  useEffect(() => () => {
+    if (pollRef.current) clearInterval(pollRef.current);
+  }, []);
+
   const runNegotiation = async () => {
     // This will be handled by the agent automatically
     // Just need to poll for state updates
-    const pollInterval = setInterval(async () => {
+    if (pollRef.current) clearInterval(pollRef.current);
+    pollRef.current = setInterval(async () => {
       try {
         const stateRes = await fetch('http://localhost:8000/get_negotiation_state');
         const stateData = await stateRes.json();
@@ -385,7 +394,7 @@ export default function NegotiationBattle() {
         });
 
         if (stateData.status === "deal" || stateData.status === "no_deal") {
-          clearInterval(pollInterval);
+          if (pollRef.current) clearInterval(pollRef.current);
         }
       } catch (error) {
         console.error('Error polling state:', error);

--- a/advanced_llm_apps/multimodal_video_moment_finder/frontend/app/page.tsx
+++ b/advanced_llm_apps/multimodal_video_moment_finder/frontend/app/page.tsx
@@ -160,13 +160,21 @@ export default function Home() {
 
   const jumpToMoment = (moment: Moment) => {
     setVideoTimestamp(moment.timestamp);
+    const switchingVideo = moment.video_id !== selectedVideo;
     setSelectedVideo(moment.video_id);
-    setTimeout(() => {
+    const seek = () => {
       if (videoRef.current) {
         videoRef.current.currentTime = moment.timestamp;
         videoRef.current.play();
       }
-    }, 100);
+    };
+    if (switchingVideo && videoRef.current) {
+      // The <video src> changes on the re-render triggered above; a fixed 100ms
+      // timeout races that reload, so seek only once the new file has loaded.
+      videoRef.current.addEventListener("loadeddata", seek, { once: true });
+    } else {
+      setTimeout(seek, 100);
+    }
   };
 
   // Drag and drop


### PR DESCRIPTION
Three independent React/Next frontends, disjoint files.

### 1. `ai_travel_planner_agent_team` client — children counter can't return to 0
`client/app/plan/page.tsx`: the "Number of children" `NumberInput` has `min={1}`, but the form's default is `children: 0`. `decrement` is a no-op and the `-` button is disabled at `value <= min`, so once children is incremented it can never go back to 0 — a no-children traveler who mis-clicks submits `children: 1`. → `min={0}` (adults/rooms correctly stay `min={1}`).

### 2. `multimodal_video_moment_finder` — cross-video jump plays from 0
`frontend/app/page.tsx`: `jumpToMoment` sets `currentTime` and `play()` after a fixed `setTimeout(..., 100)`. When the clicked result is in a different video, `setSelectedVideo` changes the `<video src>` and forces a reload, so 100ms later the new file usually isn't seekable yet — the seek is clamped and playback starts at 0. → when switching videos, seek on the new file's `loadeddata` event (`{ once: true }`) instead of a fixed delay.

### 3. `ai_negotiation_battle_simulator` — poll interval leaks / never stops
`frontend/src/app/page.tsx`: `runNegotiation` creates a `setInterval` in a local variable, cleared only when a poll observes a terminal status and with no `useEffect` cleanup. On unmount it keeps `fetch`+`setState` firing, and if the backend never reaches `deal`/`no_deal` it polls forever. → own the handle in a `useRef` and clear it on unmount (and on re-run).

Small, self-contained UI fixes.