### PR TITLE
Add SubFlow to Agent Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ streamlit run travel_agent.py
 *   [🩺 Dependency Doctor](agent_skills/dependency-doctor/) - Checks a dependency manifest for standard-library pins, obsolete backports, unpinned entries, duplicate constraints, and yanked releases
 *   [🧠 Advisor Orchestrator Worker](agent_skills/advisor-orchestrator-worker/) - Meta Loop with Claude Fable 5 as advisor, GPT-5.6 as orchestrator, and Gemini 3.5 Flash as worker
 *   [♾️ Self-Improving Agent Skills](agent_skills/self-improving-agent-skills/) - Automatically optimize agent skills using Gemini and ADK
+*   [🎬 SubFlow](https://github.com/IcaroPv01/subflow) - Fully local subtitle pipeline skill: Whisper transcription + batch translation + Netflix-style QC + ASR hallucination detection (`langcheck`). PT-BR presets for documentary translation
 
 ### 🌱 Starter AI Agents
 


### PR DESCRIPTION
## What
Adds [SubFlow](https://github.com/IcaroPv01/subflow) to the **🧩 Agent Skills** section.

SubFlow is a fully local subtitle pipeline skill for Claude Code/Codex/Cursor:
- Transcribes any video with Whisper locally (no API costs)
- Translates in batches (text-only, timing preserved)
- Runs Netflix-style QC automatically
- Detects ASR hallucinations via `langcheck`
- Includes PT-BR presets for documentary translation

Use case: documentary translation, fan-subbing, accessibility — all 100% offline, no API costs.

Repo: https://github.com/IcaroPv01/subflow (v0.2.0, MIT)
Demo: https://www.youtube.com/watch?v=8wywC_Evx9E