### PR TITLE
Add ADK career coach agent with persistent memory

### DIFF
--- a/advanced_llm_apps/llm_apps_with_memory_tutorials/adk_career_coach_agent_memory/README.md
+++ b/advanced_llm_apps/llm_apps_with_memory_tutorials/adk_career_coach_agent_memory/README.md
@@ -1,0 +1,69 @@
+## 🎯 AI Career Coach with Memory (ADK Multi-Agent)
+This Streamlit app implements a multi-agent career coaching assistant built with Google's Agent Development Kit (ADK). A **career orchestrator agent** delegates each question to the right **specialist sub-agent** (resume, interview practice, skills/learning roadmap, or salary), while **Mem0 + Qdrant** remember each candidate's career history across sessions.
+
+The point isn't just routing between specialists — it's that the advice actually changes the longer you use it. Ask "what should I focus on?" in your first session and you get generic advice. Ask the same thing two months later, and the app already knows your target roles, your tech stack, and which interview topics you've struggled with, so the answer is specific to you instead of generic.
+
+### Features
+- Root `career_orchestrator` (Google ADK `LlmAgent`) that automatically delegates to `resume_agent`, `interview_agent`, `skills_roadmap_agent`, or `salary_agent` sub-agents based on the question
+- Each specialist has its own focused tool (`get_candidate_resume`, `get_practice_question`, `get_learning_resource`, `get_salary_benchmark`) backed by mock data — swap these for real integrations (a real resume/profile store, a real interview question bank, a course catalog, Levels.fyi/Glassdoor-style salary data)
+- Mem0 + Qdrant recall relevant past context for the current candidate before the orchestrator routes the message — years of experience, target roles, tech stack, past interview weak spots, and more, depending on what's come up in prior conversations
+- Every exchange is written back to Mem0 so the next session (even with a brand-new ADK session) starts with full context
+- Sidebar "View my memory" to inspect what's been remembered for a given candidate email
+- Runs on a **single Google API key** — no Docker, no Qdrant server, no OpenAI key. Mem0 is configured to use Gemini for both its internal LLM (fact extraction) and its embeddings, and Qdrant runs in embedded on-disk mode (`./qdrant_storage/`), not as a separate service.
+
+### How it works
+1. Candidate sends a message.
+2. The app queries Mem0 for memories relevant to that message, for that `user_id`.
+3. The message plus the retrieved memory context is handed to the ADK `career_orchestrator`.
+4. The orchestrator's LLM decides which specialist sub-agent should handle it (resume, interview, skills, or salary) and transfers control.
+5. The specialist calls its tool if needed and replies — using the candidate's known profile info (e.g. target role, weak interview areas) when the message itself doesn't spell it out.
+6. The candidate's message and the final answer are both written back into Mem0.
+
+### How to get Started?
+
+1. Clone the GitHub repository
+```bash
+git clone https://github.com/Shubhamsaboo/awesome-llm-apps.git
+cd awesome-llm-apps/advanced_llm_apps/llm_apps_with_memory_tutorials/adk_career_coach_agent_memory
+```
+
+2. Install the required dependencies:
+```bash
+pip install -r requirements.txt
+```
+
+3. Get a Google API key for Gemini from [Google AI Studio](https://aistudio.google.com/apikey) — you'll paste it into the app's UI at runtime. That's the only credential this app needs.
+
+4. Run the Streamlit App
+```bash
+streamlit run adk_career_coach_agent_memory.py
+```
+
+The first run creates a `qdrant_storage/` folder next to the script — that's Mem0's embedded, on-disk vector store. Delete it if you want to wipe all remembered candidate history.
+
+### Try it out
+- *"Can you review my resume for a backend engineer role?"* (as `demo@example.com`) → routes to `resume_agent`, which calls `get_candidate_resume` to fetch the resume on file, then gives feedback tailored to that candidate's actual experience level and skills rather than generic advice.
+- *"I have an Amazon system design interview coming up, can we practice?"* → routes to `interview_agent`, pulls a sample question via `get_practice_question`.
+- *"I keep failing system design rounds, what should I study?"* → routes to `skills_roadmap_agent`.
+- *"What should I expect for a backend engineer role in Seattle?"* → routes to `salary_agent`.
+- Ask something open-ended like *"what should I focus on?"* after a few of the above, in a new session — the answer should reference your specific target role and weak areas instead of giving generic advice.
+
+### Using a real Qdrant server instead
+The embedded mode above is the default because it needs nothing beyond the one API key. If you'd rather point at a real Qdrant instance (shared across machines, or just persistent/inspectable via Qdrant's dashboard), swap the `vector_store` block in `MEM0_CONFIG` for:
+```python
+"vector_store": {
+    "provider": "qdrant",
+    "config": {
+        "collection_name": "adk_career_coach",
+        "host": "localhost",  # or use "url"/"api_key" for Qdrant Cloud
+        "port": 6333,
+        "embedding_model_dims": 768,
+    },
+},
+```
+and start a server first, either via Docker (`docker run -p 6333:6333 -p 6334:6334 -v $(pwd)/qdrant_storage:/qdrant/storage:z qdrant/qdrant`) or the standalone Windows `qdrant.exe` binary from the [Qdrant releases page](https://github.com/qdrant/qdrant/releases).
+
+### Notes / next steps
+- This is a sketch: `MOCK_RESUMES`, `MOCK_INTERVIEW_QUESTIONS`, `MOCK_LEARNING_RESOURCES`, and `MOCK_SALARY_DATA` are stand-ins for real data sources (a real resume/profile store, a real question bank, a course catalog, a salary data provider).
+- `google-adk`'s API is young and moves fast — if something doesn't match your installed version, check the [ADK docs](https://google.github.io/adk-docs/) for the current `LlmAgent` / `Runner` / `sub_agents` signatures.
+- Natural extensions: add a "Negotiation Agent" for when an offer is actually on the table, an application tracker (which companies, which stage), or split `interview_agent` into separate behavioral and system-design specialists.

--- a/advanced_llm_apps/llm_apps_with_memory_tutorials/adk_career_coach_agent_memory/adk_career_coach_agent_memory.py
+++ b/advanced_llm_apps/llm_apps_with_memory_tutorials/adk_career_coach_agent_memory/adk_career_coach_agent_memory.py
@@ -300,8 +300,12 @@ if google_api_key:
         st.session_state.messages.append({"role": "assistant", "content": answer})
 
         # Write this exchange back to long-term memory for future sessions.
+        # Only the candidate's own message goes in: one memory.add() call
+        # instead of two (half the extraction latency/cost, since infer=True
+        # runs an LLM call per add()), and the fact store stays candidate
+        # facts only -- the coach's own advice text never gets treated as a
+        # fact about the candidate.
         memory.add(prompt, user_id=user_id, metadata={"role": "user"})
-        memory.add(answer, user_id=user_id, metadata={"role": "assistant"})
     elif not user_id:
         st.error("Please enter your email to start chatting.")
 else:

--- a/advanced_llm_apps/llm_apps_with_memory_tutorials/adk_career_coach_agent_memory/adk_career_coach_agent_memory.py
+++ b/advanced_llm_apps/llm_apps_with_memory_tutorials/adk_career_coach_agent_memory/adk_career_coach_agent_memory.py
@@ -1,0 +1,308 @@
+import asyncio
+import os
+
+import streamlit as st
+from google.adk.agents import LlmAgent
+from google.adk.runners import Runner
+from google.adk.sessions import InMemorySessionService
+from google.genai import types
+from mem0 import Memory
+
+APP_NAME = "adk_career_coach"
+MODEL = "gemini-2.5-flash"
+
+# Mem0 config: Gemini for both the LLM (fact extraction) and the embedder,
+# plus an on-disk Qdrant collection -- no Docker/Qdrant server, no OpenAI
+# key. Both "llm" and "embedder" read GOOGLE_API_KEY from the environment
+# once it's set below. Gemini's embedding model outputs 768-dim vectors, so
+# embedder.embedding_dims and vector_store.embedding_model_dims must match.
+MEM0_CONFIG = {
+    "llm": {
+        "provider": "gemini",
+        "config": {"model": MODEL, "temperature": 0.2},
+    },
+    "embedder": {
+        "provider": "gemini",
+        "config": {"model": "models/gemini-embedding-001", "embedding_dims": 768},
+    },
+    "vector_store": {
+        "provider": "qdrant",
+        "config": {
+            "collection_name": "adk_career_coach",
+            "path": "./qdrant_storage",
+            "embedding_model_dims": 768,
+            "on_disk": True,
+        },
+    },
+}
+
+# --- Mock backend data the tools read from. Swap for real data sources later. ---
+MOCK_INTERVIEW_QUESTIONS = {
+    "amazon": {
+        "behavioral": "Tell me about a time you had to disagree with a decision your manager made.",
+        "system_design": "Design a URL shortener that can handle millions of requests per day.",
+    },
+    "google": {
+        "behavioral": "Describe a project where the requirements changed halfway through.",
+        "system_design": "Design a rate limiter for a public API.",
+    },
+}
+
+MOCK_LEARNING_RESOURCES = {
+    "distributed systems": {
+        "resource": "Designing Data-Intensive Applications (Martin Kleppmann)",
+        "next_step": "Start with the chapters on replication and partitioning, then practice explaining trade-offs out loud.",
+    },
+    "system design": {
+        "resource": "ByteByteGo System Design Interview series",
+        "next_step": "Work through one design problem per week and write out the trade-offs, not just the final diagram.",
+    },
+    "python": {
+        "resource": "Fluent Python (Luciano Ramalho)",
+        "next_step": "Focus on the chapters covering iterators, generators, and decorators.",
+    },
+}
+
+MOCK_SALARY_DATA = {
+    ("backend engineer", "seattle"): {"low": 140000, "high": 190000, "median": 165000},
+    ("backend engineer", "remote"): {"low": 130000, "high": 175000, "median": 152000},
+    ("senior backend engineer", "seattle"): {"low": 175000, "high": 230000, "median": 200000},
+}
+
+MOCK_RESUMES = {
+    "demo@example.com": {
+        "years_experience": 4,
+        "current_role": "Backend Engineer",
+        "skills": ["Python", "PostgreSQL", "REST APIs", "Docker"],
+        "bullet_points": [
+            "Worked on the payments team maintaining backend services.",
+            "Helped onboard new engineers to the codebase.",
+        ],
+    },
+}
+
+
+def get_candidate_resume(candidate_email: str) -> dict:
+    """Fetches the resume on file for a candidate (experience, current role, skills, bullet points)."""
+    resume = MOCK_RESUMES.get(candidate_email.strip().lower())
+    if resume:
+        return {"status": "success", "candidate_email": candidate_email, "resume": resume}
+    return {"status": "error", "message": f"No resume on file for {candidate_email}."}
+
+
+def get_practice_question(company: str, interview_type: str) -> dict:
+    """Returns a sample interview question for a given company and interview type (behavioral or system_design)."""
+    company_key = company.strip().lower()
+    type_key = interview_type.strip().lower().replace(" ", "_")
+    question = MOCK_INTERVIEW_QUESTIONS.get(company_key, {}).get(type_key)
+    if question:
+        return {"status": "success", "company": company, "interview_type": interview_type, "question": question}
+    return {"status": "error", "message": f"No sample questions on file for {company} ({interview_type})."}
+
+
+def get_learning_resource(skill: str) -> dict:
+    """Returns a suggested learning resource and next step for a given skill."""
+    resource = MOCK_LEARNING_RESOURCES.get(skill.strip().lower())
+    if resource:
+        return {"status": "success", "skill": skill, **resource}
+    return {"status": "error", "message": f"No learning resource on file for '{skill}'."}
+
+
+def get_salary_benchmark(role: str, location: str) -> dict:
+    """Returns a rough salary range for a given role and location."""
+    data = MOCK_SALARY_DATA.get((role.strip().lower(), location.strip().lower()))
+    if data:
+        return {"status": "success", "role": role, "location": location, **data}
+    return {"status": "error", "message": f"No salary data on file for {role} in {location}."}
+
+
+def build_career_orchestrator() -> LlmAgent:
+    """Root agent + 4 specialists. ADK routes to a sub-agent based on its description."""
+    resume_agent = LlmAgent(
+        name="resume_agent",
+        model=MODEL,
+        description="Reviews a candidate's resume and gives feedback tailored to a target role.",
+        instruction=(
+            "You help candidates improve their resume. Use the get_candidate_resume tool, "
+            "passing the 'Candidate email' given in the message context, to fetch their resume "
+            "on file. Then give specific, tailored suggestions based on their years of "
+            "experience, current role, and skills versus the target role -- don't just restate "
+            "the resume back to them. If the candidate also pastes a specific bullet point or "
+            "section they're drafting, give feedback on that text directly, using the fetched "
+            "resume as context for consistency and experience level."
+        ),
+        tools=[get_candidate_resume],
+    )
+
+    interview_agent = LlmAgent(
+        name="interview_agent",
+        model=MODEL,
+        description="Runs mock interview practice and gives feedback for a specific company and interview type.",
+        instruction=(
+            "You help candidates prepare for interviews. Use the get_practice_question tool, "
+            "passing the company and interview type (behavioral or system_design). If either "
+            "isn't stated, use the target companies/weak areas noted in the candidate's "
+            "profile info, or ask a quick clarifying question."
+        ),
+        tools=[get_practice_question],
+    )
+
+    skills_roadmap_agent = LlmAgent(
+        name="skills_roadmap_agent",
+        model=MODEL,
+        description="Identifies skill gaps and suggests what to learn next.",
+        instruction=(
+            "You help candidates close skill gaps. Use the get_learning_resource tool for "
+            "skills the candidate mentions, or for weak areas noted in their profile info if "
+            "they ask something open-ended like 'what should I focus on'."
+        ),
+        tools=[get_learning_resource],
+    )
+
+    salary_agent = LlmAgent(
+        name="salary_agent",
+        model=MODEL,
+        description="Gives salary benchmarks and negotiation advice for a role and location.",
+        instruction=(
+            "You help candidates understand their market value. Use the get_salary_benchmark "
+            "tool, passing the role and location. If either isn't stated, use the target roles "
+            "noted in the candidate's profile info instead of asking them to repeat it."
+        ),
+        tools=[get_salary_benchmark],
+    )
+
+    career_orchestrator = LlmAgent(
+        name="career_orchestrator",
+        model=MODEL,
+        description="Routes career coaching questions to the right specialist.",
+        instruction=(
+            "You are the first point of contact for a career coaching app. Read the "
+            "candidate's message, including any 'Relevant past information' block included "
+            "with it, and decide whether this is about resume feedback, interview practice, "
+            "a skill gap/learning roadmap, or salary/negotiation. Delegate to the matching "
+            "specialist. If it's genuinely unclear, ask a clarifying question yourself "
+            "instead of guessing."
+        ),
+        sub_agents=[resume_agent, interview_agent, skills_roadmap_agent, salary_agent],
+    )
+    return career_orchestrator
+
+
+async def ensure_session(session_service, user_id, session_id):
+    await session_service.create_session(app_name=APP_NAME, user_id=user_id, session_id=session_id)
+
+
+async def call_agent(runner, user_id, session_id, message_text) -> str:
+    content = types.Content(role="user", parts=[types.Part(text=message_text)])
+    final_text = ""
+    async for event in runner.run_async(user_id=user_id, session_id=session_id, new_message=content):
+        if event.is_final_response() and event.content and event.content.parts:
+            final_text = event.content.parts[0].text
+    return final_text
+
+
+def run_agent_sync(runner, user_id, session_id, message_text) -> str:
+    return asyncio.run(call_agent(runner, user_id, session_id, message_text))
+
+
+@st.cache_resource
+def get_memory() -> Memory:
+    # Embedded/on-disk Qdrant only allows one open client per storage path
+    # per process (it takes a file lock) -- cache_resource makes this a
+    # single instance shared by every browser session on this server,
+    # instead of one per session, which would crash the 2nd concurrent
+    # user with "Storage folder ... already accessed by another instance".
+    return Memory.from_config(MEM0_CONFIG)
+
+
+@st.cache_resource
+def get_runner():
+    career_orchestrator = build_career_orchestrator()
+    session_service = InMemorySessionService()
+    runner = Runner(agent=career_orchestrator, app_name=APP_NAME, session_service=session_service)
+    return runner, session_service
+
+
+def format_memories(memories: dict) -> str:
+    results = (memories or {}).get("results") or []
+    if not results:
+        return ""
+    lines = "\n".join(f"- {m['memory']}" for m in results if "memory" in m)
+    return f"Relevant past information:\n{lines}\n" if lines else ""
+
+
+# --- Streamlit app ---
+st.title("🎯 AI Career Coach (ADK Multi-Agent + Memory)")
+st.caption(
+    "An orchestrator agent routes your question to a resume, interview, skills, "
+    "or salary specialist (Google ADK), while Mem0 + Qdrant remember your career "
+    "history across sessions."
+)
+
+google_api_key = st.text_input(
+    "Enter Google API Key (for Gemini)",
+    type="password",
+    value=os.getenv("GOOGLE_API_KEY", ""),
+)
+
+if google_api_key:
+    os.environ["GOOGLE_API_KEY"] = google_api_key
+
+    memory = get_memory()
+    runner, session_service = get_runner()
+
+    st.sidebar.title("Candidate")
+    previous_user_id = st.session_state.get("previous_user_id")
+    user_id = st.sidebar.text_input("Your email", value="demo@example.com")
+
+    if user_id != previous_user_id:
+        st.session_state.messages = []
+        st.session_state.previous_user_id = user_id
+        st.session_state.pop("session_ready", None)
+
+    if st.sidebar.button("View my memory"):
+        memories = memory.get_all(filters={"user_id": user_id})
+        results = (memories or {}).get("results") or []
+        if results:
+            for mem in results:
+                st.sidebar.write(f"- {mem['memory']}")
+        else:
+            st.sidebar.info("No memory on file for you yet.")
+
+    if "messages" not in st.session_state:
+        st.session_state.messages = []
+
+    for message in st.session_state.messages:
+        with st.chat_message(message["role"]):
+            st.markdown(message["content"])
+
+    prompt = st.chat_input("Ask about your resume, an interview, a skill, or salary...")
+
+    if prompt and user_id:
+        session_id = f"session-{user_id}"
+        if not st.session_state.get("session_ready"):
+            asyncio.run(ensure_session(session_service, user_id, session_id))
+            st.session_state.session_ready = True
+
+        st.session_state.messages.append({"role": "user", "content": prompt})
+        with st.chat_message("user"):
+            st.markdown(prompt)
+
+        # Long-term memory: pull what Mem0 knows about this candidate before routing.
+        relevant_memories = memory.search(query=prompt, filters={"user_id": user_id}, top_k=5)
+        context = format_memories(relevant_memories)
+        full_message = f"Candidate email: {user_id}\n{context}\nCandidate says: {prompt}"
+
+        with st.chat_message("assistant"):
+            with st.spinner("Routing to the right specialist..."):
+                answer = run_agent_sync(runner, user_id, session_id, full_message)
+            st.markdown(answer)
+        st.session_state.messages.append({"role": "assistant", "content": answer})
+
+        # Write this exchange back to long-term memory for future sessions.
+        memory.add(prompt, user_id=user_id, metadata={"role": "user"})
+        memory.add(answer, user_id=user_id, metadata={"role": "assistant"})
+    elif not user_id:
+        st.error("Please enter your email to start chatting.")
+else:
+    st.warning("Please enter your Google API key to continue.")

--- a/advanced_llm_apps/llm_apps_with_memory_tutorials/adk_career_coach_agent_memory/adk_career_coach_agent_memory.py
+++ b/advanced_llm_apps/llm_apps_with_memory_tutorials/adk_career_coach_agent_memory/adk_career_coach_agent_memory.py
@@ -9,7 +9,7 @@ from google.genai import types
 from mem0 import Memory
 
 APP_NAME = "adk_career_coach"
-MODEL = "gemini-2.5-flash"
+MODEL = "gemini-3.7-flash"
 
 # Mem0 config: Gemini for both the LLM (fact extraction) and the embedder,
 # plus an on-disk Qdrant collection -- no Docker/Qdrant server, no OpenAI

--- a/advanced_llm_apps/llm_apps_with_memory_tutorials/adk_career_coach_agent_memory/idea.md
+++ b/advanced_llm_apps/llm_apps_with_memory_tutorials/adk_career_coach_agent_memory/idea.md
@@ -1,0 +1,207 @@
+# Idea / Blueprint — AI Career Coach
+
+This document explains what we're building and how all the pieces fit
+together, before any code gets written. It's meant to be readable on its own —
+no prior context needed.
+
+## What this is
+
+An AI career coach for job seekers, built as a chat app. You talk to it about
+your job search — your resume, an upcoming interview, a skill you want to
+learn, how much to ask for in salary negotiations — and it routes your
+question to the right specialist automatically. The thing that makes it
+useful, rather than just another chatbot, is that it **remembers you**: your
+experience, the kind of roles you're targeting, your tech stack, which
+companies you like, offers you've turned down, and where you've struggled in
+past interviews. That memory persists across every conversation, even if you
+close the app and come back two months later, and it directly shapes the
+advice you get.
+
+## Why memory is the whole point
+
+Without memory, every conversation starts from zero. You'd have to re-explain
+your background every single time: "I'm a backend engineer with 4 years of
+experience, I'm applying to fintech companies, I keep struggling with system
+design questions..." — every time, forever.
+
+With memory, that context builds up and gets reused automatically. Here's the
+concrete difference:
+
+**Today**, you tell it: *"I have an Amazon interview next week."*
+It has enough context from past conversations to know you're a backend
+engineer, you're targeting fintech-style companies, and system design is your
+weak point — so it can immediately suggest a focused prep plan instead of
+asking you to explain your whole background again.
+
+**Two months later**, you ask: *"What should I focus on?"*
+Instead of a generic "work on your resume and practice interviewing" answer,
+it can say something like: *"Since you've been targeting backend roles in
+fintech, have struggled with distributed systems interview questions, and
+want to work remotely, I'd prioritize practicing system design and looking
+at these three companies..."*
+
+That second example only works because the app remembered specific,
+personal facts about you across a long gap in time. That's the feature this
+whole build is designed around.
+
+## The four specialists, and why routing between them matters
+
+A career coach isn't one skill, it's several different skills bundled
+together, the same way a real career coaching service might have different
+people handle different things:
+
+| Specialist | What it actually does | Example question it should handle |
+|---|---|---|
+| **Resume Agent** | Fetches your resume on file and gives feedback tailored to a specific role you're applying for | "Can you review my resume for a backend role?" |
+| **Interview Agent** | Runs mock interview practice and gives feedback | "I have an Amazon interview next week, can we practice?" |
+| **Skills/Roadmap Agent** | Identifies skill gaps and suggests what to learn next | "I keep failing system design rounds, what should I study?" |
+| **Salary Agent** | Gives a realistic salary range and negotiation advice | "What should I expect to be offered for a senior backend role in Seattle?" |
+
+These genuinely need different knowledge and a different tone: giving resume
+feedback and negotiating salary are not the same skill, and mashing them into
+one generic "career bot" tends to produce shallow, generic answers to
+everything. Splitting them into separate specialist agents, each with a
+narrow job, lets each one be actually good at its one thing.
+
+A fifth agent, the **career_orchestrator**, sits in front of all four. It
+doesn't answer questions itself — its only job is to read your message
+(plus whatever memory tells it about you) and decide which one specialist
+should handle it. If your message is genuinely ambiguous, it asks a
+clarifying question instead of guessing which specialist you meant.
+
+**A deliberate design choice:** the orchestrator hands your message to
+**one** specialist per turn, not several at once. This keeps the system
+simple and predictable — one message, one clear routing decision, one
+answer. The alternative (splitting one message across multiple specialists
+and merging their answers together) is possible but adds real complexity for
+little benefit here, since memory already gives each specialist enough
+context to give a well-rounded answer on its own.
+
+## How a message actually flows through the system
+
+```
+                                                 ┌────────────────────────┐
+                                                 │        Mem0            │
+                                                 │  (backed by Qdrant)    │
+                                                 │  remembers you across  │
+                                                 │  every conversation    │
+                                                 └───────┬────────┬──────┘
+                                                          │        │
+                                                (1) look up│        │(5) save
+                                                 what we    │        │  new info
+                                                 know        ▼        │
+  you ──(type a message)──► [Streamlit chat] ──► "message + what we know about you"
+                              ▲                          │
+                              │ (6) show the reply        │ (2) send to agent
+                              │                           ▼
+                              │                  ┌───────────────────┐
+                              │                  │   ADK Runner       │
+                              │                  │ (+ current chat    │
+                              │                  │    state for now)  │
+                              │                  └─────────┬──────────┘
+                              │                            │ (3) picks the
+                              │                            │  right specialist
+                              │                  ┌─────────▼──────────┐
+                              │                  │ career_orchestrator │
+                              │                  │   (root agent)      │
+                              │                  └───┬─────┬─────┬────┘
+                              │                      │     │     │
+                              │                 Resume Interview  Skills/  Salary
+                              │                  Agent   Agent   Roadmap  Agent
+                              │                      │     │    Agent │      │
+                              │                      ▼     ▼     ▼    ▼
+                              │                 [tool]   [tool] [tool] [tool]
+                              │                      │     │     │     │
+                              └──────(4) the answer◄─┴─────┴─────┴─────┘
+```
+
+Step by step, in plain terms:
+
+1. You type a message in the chat box.
+2. Before doing anything else, the app searches Mem0 for anything it already
+   knows about you that's relevant to what you just asked.
+3. Your message plus that retrieved context gets handed to the ADK Runner,
+   which passes it to the orchestrator agent.
+4. The orchestrator reads it and hands it off to exactly one specialist
+   (Resume, Interview, Skills/Roadmap, or Salary), which may call its own
+   tool to look something up (a sample interview question, a salary
+   benchmark, etc.) before answering.
+5. The specialist's answer comes back through the orchestrator to the app.
+6. The app saves both your message and the answer into Mem0, so this
+   exchange is available to recall in future conversations.
+7. The answer is shown to you in the chat window.
+
+## Two very different kinds of "remembering"
+
+There are two separate memory systems here, doing two different jobs, and
+it's important not to confuse them:
+
+- **The current conversation** — everything said in this chat session, kept
+  by ADK for as long as the app is running. This is short-term and
+  disposable: if the app restarts, this is gone. It exists just so the
+  agent doesn't lose track of what you said two messages ago in the same
+  conversation.
+- **You, as a person, over time** — stored in Mem0, backed by a Qdrant
+  vector database. This is what survives closing the app, restarting the
+  server, or coming back after months. It's where the genuinely useful
+  long-term facts live:
+  - years of experience
+  - roles you're targeting (e.g. "backend engineering, fintech companies")
+  - your tech stack
+  - companies you like, or have liked in the past
+  - job offers you've turned down, and why
+  - skills or topics you're actively trying to learn
+  - interview topics or question types you've struggled with
+
+The short-term memory keeps one conversation coherent. The long-term memory
+is what makes the app feel like it actually knows you. Both are necessary,
+and they're intentionally kept separate so restarting the app (which clears
+the short-term memory) never causes it to forget who you are (which lives in
+the long-term memory instead).
+
+## Mock data — stand-ins for real data sources
+
+To build and test this without needing real integrations yet, each
+specialist's tool reads from a small, hardcoded Python dictionary instead of
+a real API:
+
+- `MOCK_RESUMES` — a resume on file for each candidate email (years of
+  experience, current role, skills, a few bullet points)
+- `MOCK_INTERVIEW_QUESTIONS` — a few sample interview questions, organized by
+  company and interview type (e.g. Amazon behavioral, Amazon system design)
+- `MOCK_LEARNING_RESOURCES` — a suggested next learning step for a handful of
+  skills (e.g. "distributed systems" → a suggested resource)
+- `MOCK_SALARY_DATA` — a rough salary range for a few role + location
+  combinations
+
+In a real, production version, these would become live data sources: a real
+resume/profile store, a real interview question bank, a real course/learning
+platform's catalog, and a real salary data provider (like Levels.fyi or
+Glassdoor). Keeping them as simple dictionaries for now means the whole
+system — routing, memory, tool-calling — can be built and tested end to end
+before any real data integration work happens.
+
+## What credentials this needs
+
+Just one: a Google API key (for Gemini). It covers three things at once:
+
+1. The actual chat responses from the orchestrator and all four specialists.
+2. Mem0's own internal reasoning (it uses an LLM to decide what's worth
+   remembering from a conversation).
+3. Mem0's embeddings (the vector representations it uses to search your
+   memories later).
+
+All three are pointed at Gemini so a single key covers everything — no
+separate OpenAI key, and no Qdrant server to install or pay for. Qdrant runs
+in an embedded, on-disk mode (just a folder on the filesystem), which is
+enough for a single-user demo like this one.
+
+## Extension ideas (later, once the basics work end to end)
+
+- A **Negotiation Agent** for when an actual offer is on the table and you
+  need help deciding how to respond
+- An **application tracker**: which companies you've applied to, and where
+  each one currently stands
+- Splitting the Interview Agent into separate behavioral and
+  technical/system-design specialists if one agent starts feeling like it's
+  covering too much ground

