### PR TITLE
Add Reverse Skill to Agent Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ streamlit run travel_agent.py
 *   [🩺 Dependency Doctor](agent_skills/dependency-doctor/) - Checks a dependency manifest for standard-library pins, obsolete backports, unpinned entries, duplicate constraints, and yanked releases
 *   [🧠 Advisor Orchestrator Worker](agent_skills/advisor-orchestrator-worker/) - Meta Loop with Claude Fable 5 as advisor, GPT-5.6 as orchestrator, and Gemini 3.5 Flash as worker
 *   [♾️ Self-Improving Agent Skills](agent_skills/self-improving-agent-skills/) - Automatically optimize agent skills using Gemini and ADK
+*   [🔧 Reverse Skill](https://github.com/zhaoxuya520/reverse-skill) <sub>↗ external</sub> - Reverse engineering / authorized pentest skill router pack: AI-powered routing, on-demand toolchain bootstrapping, and a self-evolving knowledge base for Claude Code, Kiro, Cursor, and Cline
 
 ### 🌱 Starter AI Agents
 


### PR DESCRIPTION
Adding **reverse-skill** to the Agent Skills section as an external link.

- Repo: https://github.com/zhaoxuya520/reverse-skill (21k stars, MIT)
- Reverse engineering / authorized penetration testing skill router pack: AI-powered skill routing, on-demand toolchain bootstrapping, and a self-evolving knowledge base. Works with Claude Code, Kiro, Cursor, Cline, and other AI coding clients.

Placed under the Agent Skills list, matching the existing external-link format.