### PR TITLE
Add Claude-OSINT to Agent Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ streamlit run travel_agent.py
 *   [🩺 Dependency Doctor](agent_skills/dependency-doctor/) - Checks a dependency manifest for standard-library pins, obsolete backports, unpinned entries, duplicate constraints, and yanked releases
 *   [🧠 Advisor Orchestrator Worker](agent_skills/advisor-orchestrator-worker/) - Meta Loop with Claude Fable 5 as advisor, GPT-5.6 as orchestrator, and Gemini 3.5 Flash as worker
 *   [♾️ Self-Improving Agent Skills](agent_skills/self-improving-agent-skills/) - Automatically optimize agent skills using Gemini and ADK
+*   [🕵️ Claude-OSINT](https://github.com/elementalsouls/Claude-OSINT) <sub>↗ external</sub> - Drop-in SKILL.md recon skills that turn Claude into a god-mode external recon operator for authorized red-team and bug-bounty engagements
 
 ### 🌱 Starter AI Agents
 


### PR DESCRIPTION
Adding **Claude-OSINT** to the Agent Skills section as an external link.

- Repo: https://github.com/elementalsouls/Claude-OSINT (2.2k stars)
- Drop-in SKILL.md recon skills that turn Claude into an external recon operator for authorized red-team and bug-bounty engagements.

Placed under the **?? Agent Skills** list, matching the existing `<sub>? external</sub>` format used by Openwork and the Voice Dictation Agent.