### PR TITLE
Add .gitattributes to mark lockfiles as generated

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,9 @@
+# Lockfiles are machine-generated. Keep them committed for reproducible installs,
+# but mark them as generated so GitHub collapses them in diffs and excludes them
+# from repository language statistics. Patterns without a slash match at any depth.
+package-lock.json linguist-generated=true
+yarn.lock linguist-generated=true
+pnpm-lock.yaml linguist-generated=true
+uv.lock linguist-generated=true
+poetry.lock linguist-generated=true
+Cargo.lock linguist-generated=true


### PR DESCRIPTION
## What

Adds a root `.gitattributes` that marks committed lockfiles as `linguist-generated`:

```
package-lock.json linguist-generated=true
yarn.lock         linguist-generated=true
pnpm-lock.yaml    linguist-generated=true
uv.lock           linguist-generated=true
poetry.lock       linguist-generated=true
Cargo.lock        linguist-generated=true
```

Patterns without a slash match at any depth, so this covers every lockfile in the repo (~20 today across `generative_ui_agents/`, `advanced_ai_agents/`, `rag_tutorials/`, and others) plus any added later.

## Why

The repo already commits lockfiles in many projects for reproducible installs, which is good. The downside is that a machine-generated `package-lock.json` or `uv.lock` can add 10k+ lines to a PR and bury the actual source under lockfile churn during review. Marking them generated tells GitHub to collapse them in diffs and exclude them from language stats.

## Effect

- Reproducibility is fully preserved: no lockfiles are removed.
- Lockfiles show collapsed ("Load diff") in PR file views.
- Contributors can keep shipping lockfiles without bloating a review, so we never have to ask them to drop or hand-manage them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0174eaH6iN7hAo2BGWKXjd3S

---
_Generated by [Claude Code](https://claude.ai/code/session_0174eaH6iN7hAo2BGWKXjd3S)_