### PR TITLE
Add Open Reverse Lab to MCP AI Agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,7 @@ streamlit run travel_agent.py
 *   [📑 Notion MCP Agent](mcp_ai_agents/notion_mcp_agent) - Talk to your Notion pages from the terminal
 *   [🌍 AI Travel Planner MCP Agent](mcp_ai_agents/ai_travel_planner_mcp_agent_team) - Itineraries built on live Airbnb and Google Maps data
 *   [🔀 Multi-MCP Agent Router](mcp_ai_agents/multi_mcp_agent_router/) - Specialist agents, each wired to its own MCP server
+*   [🔬 Open Reverse Lab](https://github.com/LING71671/open-reverselab) <sub>↗ external</sub> - Agent-native reverse-engineering lab with a 197-article knowledge base, MCP tools, and CTF/APK/PE automation workflows
 
 ### 📀 RAG (Retrieval Augmented Generation)
 


### PR DESCRIPTION
Adding **open-reverselab** to the MCP AI Agents section as an external link.

- Repo: https://github.com/LING71671/open-reverselab (1k stars, GPL-3.0)
- Agent-native reverse-engineering lab with a 197-article knowledge base, MCP tools, and CTF/APK/PE automation workflows.

Placed under **?? MCP AI Agents** since it ships as MCP tools, matching the existing `<sub>? external</sub>` format used by Openwork and the Voice Dictation Agent.