### PR TITLE
docs: add Memex to Advanced AI Agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ streamlit run travel_agent.py
 *   [🔍 AI Fraud Investigation Agent](advanced_ai_agents/single_agent_apps/ai_fraud_investigation_agent/) - Cross-references public records to flag facilities that don't add up
 *   [🗞️ AI Journalist Agent](advanced_ai_agents/single_agent_apps/ai_journalist_agent/) - Researches, writes, and edits articles on any topic
 *   [🧠 AI Mental Wellbeing Agent](advanced_ai_agents/multi_agent_apps/ai_mental_wellbeing_agent/) - A coordinated agent team for mental health support plans
+*   [🧠 Memex - Local-First AI Journal](https://github.com/memex-lab/memex) <sub>↗ external</sub> - Captures text, photos, and voice into a private on-device timeline and knowledge base through coordinated AI agents
 *   [📑 AI Meeting Agent](advanced_ai_agents/single_agent_apps/ai_meeting_agent/) - Context, industry insights, and strategy briefs before you walk in
 *   [🧬 AI Self-Evolving Agent](advanced_ai_agents/multi_agent_apps/ai_self_evolving_agent/) - Agents that rewrite their own workflows with EvoAgentX
 *   [👨🏻‍💼 AI Sales Intelligence Agent Team](advanced_ai_agents/multi_agent_apps/agent_teams/ai_sales_intelligence_agent_team) - Generates competitive sales battle cards in real time


### PR DESCRIPTION
## Summary
- add Memex to the Advanced AI Agents catalog
- describe its local-first mobile journal, coordinated AI agents, and multimodal capture workflow
- mark the project as an external open-source repository, matching existing README conventions

## Validation
- ran `git diff --check`
- verified the Memex repository link and README placement