### PR TITLE
Add Anthropic Cybersecurity Skills to Agent Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ streamlit run travel_agent.py
 *   [🩺 Dependency Doctor](agent_skills/dependency-doctor/) - Checks a dependency manifest for standard-library pins, obsolete backports, unpinned entries, duplicate constraints, and yanked releases
 *   [🧠 Advisor Orchestrator Worker](agent_skills/advisor-orchestrator-worker/) - Meta Loop with Claude Fable 5 as advisor, GPT-5.6 as orchestrator, and Gemini 3.5 Flash as worker
 *   [♾️ Self-Improving Agent Skills](agent_skills/self-improving-agent-skills/) - Automatically optimize agent skills using Gemini and ADK
+*   [🛡️ Anthropic Cybersecurity Skills](https://github.com/mukul975/Anthropic-Cybersecurity-Skills) <sub>↗ external</sub> - 817 structured cybersecurity skills for AI agents across 29 security domains, mapped to MITRE ATT&CK, NIST CSF 2.0, MITRE ATLAS, D3FEND, NIST AI RMF & MITRE F3
 
 ### 🌱 Starter AI Agents
 


### PR DESCRIPTION
Adding **Anthropic-Cybersecurity-Skills** to the Agent Skills section as an external link.

- Repo: https://github.com/mukul975/Anthropic-Cybersecurity-Skills (27k stars, Apache-2.0)
- 817 structured cybersecurity skills for AI agents across 29 security domains, mapped to 6 frameworks: MITRE ATT&CK, NIST CSF 2.0, MITRE ATLAS, D3FEND, NIST AI RMF and MITRE F3. Follows the agentskills.io standard - works with Claude Code, Copilot, Codex CLI, Cursor, Gemini CLI and 20+ platforms.

Placed under the Agent Skills list, matching the existing external-link format.