### PR TITLE
Add LLMVault to Advanced AI Agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ streamlit run travel_agent.py
 *   [🎧 AI Social Media News and Podcast Agent](advanced_ai_agents/multi_agent_apps/ai_news_and_podcast_agents/) - Curates your trusted sources into briefs and generated podcasts
 *   [🌐 Openwork - Open Browser Automation Agent](https://github.com/accomplish-ai/openwork) <sub>↗ external</sub> - Open-source agent that operates a real browser
 *   [🛡️ Trust-Gated Multi-Agent Research Team](advanced_ai_agents/multi_agent_apps/trust_gated_agent_team/) - Every agent verified, every action in a hash-chained audit trail
+*   [🎯 LLMVault](https://github.com/CyberSunil/LLMVault) <sub>↗ external</sub> - Intentionally vulnerable OWASP LLM Top 10 training platform for prompt injection, RAG security, agent security, and GenAI pentesting
 
 ### 🛰️ Always-on Agents
 


### PR DESCRIPTION
Adding **LLMVault** to the Advanced AI Agents section as an external link.

- Repo: https://github.com/CyberSunil/LLMVault (MIT)
- An intentionally vulnerable OWASP LLM Top 10 training platform for AI security, prompt injection, RAG security, agent security, and GenAI penetration testing.

Placed at the end of **?? Advanced AI Agents** alongside the other external entries, using the existing `<sub>? external</sub>` format.