--- a/advanced_llm_apps/llm_apps_with_memory_tutorials/adk_career_coach_agent_memory/idea.md
+++ b/advanced_llm_apps/llm_apps_with_memory_tutorials/adk_career_coach_agent_memory/idea.md
@@ -127,8 +127,11 @@ Step by step, in plain terms:
    tool to look something up (a sample interview question, a salary
    benchmark, etc.) before answering.
 5. The specialist's answer comes back through the orchestrator to the app.
-6. The app saves both your message and the answer into Mem0, so this
-   exchange is available to recall in future conversations.
+6. The app saves your message into Mem0 -- just your side of the exchange,
+   not the coach's reply. The long-term store is meant to hold facts about
+   you (the candidate), not the advice the coach gave, so only your message
+   goes in. This also means only one Mem0 write per turn instead of two,
+   which matters because each write triggers its own LLM call internally.
 7. The answer is shown to you in the chat window.
 
 ## Two very different kinds of "remembering"

--- a/advanced_llm_apps/llm_apps_with_memory_tutorials/adk_career_coach_agent_memory/requirements.txt
+++ b/advanced_llm_apps/llm_apps_with_memory_tutorials/adk_career_coach_agent_memory/requirements.txt
@@ -1,0 +1,4 @@
+streamlit
+google-adk
+mem0ai==2.0.14
+qdrant-client


### PR DESCRIPTION
## Summary

Adds an ADK-based career coach agent with persistent memory using Mem0 and Qdrant. The agent remembers user career goals, experience, skills, and preferences across sessions to provide personalized coaching over time.

## Changes

- `advanced_llm_apps/llm_apps_with_memory_tutorials/adk_career_coach_agent_memory/adk_career_coach_agent_memory.py` — main agent implementation
- `advanced_llm_apps/llm_apps_with_memory_tutorials/adk_career_coach_agent_memory/README.md` — setup and usage guide
- `advanced_llm_apps/llm_apps_with_memory_tutorials/adk_career_coach_agent_memory/requirements.txt` — dependencies

## Test plan

- [ ] Run `adk_career_coach_agent_memory.py` and verify the agent starts successfully
- [ ] Ask career-related questions and confirm the agent responds with personalized advice
- [ ] Restart the agent and verify it recalls information from a previous session
- [ ] Verify `requirements.txt` installs cleanly in a fresh virtual environment

🤖 Generated with [Claude Code](https://claude.com/claude-code)
