### PR TITLE
Add md-review skill: scenario-aware Markdown review with weighted scoring

### DIFF
--- a/agent_skills/md-review/README.md
+++ b/agent_skills/md-review/README.md
@@ -17,18 +17,18 @@ Reviews ONE Markdown document per invocation across 14 document scenarios (PRD, 
 
 ## Usage
 
-```
+```text
 /md-review <path> [scenario] [--dimensions 1,2,3,4,5,6] [--format full|summary|fix] [--solo] [--pass-threshold N] [--output file] [json]
 ```
 
 - `<scenario>` — one of the 14 scenarios; omit for generic mode
-- `--solo` — non-interactive CI mode; exit codes: `0` = no P0 and score ≥ threshold (default 75), `1` = P0 issues or below threshold, `2` = error
+- `--solo` — non-interactive CI mode; exit codes: `0` = no P0 (blocking/bug-level issue) and score ≥ threshold (default 75), `1` = P0 issues or below threshold, `2` = error
 - `--format fix` — applies only safe mechanical fixes automatically (link-text repairs, filler-word removal, echo-title removal); judgment calls are reported unfixed
 - Every report ends with a machine-readable `MD-REVIEW-SUMMARY` block for CI parsing
 
 ## Structure
 
-```
+```text
 md-review/
 ├── SKILL.md                  skill definition (workflow + phases 0-6)
 ├── references/               5 review-rules files + 14 per-scenario checklists

--- a/agent_skills/md-review/README.md
+++ b/agent_skills/md-review/README.md
@@ -1,0 +1,47 @@
+# md-review
+
+Scenario-aware Markdown document review with weighted scoring. **Finds bugs and logic errors that would break downstream implementation first**, then checks scenario-specific completeness — style and formatting are secondary.
+
+## What it does
+
+Reviews ONE Markdown document per invocation across 14 document scenarios (PRD, API spec, GDD, TDD, ADR, BRD, MRD, FSD, GDO, LDD, Concept, TLD, TCD) or in generic mode, scoring across 6 weighted dimensions:
+
+| Dimension | Weight |
+|---|---|
+| Logic (bug detection) | 30% |
+| Scenario completeness | 25% |
+| Sections | 15% |
+| References | 10% |
+| Redundancy | 10% |
+| Format | 10% |
+
+## Usage
+
+```
+/md-review <path> [scenario] [--dimensions 1,2,3,4,5,6] [--format full|summary|fix] [--solo] [--pass-threshold N] [--output file] [json]
+```
+
+- `<scenario>` — one of the 14 scenarios; omit for generic mode
+- `--solo` — non-interactive CI mode; exit codes: `0` = no P0 and score ≥ threshold (default 75), `1` = P0 issues or below threshold, `2` = error
+- `--format fix` — applies only safe mechanical fixes automatically (link-text repairs, filler-word removal, echo-title removal); judgment calls are reported unfixed
+- Every report ends with a machine-readable `MD-REVIEW-SUMMARY` block for CI parsing
+
+## Structure
+
+```
+md-review/
+├── SKILL.md                  skill definition (workflow + phases 0-6)
+├── references/               5 review-rules files + 14 per-scenario checklists
+├── scripts/                  5 python helpers (probe, analyze, extract_refs, score, path-gate)
+└── example/                  report, review-plan, fix-plan, summary and delta templates
+```
+
+All helpers are read-only analyzers; nothing leaves the machine, no network calls.
+
+## Testing
+
+The skill ships a self-contained regression suite in its source repository ([viggo-pod/md-review](https://github.com/viggo-pod/md-review), MIT): `bash evals/run_self_test.sh` runs 5/5 checks (script verification, clean-doc precision, error-path protocol, registry integrity, step-numbering detection). Development benchmark: 212/213 runs passed (99.5%), 100% of injected defects detected.
+
+## License
+
+MIT

--- a/agent_skills/md-review/SKILL.md
+++ b/agent_skills/md-review/SKILL.md
@@ -1,0 +1,295 @@
+---
+name: md-review
+description: 'Review Markdown documents with scenario-aware weighted scoring, prioritizing bug and logic-error detection over style. Use this skill whenever the user asks to review, audit, check, or grade any Markdown document — review this doc, check the markdown for bugs, find logic errors, verify references, detect redundancy, check formatting, score or grade a document, review a PRD/ADR/API spec/GDD/FSD/MRD/BRD/task list/test case/level design/technical design/concept document, audit documentation, or run a document quality gate before release.'
+argument-hint: '[path] [scenario: prd|adr|add|api|brd|mrd|fsd|gdd|gdo|tdd|ldd|concept|tld|tcd] [--dimensions 1-6] [--format full|summary|fix] [--solo] [--pass-threshold N] [--output file] [json]'
+user-invocable: true
+allowed-tools: Read, Glob, Grep, Write, Edit, Bash, SearchExtraTools
+model: sonnet
+license: MIT
+compatibility: Requires python3 (scripts/ for structural analysis, probing, and scoring)
+metadata:
+  hermes:
+    tags: [Markdown, Documentation, Review, Quality]
+    category: productivity
+    related_skills: [skill-creator]
+---
+
+# MD Review — Scenario-Aware Markdown Review
+
+Reviews ONE Markdown document per invocation with scenario-aware weighted scoring. **Core positioning: find bugs and logic errors that would break downstream implementation first, then check whether the document's scenario-specific required content is complete.**
+
+## Scenarios
+
+The scenario is optional. Without one, the review runs in generic mode (the scenario-completeness dimension is skipped).
+
+| Scenario | Document | Required-content focus |
+|---|---|---|
+| `prd` | Product Requirements Document | requirement list, user stories, acceptance criteria, 5W1H |
+| `adr` | Architecture Decision Record | context / decision / rationale / alternatives / consequences |
+| `add` | Architecture Design Description | architecture views, quality attributes, interfaces, data flow |
+| `api` | API Document | endpoint contracts, error codes, auth, runnable examples |
+| `brd` | Business Requirements Document | business goals, ROI, cost/revenue model, 5W1H |
+| `mrd` | Market Requirements Document | market analysis, user personas, value proposition, 5W1H |
+| `fsd` | Functional Specification Document | functional behavior, use cases, test cases, acceptance criteria |
+| `gdd` | Game Design Document | core loop, numbers, test cases, task lists |
+| `gdo` | Game Overview Document | executive summary, core concept, design pillars, USP |
+| `tdd` | Technical Design Document | system architecture, tech stack, coding standards, performance goals |
+| `ldd` | Level Design Document | level layout, player path, challenge configuration, pacing |
+| `concept` | Concept Design Document | game concept, market analysis, core selling points |
+| `tld` | Task List Document | task decomposition, dependencies, effort estimates, owners |
+| `tcd` | Test Case Document | case IDs, test steps, inputs/outputs, requirement traceability |
+
+## Review Dimensions & Weights
+
+| # | Dimension | Weight | Scope |
+|---|---|---|---|
+| 1. | **Logic (bug detection)** | **30%** | formula/number contradictions, missing edge cases, broken flows (generic, all scenarios) |
+| 2. | **Scenario completeness** | **25%** | required content for the scenario (test cases / checklists / 5W1H, etc.) |
+| 3. | Sections | 15% | missing required sections, undefined terms, incomplete markers (generic) |
+| 4. | References | 10% | broken links, wrong references, version inconsistency (generic) |
+| 5. | Redundancy | 10% | duplicated content, low-value information (generic) |
+| 6. | Format | 10% | rendering-critical formatting (detailed linting is the editor's job) |
+
+**Overall score = Σ(dimension score × weight)**. Dimensions that don't apply to the document are scored 100.
+
+## Usage
+
+```
+/md-review <path> <scenario: prd|adr|add|api|brd|mrd|fsd|gdd|gdo|tdd|ldd|concept|tld|tcd (optional)> [--dimensions 1,2,3,4,5,6] [--format full|summary|fix] [--solo] [--pass-threshold N] [--output file] [json]
+```
+
+- **path** — the Markdown file to review
+- **Scenario (optional arg 1)** — document scenario; omit to review as generic (skips the scenario-completeness dimension)
+- `--dimensions` — restrict to specific dimensions (default: all), e.g. `--dimensions 1,2` (logic + scenario completeness only); when focusing on specific dimensions, Error-level issues must still be flagged. **P0 (blocking) determination is independent of `--dimensions`**: a P0 found in any dimension — including non-focused ones — still sets the solo exit code to `1` and is listed in the report
+- `--format` — `full` (default) complete report / `summary` score table only / `fix` report + auto-fix
+- `--solo` — non-interactive mode, see Modes below
+- `--pass-threshold` — solo-mode exit-code gate on the overall score (default 75)
+- `--output` — write the report to a file (useful in solo mode / CI)
+- `json` — append to also emit machine-readable JSON output
+
+## Examples
+
+**Example 1: Full review of a single document (interactive)**
+Input: `/md-review docs/requirements.md prd`
+Output: a review plan first (approval gate), then a full report with weighted scores, bug-level issues, and missing scenario content.
+
+**Example 2: Solo-mode CI gate**
+Input: `/md-review docs/requirements.md prd --solo --pass-threshold 75`
+Output: report to stdout ending with the `MD-REVIEW-SUMMARY` block; exit code 0 (no P0, score ≥ 75) / 1 (P0 issues or below threshold) / 2 (error).
+
+**Example 3: Score table only**
+Input: `/md-review docs/api-spec.md api --format summary`
+Output: weighted score table only, no issue details.
+
+## Modes
+
+### Interactive Mode (default)
+
+The full workflow below with approval gates at Phase 0 (review plan) and before any fix. Use `AskUserQuestion` (load it via SearchExtraTools first) when a decision is needed; report obvious findings (broken links, formula errors) directly.
+
+### Solo Mode (`--solo`)
+
+Non-interactive, for CI pipelines and headless invocation. Skips all approval gates, never prompts, and never calls AskUserQuestion:
+
+- Phase 0 runs metadata probing only — no plan is printed and no approval is requested
+- `--format fix` applies only safe mechanical fixes automatically (link-text repairs, filler-word replacements, echo-title removals, trailing newlines); anything requiring judgment is reported as unfixed
+- Writes the full report to stdout; `--output <file>` also saves it
+- Always ends with the machine-readable `MD-REVIEW-SUMMARY` block so CI can parse the result
+- Exit codes: `0` = review completed with no P0 (blocking) issues and overall score ≥ `--pass-threshold`; `1` = review completed but P0 issues exist or the score is below the threshold; `2` = error (missing file, invalid arguments)
+
+## Workflow
+
+Core principle: **review phases are read-only**. Files change only after user approval in interactive mode, or in solo mode with `--format fix` — and always after a fix plan is presented (the fix-plan approval is skipped only in solo mode).
+
+### Phase 0: Path Gate & Review Plan (all modes)
+
+1. **Path-argument gate FIRST (all modes)** — run `python3 <skill-dir>/scripts/validate_path.py <path>`; it is the single entry gate and rejects directories, missing files, non-`*.md` files, and binary/undecodable content with a clear stderr message and exit `2`. Proceed only if it exits `0`. Do not run any probe or script before this gate.
+2. **Metadata probing** (without a full read): run `python3 <skill-dir>/scripts/probe.py <file>`
+3. Print the review plan and wait for approval (interactive only): load example/review-plan.md, fill it in with the probe results, and present it
+
+**In solo mode, the gate and probing still run, but no plan is printed and no approval is requested — go straight to Phase 1.**
+
+After approval, continue to Phase 1. If the user asks for adjustments (e.g. "logic only"), update the plan and continue.
+
+### Phase 1: Initial Understanding
+
+1. **Resolve the scenario and remaining flags**
+2. **Classify the document** — read the first 10 lines / frontmatter to guess the type (by content, not by file path); if no scenario was given, try to infer it (SCQA, user stories, interface definitions, architecture diagrams, ...)
+3. **Structural analysis** — run `python3 <skill-dir>/scripts/analyze_structure.py <file>` for lines/words/tokens, heading-level distribution, code-block languages, tables/links/images counts, TODO/FIXME markers, and heading skips (H1→H3); then read the document and check for orphan headings
+
+### Phase 2: Single-Document Scope
+
+Review the single document directly across all 6 dimensions in Phase 3. Do **not** recursively follow links out of the reviewed document to review other files — reference links are verified for correctness only (target existence, anchors), never followed as review subjects.
+
+### Phase 3: Dimension-by-Dimension Review
+
+Run the 6 dimensions on the single document. **Load each dimension rule file when running its dimension (the `Rules:` line below); the scenario checklists are read only when that scenario is reviewed.**
+
+#### 1. Logic — bug detection (30%, generic)
+
+The core dimension. Focus on bugs that would make implementation wrong:
+
+- **Formula errors**: undefined variables, inconsistent units, ambiguous evaluation order, division by zero
+- **Number contradictions**: same parameter with different values, unit conversion errors, percent vs. multiplier confusion
+- **Missing edge cases**: null/zero/negative/extreme values, timeout/retry, concurrency conflicts, data-volume limits
+- **Broken flows**: data flow without source or sink, unreasonable operation order, circular dependencies, dead branches
+- **Interface inconsistencies**: the same interface with conflicting parameters/returns/error codes across sections
+- **Logical fallacies**: causal jumps, overgeneralization, false dichotomy, circular reasoning
+
+Rules: @./references/logic-rules.md
+
+#### 2. Scenario completeness (25%, scenario-specific)
+
+Load the checklist for the scenario and verify every required item, both presence and quality. Each checklist contains "Core Questions" (what editors must address) and "Key Focus". Required content per scenario:
+
+**Report every checklist item individually.** An item that is absent or under-specified must appear as its own entry in the Missing Scenario Content section — do not merge several thin items into one row (e.g. folding an incomplete Physical View into "scalability content") just because the document also has larger P0 defects. Placeholder markers in the source ("no further details", "TBD", "to be defined", "lorem ipsum") count as under-specified.
+
+- **PRD**: requirement list (unique IDs) / user stories / business rules / quantifiable acceptance criteria / 5W1H
+- **ADR**: context / decision / rationale / at least 2 rejected alternatives / consequences / impact scope
+- **ADD**: module list / system layers / data flow / deployment topology / non-functional requirements / tech-stack compatibility
+- **API**: endpoint contracts / error-code list / auth method / runnable examples
+- **BRD**: business value / ROI data / cost estimates / external risks / success metrics
+- **MRD**: market analysis / real research-backed personas / competitor differentiation / timing window
+- **FSD**: atomic function list / inputs-outputs / business rules / state diagrams / edge cases
+- **GDD**: core experience / core-loop visualization / system rule interactions / core mechanics list
+- **GDO**: executive summary / core concept (1-2 pages) / design pillars / USP / target audience & platform
+- **TDD**: technical spec translation / system architecture / tech-stack alignment / coding standards / performance goals
+- **LDD**: level list / layout / player path / challenge pacing / metrics / interactive element list
+- **Concept**: concept appeal / market potential / competitor analysis / go-no-go rationale / core selling points
+- **TLD**: task decomposition granularity / dependencies / effort estimates / owners & acceptance criteria / task list
+- **TCD**: positive / boundary / exception coverage / preconditions / verifiable expected results / requirement traceability / test case set
+
+Checklists: load the matching file under references/scenarios/ (prd.md / adr.md / add.md / api.md / brd.md / mrd.md / fsd.md / gdd.md / gdo.md / tdd.md / ldd.md / concept.md / tld.md / tcd.md)
+
+#### 3. Sections (15%, generic)
+
+Context first ("why" before "what"), basic structure (title / overview / progression / conclusion), doc-type required sections, SCQA (for technical proposals), incomplete markers (TODO / TBD / empty sections — **undefined terms and missing edge-case explanations are bug sources**).
+
+Rules: @./references/completeness-rules.md
+
+#### 4. References (10%, generic)
+
+Run `python3 <skill-dir>/scripts/extract_refs.py <file>` first; then check internal links (do the target files/anchors/images exist), external links (URL format / placeholders / text match), link quality (descriptive text, links inside headings, duplicates), version consistency. Reference targets are verified for existence/anchors only — never reviewed as review subjects.
+
+Rules: @./references/reference-rules.md
+
+#### 5. Redundancy (10%, generic)
+
+Word-level redundancy (filler words / hedges / overuse), structural redundancy (echo headings / repeated intros / repeated examples / mergable sections), semantic duplication (>80% similar paragraphs), over-detail (copied install instructions, explained common sense, irrelevant content), decorative elements (excess emoji / dividers), token optimization, reader-focused writing (preamble/closers, tangents, over-long lists, vague estimates, buried actions).
+
+Rules: @./references/redundancy-rules.md
+
+#### 6. Format (10%, generic)
+
+Only rendering-critical and structural issues; detailed linting is the editor's job: unclosed fenced code blocks, unclosed inline code, heading-level skips, multiple H1s, step-numbering breaks in ordered lists (1,2,4 gaps / duplicates), incomplete link syntax.
+
+Rules: @./references/format-rules.md
+
+### Phase 4: Report Generation
+
+#### Weighted scoring (100-point scale)
+
+**Overall = Logic×0.30 + Scenario completeness×0.25 + Sections×0.15 + References×0.10 + Redundancy×0.10 + Format×0.10** — compute it with `python3 <skill-dir>/scripts/score.py <d1> <d2> <d3> <d4> <d5> <d6> [--p0 N]` (validates 0-100 and outputs grade + risk; `--p0` is the P0 issue count)
+
+| Overall | Grade | Action |
+|---|---|---|
+| 90-100 | Excellent | Ready to publish; minor polish only |
+| 75-89 | Good | Fix P0/P1, then publish |
+| 60-74 | Passing | Must fix P0 (bug-level) before re-review |
+| < 60 | Failing | Rewrite or restructure recommended |
+
+**Risk level**: Low (≥80 and no P0) / Medium (60-79 or few P0) / High (40-59 or multiple P0) / Critical (<40 or a blocking bug)
+
+#### Report template
+
+Load example/report-full.md and fill it in (its in-template notes mark what to omit in generic mode).
+
+### Phase 5: Output & Handoff
+
+1. **Review summary table**: load example/summary-table.md and fill it in
+
+2. **Handoff block** (for downstream tools):
+
+```
+MD-REVIEW-SUMMARY
+File: <doc> | P0 bugs: N | Scenario gaps: N | Fixable: N | Generated: {timestamp}
+```
+
+   Field semantics (CI contract): `P0 bugs` = blocking/bug-level issue count; `Scenario gaps` = missing/under-specified scenario-checklist items; `Fixable` = issues that carry a concrete fix suggestion in the report (mechanical or judgmental). The `--format fix` Auto-Fix Summary separately reports `Fixed: X | Could not auto-fix: Y` (mechanical fixes applied vs. left for judgment) — `Fixable` counts suggestions, not applied fixes.
+
+   The `MD-REVIEW-SUMMARY` block must be the **last line of the output**: when `--output` is used, append it as the final line of the written file too (the report template ends with it), and repeat it in the stdout handoff.
+
+3. **JSON output** (when the user appends `json`): emit machine-readable `{doc, scenario, scores, weights, overall, risk, issues[]}` during the initial run (parameter-driven). If the user later asks for the review in another format in-session, re-emit from the already-computed scores without re-running — see Phase 6 "Regenerate output".
+
+4. **Output self-check** (mandatory): after writing the report with `--output`, verify the written file is the complete report — it contains the sections filled from example/report-full.md (omitting only what generic mode marks to omit) and its last non-empty line is the `MD-REVIEW-SUMMARY` block. If the write failed (permission/disk error) or the file is incomplete, retry the write once; if it still fails, print the full report to stdout and state explicitly that `report.md` was not written. Never leave a partial or placeholder file as the artifact.
+
+### Phase 6: Follow-Up & Re-review
+
+The report is a starting point, not an endpoint. Handle these follow-ups:
+
+1. **Explain findings** — the user asks "why is this a bug?" or "why did dimension Y score low?": answer with the original text as evidence and the concrete impact; no re-run needed.
+2. **Focused re-review** — the user fixed specific issues and asks to re-check: re-review only the changed sections or dimensions; list resolved issues and any new ones introduced by the fix.
+3. **Full re-review** — after significant edits, re-run the complete review and produce a **delta report**: before/after scores per dimension, and resolved / remaining / new issues.
+4. **Delta table** (for 2 & 3): load example/delta-table.md and fill it in
+
+5. **Regenerate output** — the user wants the same review in another format (summary / JSON / markdown table) after the initial run: re-emit from the already-computed scores/issues without re-running (distinct from the parameter-driven `json` flag in Phase 5, which emits during the initial run).
+
+Next steps after a review: fix P0 issues (see Fix Plan below), ask for a focused re-review of a dimension, or re-run `/md-review <path> <scenario>` after edits to track the score.
+
+## Fix Plan
+
+**Never modify the original without first presenting a fix plan and getting approval** — even in `--format fix` mode (solo mode is the exception: mechanical fixes only, applied directly and reported).
+
+Load example/fix-plan.md, fill it in, and present it.
+
+Only after approval, edit with Edit/Write. Mechanical fixes safe to auto-apply without per-item confirmation: link-text repairs, filler-word replacements, echo-title removals, trailing newlines. Mark auto-fixes with ✅ and show diffs; mark un-fixable items with ⚠️.
+
+## Error Handling
+
+- **Path validation (run `scripts/validate_path.py <path>` first)**: rejects directories, a missing file, a non-`*.md` extension, and binary/undecodable content — all with a clear stderr message and exit `2`
+- Missing file / binary file / non-UTF-8 encoding: the helper scripts (`probe.py` / `analyze_structure.py` / `extract_refs.py`) also handle these themselves: missing or binary (NUL-containing) input → clear stderr message and exit `2`; non-UTF-8 text that decodes as latin-1 is processed normally
+- `extract_refs.py` failure: fall back to manual link checking
+- Invalid scenario value (not in the 14 scenarios): list the valid values and review as generic
+
+Solo-mode exit codes (CI gate): `0` = no P0 and score ≥ `--pass-threshold`; `1` = P0 issues exist or score below threshold; `2` = error (missing file, invalid arguments, undecodable input).
+
+## Reference Files
+
+- `references/logic-rules.md` — logic consistency (bug detection) rules — load when running dimension 1 (Logic)
+- `references/completeness-rules.md` — section completeness rules — load when running dimension 3 (Sections)
+- `references/reference-rules.md` — reference correctness rules — load when running dimension 4 (References)
+- `references/redundancy-rules.md` — redundancy detection rules — load when running dimension 5 (Redundancy)
+- `references/format-rules.md` — format rules (rendering-critical only) — load when running dimension 6 (Format)
+
+## Scenario Checklists
+
+- `references/scenarios/prd.md` — Product Requirements Document
+- `references/scenarios/adr.md` — Architecture Decision Record
+- `references/scenarios/add.md` — Architecture Design Description
+- `references/scenarios/api.md` — API Document
+- `references/scenarios/brd.md` — Business Requirements Document
+- `references/scenarios/mrd.md` — Market Requirements Document
+- `references/scenarios/fsd.md` — Functional Specification Document
+- `references/scenarios/gdd.md` — Game Design Document
+- `references/scenarios/gdo.md` — Game Overview Document
+- `references/scenarios/tdd.md` — Technical Design Document
+- `references/scenarios/ldd.md` — Level Design Document
+- `references/scenarios/concept.md` — Concept Design Document
+- `references/scenarios/tld.md` — Task List Document
+- `references/scenarios/tcd.md` — Test Case Document
+
+## Helper Scripts
+
+- `scripts/validate_path.py` — path-argument gate: validates the target is a single `*.md` file (rejects missing/non-md/binary; exit 2) — run FIRST in Phase 0 (all modes)
+- `scripts/probe.py` — metadata probe: lines / words / est. tokens / heading outline / preview (Phase 0)
+- `scripts/analyze_structure.py` — structural analysis: heading levels, code-block languages, tables/links/images, TODO/FIXME, heading skips (Phase 1)
+- `scripts/extract_refs.py` — extract and classify reference links (target existence is verified manually, used in dimension 4)
+- `scripts/score.py` — weighted scoring: overall score, grade, risk, 0-100 validation (Phase 4)
+
+## Templates
+
+- example/review-plan.md — Phase 0 review plan
+- example/report-full.md — Phase 4 full report
+- example/summary-table.md — Phase 5 summary table
+- example/delta-table.md — Phase 6 delta table
+- example/fix-plan.md — Fix Plan

--- a/agent_skills/md-review/example/delta-table.md
+++ b/agent_skills/md-review/example/delta-table.md
@@ -1,0 +1,8 @@
+# Re-review Delta Table Template
+
+Used in Phase 6 (focused or full re-review) to compare before/after scores, resolved / remaining / new issues.
+
+| Dimension | Before | After | Δ | Resolved | Remaining | New |
+|---|---|---|---|---|---|---|
+| 1. Logic | 60 | 82 | +22 | 3 | 1 | 1 |
+| Overall | 68.5 | 85.2 | +16.7 | - | - | - |

--- a/agent_skills/md-review/example/fix-plan.md
+++ b/agent_skills/md-review/example/fix-plan.md
@@ -1,0 +1,20 @@
+# Fix Plan Template
+
+Present before any modification, and wait for approval (solo mode: mechanical fixes only, applied directly and reported).
+
+## Fix Plan
+
+### Fix List
+
+| # | Original issue | Fix action | File | Risk |
+|---|---|---|---|---|
+| 1 | Broken link ../design/overview.md | Update path or remove | <file> | Low |
+| 2 | Formula division by zero | Add a zero-value branch | <file> | Medium (confirm) |
+| 3 | Missing test cases | Add core-mechanic cases | <file> | Medium (confirm) |
+
+### Execution Order
+
+1. P0 bugs → scenario gaps → P1 → P2; verify readability after each group
+2. Re-review the affected dimensions after fixing; user confirms
+
+Approve this fix plan? (reply y to execute, or tell me what to adjust)

--- a/agent_skills/md-review/example/report-full.md
+++ b/agent_skills/md-review/example/report-full.md
@@ -1,0 +1,75 @@
+# Full Review Report Template
+
+Fill in this template during Phase 4. Generic mode (no scenario): omit the "Missing Scenario Content" section and the "2. Scenario completeness" row (that dimension is skipped and scored 100) — the in-template notes mark these.
+
+# MD Review Report
+
+## Basic Info
+
+- **Document**: <path> | **Scenario**: [PRD/.../Generic] | **Size**: X lines / X words / ~Y tokens
+- **Overall**: X/100 | **Risk**: [Low/Medium/High/Critical]
+
+## Executive Summary
+
+3-5 sentences on document quality: main strengths, key defects (bug-level issues and scenario gaps first), publish recommendation.
+
+## Bug-Level Issues (P0, may break downstream implementation)
+
+| # | Type | Location | Description | Fix | Impact |
+|---|---|---|---|---|---|
+| 1 | 🔴 Formula error | line 45 | Division by zero unhandled | Add a zero-value branch | Runtime crash |
+
+## Missing Scenario Content ({scenario} required items)
+
+| # | Missing item | Note | Suggestion |
+|---|---|---|---|
+| 1 | Test cases | Core mechanic has no executable tests | Add input → expected-output cases |
+
+> Generic mode (no scenario): omit this section entirely.
+
+## Issue Summary
+
+| # | Level | Dimension | Location | Description | Suggestion | Impact |
+|---|---|---|---|---|---|---|
+| 1 | 🔴 Error | Logic | line 45 | Contradictory parameters | Unify defaults | May cause... |
+
+Levels: 🔴 Error (must fix) / 🟡 Warning (should fix) / 🟢 Suggestion (optional)
+
+## Dimension Scores
+
+| Dimension | Weight | Score | Weighted | Issues | Severe |
+|---|---|---|---|---|---|
+| 1. Logic | 30% | 60 | 18.0 | 5 | 2 (bug-level) |
+| 2. Scenario completeness | 25% | 70 | 17.5 | 3 | 1 |
+| 3. Sections | 15% | 80 | 12.0 | 2 | 0 |
+| 4. References | 10% | 50 | 5.0 | 4 | 1 |
+| 5. Redundancy | 10% | 70 | 7.0 | 3 | 0 |
+| 6. Format | 10% | 90 | 9.0 | 1 | 0 |
+| **Overall** | 100% | - | **68.5** | **18** | **4** |
+
+> Generic mode (no scenario): omit the "2. Scenario completeness" row (the dimension is skipped and scored 100).
+
+## Top 5 Issues
+
+1. [most severe issue, one sentence] ...
+
+## Detailed Issue List
+
+Each issue must include: location (line or section), original text (evidence), level, dimension, description, fix suggestion, impact.
+
+## Fix Priority
+
+**P0 (bug-level / scenario gaps, must fix)**: ... | **P1 (strongly recommended)**: ... | **P2 (optional)**: ...
+
+## Highlights (optional)
+
+[Notable strengths; stay constructive]
+
+## Auto-Fix Summary (--format fix)
+
+- Fixed: X | Could not auto-fix: Y (needs judgment)
+
+---
+
+MD-REVIEW-SUMMARY
+File: <doc> | P0 bugs: N | Scenario gaps: N | Fixable: N | Generated: {timestamp}

--- a/agent_skills/md-review/example/review-plan.md
+++ b/agent_skills/md-review/example/review-plan.md
@@ -1,0 +1,30 @@
+# Review Plan Template
+
+Fill in this template during Phase 0 and present it for approval (interactive mode only). In solo mode, do not print it.
+
+## Review Plan
+
+### 1. Document Overview
+
+- **Document**: <path> | **Lines**: X | **Est. tokens**: ~Y
+- **Scenario**: [PRD / ADR / ADD / API / BRD / MRD / FSD / GDD / GDO / TDD / LDD / Concept / TLD / TCD / Generic]
+- **Type guess**: [based on content features]
+
+### 2. Dimensions & Priority
+
+| Dimension | Weight | Priority | Expected risk |
+|---|---|---|---|
+| Logic (bug detection) | 30% | P0 | High |
+| Scenario completeness | 25% | P0 | High |
+| Sections | 15% | P0 | Medium |
+| References | 10% | P1 | Medium |
+| Redundancy | 10% | P2 | Low |
+| Format | 10% | P2 | Low |
+
+### 3. Risk Warnings
+
+- This review never modifies the original document; it only produces a report
+- Documents over 500 lines are reviewed in segments (each ≤300 lines); cross-segment issues may be missed
+- External link checks depend on network access and may false-positive
+
+Approve this review plan? (reply y to continue, or tell me what to adjust)

--- a/agent_skills/md-review/example/summary-table.md
+++ b/agent_skills/md-review/example/summary-table.md
@@ -1,0 +1,15 @@
+# Review Summary Table Template
+
+Used in Phase 5 for the single-document review (step 1). Weighted per-dimension scores and the overall.
+
+| Dimension | Weight | Score | Weighted | Issues | Severe |
+|---|---|---|---|---|---|
+| 1. Logic | 30% | 75 | 22.5 | 5 | 2 (bug-level) |
+| 2. Scenario completeness | 25% | 80 | 20.0 | 3 | 1 |
+| 3. Sections | 15% | 90 | 13.5 | 2 | 0 |
+| 4. References | 10% | 60 | 6.0 | 4 | 1 |
+| 5. Redundancy | 10% | 80 | 8.0 | 3 | 0 |
+| 6. Format | 10% | 95 | 9.5 | 1 | 0 |
+| **Overall** | 100% | - | **79.5** | **18** | **4** |
+
+> Generic mode (no scenario): omit the "2. Scenario completeness" row (the dimension is skipped and scored 100).

--- a/agent_skills/md-review/references/completeness-rules.md
+++ b/agent_skills/md-review/references/completeness-rules.md
@@ -1,0 +1,145 @@
+# Completeness Rules — Detailed Rules for Content Completeness
+
+## Document Type Classification
+
+First determine the document type; different types have different completeness standards:
+
+| Document type | Typical characteristics | Applicable standard |
+|---|---|---|
+| **Requirements doc** | Describes what to build, user flows, acceptance conditions | Requirements standard |
+| **Technical proposal / RFC** | Describes technical decisions, architecture options, trade-off analysis | Proposal standard |
+| **Design doc** | Describes system design, interface definitions, data flow | Design standard |
+| **Tutorial / Guide** | Guides the user through operational steps | Tutorial standard |
+| **Reference doc** | API reference, configuration instructions, spec definitions | Reference standard |
+| **General description** | Doesn't fit the above | General standard |
+
+## General Completeness Standard (applies to all types)
+
+### Basic Structure
+
+- [ ] **Title**: a clear and unique H1 title (MD025)
+- [ ] **Overview**: the first 1-3 paragraphs state the document's purpose and scope
+- [ ] **Logical progression**: sections ordered by the reader's comprehension sequence
+- [ ] **Conclusion/Summary**: the document has a clear ending (not required but recommended)
+
+### Content Depth
+
+- [ ] Every point fully elaborated (no fewer than 2 sentences)
+- [ ] Key concepts and terms defined at first occurrence
+- [ ] Every section has a clear reason to exist
+- [ ] No "orphan paragraphs" (paragraphs unrelated to the rest)
+
+### Completion Markers
+
+Scan for these markers:
+
+- [ ] Incomplete markers: "TODO", "FIXME", "HACK", "TBD", "WIP"
+- [ ] Empty section headings (heading with no content after it)
+- [ ] Placeholder text (e.g., "lorem ipsum")
+
+## System Design Document Standard (10 required sections)
+
+> Applies to system-level design documents (full architecture, multiple modules). For module-level or single-system designs, use the [Design Document Standard](#design-document-standard) below instead.
+
+- [ ] **Background and Goals**: why? what problem does it solve?
+- [ ] **Scope Definition**: In-Scope / Out-of-Scope
+- [ ] **Overall Architecture**: system topology diagram, core components, interaction relationships
+- [ ] **Module Design**: each module's responsibility, input, output, dependencies
+- [ ] **Interface Design**: API definitions, parameters, return values, error codes
+- [ ] **Data Model**: ER diagram, key table structures, data flow
+- [ ] **Deployment Architecture**: environment division, service topology, resource configuration
+- [ ] **Non-Functional Requirements**: performance, security, availability, scalability metrics
+- [ ] **Risk Assessment**: technical risks, business risks, mitigation plans
+- [ ] **Milestones**: implementation plan, acceptance criteria
+
+## PRD Standard
+
+The authoritative PRD required-content checklist lives in `references/scenarios/prd.md` — load it when reviewing with scenario `prd` and use its deduction scale. Do not apply a different scale here. For quick reference, the required sections are: Requirements Background, User Stories / Use Cases, Feature List, Flow / Sequence Diagrams, Data Requirements, Acceptance Criteria, Release Plan.
+
+## API Document Standard
+
+The authoritative API required-content checklist lives in `references/scenarios/api.md` — load it when reviewing with scenario `api` and use its deduction scale. Do not apply a different scale here. For quick reference, the required sections are: Interface Overview, Authentication, Request/Response Format, Error Code Definitions, Examples, Change Log.
+
+## Requirements Document Standard
+
+Applies to generic requirements documents that do not match the PRD scenario (e.g., plain requirement specs without product framing). For product requirements, use the PRD Standard above / `references/scenarios/prd.md`.
+
+### Required Sections
+
+- [ ] **Background and Goals**: why this requirement is needed
+- [ ] **Users/Roles**: which roles are involved
+- [ ] **Key Flows**: core user flows or feature flows
+- [ ] **Acceptance Examples**: concrete acceptance conditions and examples
+- [ ] **Open Questions**: record unresolved issues
+
+### Content Completeness Checks
+
+- [ ] Each requirement has a unique number (R1, R2...)
+- [ ] Each flow has a happy path and an exception path
+- [ ] Acceptance conditions testable (QA can clearly determine pass/fail)
+- [ ] Priority marked (P0/P1/P2 or must-have/should-have)
+- [ ] Edge cases considered
+
+## Technical Proposal / RFC Document Standard
+
+Uses the SCQA framework:
+
+### SCQA Structure
+
+- [ ] **Situation**: the current technical background and context clearly described
+- [ ] **Complication**: the problem or deficiency of the current solution clearly stated
+- [ ] **Question**: the core question to be resolved posed
+- [ ] **Answer**: a clear solution or recommendation given
+
+### Additional Requirements
+
+- [ ] Multiple options compared (at least the rejected ones mentioned)
+- [ ] Implementation plan present
+- [ ] Migration/rollback plan present (if applicable)
+- [ ] Impact on other systems considered
+- [ ] Performance/security/compliance considerations
+
+## Design Document Standard
+
+> Applies to module-level or single-system design documents. For full system architecture designs, use the [System Design Document Standard](#system-design-document-standard-10-required-sections) above.
+
+### Required Sections
+
+- [ ] **Overview**: one-sentence description of the module's responsibility
+- [ ] **Interface Definition**: type signatures / function signatures / API definitions
+- [ ] **Data Flow**: complete chain of input → processing → output
+- [ ] **Edge Cases**: strategies for null values, errors, concurrency conflicts
+- [ ] **Tuning Knobs**: configurable parameter names, defaults, impact scope
+
+### Content Depth
+
+- [ ] Interface definitions include input/output types
+- [ ] Data flow diagram or sequence diagram (if necessary)
+- [ ] Bidirectional dependency declaration (A depends on B, B's doc mentions A)
+- [ ] Verification/testing strategy
+
+## Tutorial / Guide Standard
+
+- [ ] **Prerequisites**: what the reader needs to prepare
+- [ ] **Steps**: numbered and executable operation steps
+- [ ] **Examples**: key steps have copyable commands or code
+- [ ] **Expected Output**: lets the reader confirm success
+- [ ] **Troubleshooting**: solutions for common problems
+
+## Reference Document Standard
+
+- [ ] **Completeness**: covers all relevant configuration/API/parameters
+- [ ] **Examples**: every configuration item or API has a usage example
+- [ ] **Defaults**: all defaults marked
+- [ ] **Value Ranges**: valid ranges for parameters
+
+## Scoring Guide
+
+| Finding | Deduction |
+|---|---|
+| Missing overview | -2 |
+| Missing required sections (per document type) | -1 each |
+| Incomplete markers (TODO/TBD) | -1 each |
+| Key terms undefined | -1 each |
+| Single-sentence paragraphs (need expansion) | -0.5 each |
+| No conclusion/summary | -1 |

--- a/agent_skills/md-review/references/format-rules.md
+++ b/agent_skills/md-review/references/format-rules.md
@@ -1,0 +1,35 @@
+# Format Rules — Detailed Rules for Format (Basic Checks Only)
+
+This dimension carries only 10% of the overall weight. Detailed linting (item-by-item MD spec checks) is handled by the editor's linting tooling (e.g., a VS Code extension, if installed); this file covers only **formatting issues that affect rendering correctness** (readability issues are handled by external tooling and are not checked here).
+
+## Rendering-Critical Formatting Issues (must report)
+
+### Headings
+- Heading-level skips (H1 → H3 skipping H2) — affects document structure comprehension and table-of-contents generation
+- Multiple H1 headings (the document title should be the unique H1)
+- No blank line before/after headings (may be parsed as body text)
+
+### Code Blocks
+- Unclosed fenced code blocks (opening/closing backtick counts differ) — subsequent content may be swallowed into the code block
+- Unclosed inline code (single backtick) — affects rendering
+
+### Numbered Lists (step-numbering breaks)
+- **Gap in a contiguous ordered list** (1, 2, 4): a step number is skipped — in procedures (test steps, build steps, process flows) this usually means a step was deleted or forgotten; flag it
+- **Duplicate number in a contiguous ordered list** (1, 2, 2, 3): numbering error in the source
+- **Do NOT flag** (precision): a new list that legitimately restarts at 1 after a reset boundary (blank line, heading, table, or code block); identifier-style numbers (T-1, TC-1, REQ-001) are not ordered lists; single-item lists
+- A step-numbering gap in a **semantic procedure** (test steps, build/deploy steps, process flows) should ALSO be reported under Logic as a broken/missing step — the gap often hides a deleted or forgotten step
+
+### Links and Images
+- Incomplete `[text](url)` syntax (missing parentheses)
+- Relative paths not starting with `./` or `../` (likely wrong paths)
+
+## Scoring Guide (format dimension, out of 100)
+
+| Finding | Deduction |
+|---|---|
+| Heading-level skip | -5 per occurrence |
+| Multiple H1s | -10 |
+| Step-numbering break (gap or duplicate) in an ordered list | -3 per occurrence |
+| Incomplete link syntax | -5 per occurrence |
+
+Format dimension floor: as long as a rendering-level error exists (unclosed code block), the format score cannot exceed 60; only minor issues score 80-95.

--- a/agent_skills/md-review/references/logic-rules.md
+++ b/agent_skills/md-review/references/logic-rules.md
@@ -1,0 +1,149 @@
+# Logic Rules — Detailed Rules for Logical Consistency (Bug Detection)
+
+This dimension carries 30% weight and is the core of md-review. **Prioritize finding bugs that would break downstream implementation** rather than pure style issues.
+
+## Bug-Level Detection Checklist (P0, must report)
+
+Mark all of the following as 🔴 Error, because they can break the implementation code:
+
+### Formula and Calculation Errors
+- [ ] Are all variables in formulas defined? (undefined variables = the implementer cannot code)
+- [ ] Are formula units consistent? (e.g., mixing seconds vs. milliseconds)
+- [ ] Is the evaluation order unambiguous? (missing parentheses)
+- [ ] Can the divisor be zero? (division by zero = runtime crash)
+- [ ] Can formula results fall outside the expected range? (overflow/underflow)
+- [ ] Do formulas match their prose description? (text says A, formula computes B)
+
+### Number and Parameter Contradictions
+- [ ] Does the same parameter have different values in different sections? (defaults / maximums / thresholds / cooldowns)
+- [ ] Unit conversion errors? (e.g., "1.5x" written as "150%x" with different meanings)
+- [ ] Percent vs. multiplier mixing? ("increase by 20%" vs. "multiply by 1.2" differ semantically)
+- [ ] Boundary value contradictions? ("max 100" conflicting with an example "101")
+- [ ] Version numbers / dependency versions inconsistent across locations
+
+### Missing Edge Conditions (bug hotbed)
+- [ ] Are null/None/empty lists handled?
+- [ ] Are zero/negative/over-limit inputs handled?
+- [ ] Are timeouts explicitly defined? (timeout duration, retry count, backoff strategy)
+- [ ] Is there a concurrency conflict strategy? (optimistic lock / pessimistic lock / version number)
+- [ ] Are data-volume limits stated? (per table / per request / concurrent connections)
+- [ ] Are exception paths described? (failure behavior, not just the success path)
+- [ ] Does every mechanism/feature state its boundary behavior where it is introduced? (a feature that depends on an unstated rule — e.g. a respawn feature with no death/failure rule, a continue feature with no state-restoration rule — cannot be implemented and is a P0 bug source)
+- [ ] Do scalability assumptions ("scale horizontally later", "support X in the future") have reserved interfaces or explicit unimplemented markers?
+
+### Flow and State Errors
+- [ ] Is the operation order reasonable? (auth before business logic, validation before persistence)
+- [ ] Is the data flow closed-loop? (input → process → output → storage, nothing appearing/disappearing)
+  - [ ] Does every data flow have a clear source and sink?
+  - [ ] Are data transformation steps traceable? (input → process → output → storage)
+  - [ ] Does data "appear from nowhere"? (output without a stated source)
+  - [ ] Does data "disappear without a trace"? (input without a stated destination)
+  - [ ] Is every step of the data flow covered by a document section?
+- [ ] Are there circular dependencies? (A depends on B, B depends on A)
+- [ ] Are state transitions missing from the state machine? (state X unreachable from state Y)
+- [ ] Dead branches / unreachable logic
+- [ ] Do async operations have callbacks/notifications? (no callback = hang)
+- [ ] Do concurrent operations have explicit ordering guarantees or conflict handling?
+
+### Interface Definition Conflicts
+- [ ] Are the same interface's parameters / return values / error codes consistent across sections?
+- [ ] Do interface parameters cover all required fields?
+- [ ] Is the error code definition complete? (success / failure / partial success)
+- [ ] Is backward compatibility considered for interface changes?
+
+## Internal Consistency Checks
+
+### Terminology Consistency
+- [ ] Is the same concept named consistently throughout? (e.g., "login" and "sign-in" used interchangeably for the same thing)
+- [ ] Are abbreviations expanded on first use?
+- [ ] Is capitalization of proper nouns consistent?
+- [ ] Is the same feature described consistently across locations?
+- [ ] Do proper nouns give their full name and abbreviation on first appearance? (e.g., "React (a UI library by Facebook)")
+- [ ] Is English terminology capitalization unified? (e.g., "MySQL" not mixed "mysql"/"Mysql")
+
+### Data Consistency
+- [ ] Are numbers/values consistent across locations?
+  - Example: one place says "supports 100 concurrent connections", another says "supports 1000"
+- [ ] Is the timeline self-consistent?
+  - Example: A is released in May, but B (which depends on A) was completed in March
+- [ ] Are default values consistent across locations?
+- [ ] Are limits/constraints consistent across locations?
+
+### Behavior Consistency
+- [ ] Is the judgment logic for the same condition consistent?
+- [ ] Is error handling consistent?
+- [ ] Is permission control described consistently?
+
+## Logical Fallacy Detection
+
+### Causal Fallacy
+- **Signature**: B happened after A, therefore A caused B
+- **Example**: "User growth increased 50% after we deployed the new version, so the new version drove the growth"
+- **Check**: Are there other factors that could explain the result?
+
+### Overgeneralization
+- **Signature**: Generalizing from a limited sample to a universal conclusion
+- **Example**: "Two users reported this issue, so all users have it"
+- **Check**: Is the sample size sufficient? Are there counterexamples?
+
+### False Dichotomy
+- **Signature**: Offering only two options, ignoring other possibilities
+- **Example**: "We either use microservices or stay on a monolith"
+- **Check**: Is there a third or further option?
+
+### Circular Reasoning
+- **Signature**: The conclusion appears as a premise
+- **Example**: "This solution is good because it is best practice; it is best practice because this solution is good"
+- **Check**: Is the argument's conclusion assumed as a premise?
+
+### Slippery Slope
+- **Signature**: Accepting A inevitably leads to Z, skipping the intermediate argumentation
+- **Example**: "If we allow remote work, the team will completely fall apart"
+- **Check**: Is every step from A to Z reasonably argued?
+
+### Appeal to Authority
+- **Signature**: Relying solely on the word of an authority figure/organization as evidence
+- **Example**: "The CEO thinks this solution is best"
+- **Check**: Is there substantive evidence besides the authority's opinion?
+
+### Straw Man
+- **Signature**: Distorting the opponent's view to make it easier to refute
+- **Example**: "Opponents think we shouldn't optimize performance → they think performance doesn't matter"
+- **Check**: Does the refuted view accurately represent the original?
+
+## Argument Quality Checks
+
+### Claims and Evidence
+- [ ] Does every important claim have sufficient supporting evidence?
+- [ ] Does the evidence come from reliable sources?
+- [ ] Are there unsourced assertions? ("according to statistics...", "research shows...")
+- [ ] Is the source of data/statistics clear?
+
+### Weak Argument Markers
+- Flag arguments that use these vague phrases:
+  - "As everyone knows..." — not everyone knows
+  - "Obviously..." — if it's not obvious, the phrase masks insufficient argumentation
+  - "It's not hard to see that..." — leaving the reader to conclude
+  - "One might say..." — a preamble to a straw man
+
+### Objections and Rebuttals
+- [ ] Are possible rebuttals considered?
+- [ ] Is there a response to known objections?
+- [ ] Are both "pros" and "cons" listed? (rather than only one side)
+
+## Convention Consistency
+
+- [ ] Does the document content conflict with declared conventions or standards referenced in the document set (e.g., style guides, interface contracts, process rules)?
+- [ ] Does the described practice match previously established decisions in the reviewed documents?
+
+## Scoring Guide
+
+| Finding | Deduction |
+|---|---|
+| Self-contradictory statements | -3 |
+| Terminology inconsistency | -1 per occurrence |
+| Data/number inconsistency | -2 per occurrence |
+| Logical fallacy | -2 each |
+| Unsourced assertion | -1 each |
+| Unconsidered rebuttal | -1 |
+| Vague statement (multiple interpretations) | -0.5 per occurrence |

--- a/agent_skills/md-review/references/redundancy-rules.md
+++ b/agent_skills/md-review/references/redundancy-rules.md
@@ -1,0 +1,180 @@
+# Redundancy Rules — Detailed Rules for Redundancy Detection
+
+## Word-Level Redundancy
+
+### Filler-Word Replacement Table
+
+Replace the following verbose phrases with concise versions:
+
+| Verbose phrase | Concise phrase | Tokens saved |
+|---|---|---|
+| "in order to" | "To" | 2 |
+| "due to the fact that" | "Because" | 4 |
+| "at this point in time" | "Now" | 4 |
+| "in the event that" | "If" | 3 |
+| "for the purpose of" | "To" / "For" | 3 |
+| "a large number of" | "Many" | 3 |
+| "in close proximity to" | "Near" | 3 |
+| "it is important to note that" | "Note:" | 5 |
+| "with the exception of" | "Except" | 3 |
+| "in spite of the fact that" | "Although" | 4 |
+| "on a regular basis" | "Regularly" | 2 |
+| "in the near future" | "Soon" | 3 |
+| "a majority of" | "Most" | 2 |
+| "are able to" | "Can" | 2 |
+| "is responsible for" | "Handles" / "manages" | 3 |
+
+### Unnecessary Hedges
+
+Flag these weakening qualifiers:
+
+- "very" — "very important" → "critical", "very large" → "massive"
+- "quite" — "quite useful" → just "useful"
+- "rather" — "rather complex" → just "complex"
+- "somewhat" — "somewhat difficult" → just "difficult"
+- "really" / "definitely" — usually deletable
+- "literally" — almost always redundant
+- "actually" — almost always redundant (unless emphasizing a contrast)
+- "basically" — "Basically, it works like this" → "It works like this"
+
+### Overuse Detection
+- Same word/phrase appearing 3+ times in one paragraph → flag
+- Same word/phrase appearing 7+ times on one page → suggest a synonym
+- Domain-specific terms excepted (e.g., API names can't be replaced)
+
+## Structural Redundancy
+
+### Echo Headings
+- **Definition**: a heading immediately followed by an explanatory sentence starting with "This section"
+- **Example**:
+  - `## Troubleshooting` + "This section describes troubleshooting steps"
+- **Fix**: delete the lead-in sentence; the heading already says it
+
+### Repeated Introductions
+- Multiple sections each re-introducing the same background knowledge → should be introduced once at the document start
+- Every chapter and section repeating the same context → explain once, in one place
+
+### Repeated Examples
+- 3 examples with 95% identical commands, differing only in parameters → merge into one example with a comment
+  ```markdown
+  # ❌ Redundant
+  az storage account create -n myaccount1 -g mygroup -l eastus
+  az storage account create -n myaccount2 -g mygroup -l eastus
+  az storage account create -n myaccount3 -g mygroup -l eastus
+
+  # ✅ Concise
+  az storage account create -n NAME -g mygroup -l eastus
+  # Examples: myaccount1, myaccount2, myaccount3
+  ```
+
+### Mergable Similar Sections
+- Adjacent sections with highly similar topics → consider merging
+- Example: `## Windows Installation`, `## macOS Installation`, `## Linux Installation`
+- Merge into `## Installation`, distinguishing with subsections or tabs
+
+## Semantic Duplication Checks
+
+### Duplicate Paragraphs
+- Same paragraph appearing > 1 time in the document → keep one, delete or reference the rest
+- Different sections expressing the same idea with different wording (>80% semantic similarity) → merge and unify the phrasing
+- Example code duplicating what the prose already explains → delete the duplicate
+
+### Over-Detail
+- Copied install instructions for a common library (should link to the official docs) → replace with a one-line link
+- Explained common-sense concepts (e.g., "what is a REST API", "what is a database") → delete, unless the target reader genuinely needs it
+- Generic best practices unrelated to the current system → delete or move to an appendix
+- "Filler statements" (correct but information-free, e.g., "this solution uses mature industry technology") → delete
+
+### Irrelevant Content
+- Paragraphs unrelated to the document topic → flag and suggest deletion
+- Leftover template placeholder text → mark as incomplete
+
+## Decorative Elements
+
+### Emoji Usage
+- **SHOULD**: no more than 3 decorative emoji
+- **Allowed**:
+  - Status indicators in tables (✅ ❌ ⚠️)
+  - Conveying actual meaning (not purely decorative)
+- **Not allowed**:
+  - Emoji around headings 🙅 → `# 🚀 Getting Started 🎉`
+  - Emoji at the start of every paragraph 🙅
+  - Multiple consecutive emoji 🙅
+
+### Dividers
+- Consecutive `---` dividers → two adjacent headings are already a natural break; no divider needed
+- **Suggestion**: only when emphasizing a topic switch, and no more than 1 per page
+
+## Reader-Focused Writing
+
+Readers have limited working memory and attention; documents that bury the action, pad with preamble, or wander into tangents lose them. These checks complement the redundancy rules above — they remove the same fluff from the reader's perspective.
+
+- [ ] **Action-first lead**: does the document put the actionable content first instead of an announcing opener? Flag openers like "In this document, we will...", "This section describes..."
+- [ ] **No closing pleasantries / recaps**: does it end with "Hope this helps", "Let me know if you have questions", or a full recap paragraph instead of stopping at the conclusion?
+- [ ] **No tangents**: are there "by the way" asides or secondary topics offered mid-document instead of a separate section or appendix?
+- [ ] **Lists capped at 5**: is any list over 5 items split into "do now" vs "later" (or ranked top 5) rather than one unranked wall?
+- [ ] **Specific time/effort estimates**: are vague "soon", "a while", "some work" replaced with concrete units ("~15 minutes", "1-2 hours")?
+- [ ] **Hedging without information**: are "perhaps", "might", "could possibly" deleted unless they carry real uncertainty?
+- [ ] **Literal over figurative**: are idioms ("circle back", "get the ball rolling") replaced with the literal action?
+- [ ] **Buried next step**: is the next action stated explicitly at the end rather than implied?
+
+## Token Optimization
+
+### Calculation Standard
+- Approximately 4 characters = 1 token (Chinese estimated by character count)
+- Report format: `current: X tokens | potential: Y tokens | savings: Z tokens (Z%)`
+
+### Large Content Handling
+| Content type | Suggestion | Threshold |
+|---|---|---|
+| Tables | move to a reference file | 10+ rows |
+| Code blocks | trim examples | 20+ lines |
+| Long lists | compress or split | 15+ items |
+| Inline docs | move to a reference file | 100+ lines |
+
+### Format Optimization
+- **List → table**: when list items have multiple attributes
+  ```markdown
+  # ❌ Verbose list
+  - Storage: min 3, max 24 chars, lowercase only, globally unique
+  - Key Vault: min 3, max 24 chars, alphanumeric + hyphens, globally unique
+
+  # ✅ Concise table
+  | Resource | Min | Max | Allowed | Global |
+  |----------|-----|-----|---------|--------|
+  | Storage | 3 | 24 | a-z, 0-9 | Yes |
+  | Key Vault | 3 | 24 | a-z, 0-9, - | Yes |
+  ```
+
+- **Code block → inline code**: single-line commands don't need a code block
+  ````markdown
+  # ❌ Code block
+  Run the server:
+  ```bash
+  npm start
+  ```
+
+  # ✅ Inline code
+  Run the server: `npm start`
+  ````
+
+## Scoring Guide
+
+| Finding | Deduction |
+|---|---|
+| Filler words (in order to, etc.) | -0.5 per occurrence |
+| Unnecessary hedges | -0.5 each |
+| Echo headings | -1 per occurrence |
+| Repeated examples (>90% identical) | -1.5 per group |
+| Decorative emoji (more than 3) | -0.5 each |
+| Redundant lead-in paragraphs | -1 per occurrence |
+| Mergable similar sections | -2 |
+| Large content that should move to references | -1 per occurrence |
+| Announcing openers / preamble paragraphs | -1 per occurrence |
+| Closing pleasantries / recap paragraphs | -1 per occurrence |
+| Tangents ("by the way" asides) | -1 per occurrence |
+| Lists over 5 items left ungrouped | -1.5 each |
+| Vague time/effort estimates | -1 per occurrence |
+| Hedging adverbs without information | -0.5 per occurrence |
+| Idioms replacing literal action | -0.5 per occurrence |
+| Buried next action | -1 per occurrence |

--- a/agent_skills/md-review/references/reference-rules.md
+++ b/agent_skills/md-review/references/reference-rules.md
@@ -1,0 +1,92 @@
+# Reference Rules — Detailed Rules for Reference Correctness
+
+## Check Method
+
+For each MD file, run `python3 <skill-dir>/scripts/extract_refs.py <file>` to extract and classify all reference patterns, then verify each one manually. If the script is unavailable, fall back to Grep to extract the patterns.
+
+### Reference Pattern Matching
+
+```
+# Internal links: [text](path/to/file.md) or [text](path/to/file.md#anchor)
+# Anchor links: [text](#anchor)
+# Image references: ![alt](path/to/image.png)
+# External links: [text](https://...)
+# Auto links: <https://...>
+# Reference links: [text][ref] and [ref]: url
+```
+
+## Internal Link Checks
+
+### File References
+- **MUST** `[text](relative-path.md)` — verify the target file exists
+- **MUST** `[text](relative-path.md#anchor)` — verify the target file exists and the anchor exists
+- **SHOULD** verify the reference path uses the correct relative base (relative between documents vs. project root path)
+
+### Anchor Verification
+- **MUST** `[text](#anchor)` — check whether a matching anchor exists in the same document
+- Anchor matching rule: GitHub-style anchor generation (lowercase, strip punctuation, spaces to hyphens)
+  - `## My Section` → `#my-section`
+  - `## API Reference (v2)` → `#api-reference-v2`
+- **SHOULD** check whether the referenced anchor is accurate (near-but-not-exact anchors may point to the wrong location)
+
+### Image References
+- **MUST** `![alt](path/to/image.png)` — does the image file exist?
+- **MAY** is the image size reasonable? (shouldn't reference a huge uncompressed image)
+
+## External Link Checks
+
+### URL Format
+- **MUST** is the URL format complete? (with `https://` or `http://` protocol header)
+- **MUST** no placeholder links: `[text]()` empty parentheses
+- **SHOULD** no spelling errors in `[text](url)` URLs
+- **SHOULD** URLs pointing to well-known sites use HTTPS
+
+### Link Text Quality
+- **MUST** no non-descriptive link text:
+  - ❌ "click here", "read more", "this page", "link"
+  - ✅ descriptive text, e.g., "view the installation guide", "see the API docs"
+- **SHOULD** link text match the URL content
+  - Example: link text says "Pricing details" but the URL slug is `/blog/technical-post` → mismatch
+- **SHOULD** no links inside headings (links in headings are hard to click and lose context when printed)
+
+### External Link Health (MAY)
+- If the environment allows, check link status with `curl -sI -o /dev/null -w "%{http_code}" <url>`
+- 200/301/302: normal; 4xx/5xx: abnormal
+- Note: this check is time-consuming; sample only in `--format full` mode
+
+## Cross-Reference Checks
+
+This skill reviews one document per invocation; only checks executable on that single document are listed here. Reference targets are verified for existence and anchors only.
+
+### Document Reference Completeness
+- [ ] Do the referenced file names exist? (target file present on disk)
+- [ ] Is the case of referenced file names correct? (case-sensitive file systems)
+- [ ] Do the referenced anchors/sections exist in the target file? (verified from the target file's heading outline only — never a full review of the target)
+- [ ] Are version-number references internally consistent within the document?
+
+### Duplicate References
+- [ ] Does the same link appear multiple times in the same file? (consider merging)
+- [ ] Do links to the same target use a consistent URL? (avoid multiple different URLs for the same target)
+
+### Version Consistency (within the document)
+- [ ] Is a version referenced in one section the same as the version stated elsewhere in the document? (cross-section contradiction = defect)
+- [ ] Does the architecture diagram version match the text description? (if applicable)
+- [ ] Flag versions the document itself marks as provisional, legacy, or outdated (e.g. "deprecated", "old version"); do NOT verify against external sources or the codebase
+
+### Internal Reference Completeness
+- [ ] Do the referenced section/figure numbers exist and are correct within the document?
+- [ ] Are the referenced interfaces/modules defined in the document?
+- [ ] Are the referenced config files/environment variables documented?
+
+## Scoring Guide
+
+| Finding | Deduction |
+|---|---|
+| Link points to a nonexistent file | -2 each |
+| Anchor doesn't exist in the target file | -1 each |
+| Image file doesn't exist | -2 each |
+| Placeholder link | -1 each |
+| "Click here"-style link text | -1 each |
+| Link text mismatches URL | -1 each |
+| Link inside a heading | -0.5 each |
+| Broken cross-reference | -2 each |

--- a/agent_skills/md-review/references/scenarios/add.md
+++ b/agent_skills/md-review/references/scenarios/add.md
@@ -1,0 +1,65 @@
+# ADD Scenario Checklist — Architecture Design Description
+
+Enabled when the scenario parameter is `add`. Checks whether the architecture design description document contains the following content and assesses its completeness.
+
+## Core Questions (editors must address)
+1. Are module inputs/outputs and dependency relationships clear?
+2. Does it cover non-functional requirements such as performance, security, and scalability?
+3. Is the chosen technology stack compatible with existing systems?
+
+## Key Focus
+System layering + data flow + deployment topology
+- Includes: **Module List** (a list of all subsystems/services)
+
+## Required Content (deduct if missing)
+
+### Architecture Views
+- [ ] **Logical View**: Are the system functional decomposition, module responsibilities, and interaction relationships described?
+- [ ] **Physical View**: Are the deployment topology and server/node distribution described? Report the view as INCOMPLETE when it is only a sentence or contains placeholder markers such as "no further details", "TBD", "to be defined" — do not fold a thin view into a different checklist item (e.g. scalability); list it explicitly
+- [ ] **Data View**: Are the data model, storage scheme, and data flows described?
+- [ ] **Interface View**: Are the internal and external interface definitions complete?
+
+### Architecture Elements
+- [ ] **Overall Architecture Diagram**: Is there an architecture diagram (ASCII/Mermaid/UML)?
+- [ ] **Module Design**: Are each module's responsibilities/inputs/outputs/dependencies explained?
+- [ ] **Interface Definitions**: Are API/service interface parameters, return values, and error codes complete?
+- [ ] **Data Flow**: Is the core data flow (input → processing → output → storage) closed-loop?
+- [ ] **Constraints and Assumptions**: Are technical constraints, business constraints, and assumptions declared?
+
+### Quality Attributes
+- [ ] **Quality Attribute Scenarios**: Are scenarios described for performance/availability/security/maintainability/scalability (stimulus → response → measure)?
+- [ ] **Reliability**: Single point of failure / fault isolation / degradation strategies
+- [ ] **Performance**: Bottleneck identification / caching strategy / asynchronous processing
+- [ ] **Security**: Authentication / authorization / data protection / input validation
+- [ ] **Scalability**: Horizontal scaling / sharding / plug-in architecture
+
+### Decisions and Evolution
+- [ ] **Key Decisions**: Are architecture decisions recorded (linkable to ADRs)?
+- [ ] **Trade-off Analysis**: Are the trade-offs of key technology choices explained?
+- [ ] **Evolution Path**: Is the future architecture evolution direction described?
+
+### 5W1H Check (architecture context)
+- [ ] **What**: What system/subsystem does the architecture describe?
+- [ ] **Why**: Why was this architecture adopted (business drivers)?
+- [ ] **Who**: Who uses this system / who maintains it?
+- [ ] **Where**: Where is it deployed / in what environment does it run?
+- [ ] **When**: When are key flows triggered?
+- [ ] **How**: How do components collaborate / how is it deployed?
+
+## Completeness Issue Markers
+- Only a module list without interaction relationships
+- Missing architecture diagram (pure text descriptions are hard to understand)
+- Incomplete interface definitions (missing parameters/error codes)
+
+## Scoring Guide
+| Finding | Deduction |
+|---|---|
+| Missing overall architecture diagram | -15 |
+| Missing any of logical/physical/data views | -10 per view |
+| Missing quality attribute scenarios | -12 |
+| Missing interface definitions | -12 |
+| Data flow not closed-loop | -10 |
+| Missing constraints and assumptions | -8 |
+| Missing key decision records | -8 |
+| Missing trade-off analysis | -10 |
+| Missing reliability/performance/security | -8 per item |

--- a/agent_skills/md-review/references/scenarios/adr.md
+++ b/agent_skills/md-review/references/scenarios/adr.md
@@ -1,0 +1,59 @@
+# ADR Scenario Checklist — Architecture Decision Record
+
+Enabled when the scenario parameter is `adr`. Checks whether the architecture decision record contains the following content and assesses its completeness.
+
+## Core Questions (editors must address)
+1. Is the context sufficient (can a newcomer understand the decision background)?
+2. Are at least 2 rejected alternatives listed with the reasons for rejection?
+3. Is the impact scope (affected modules/services) clearly marked?
+
+## Key Focus
+Decision context + trade-off logic + consequence estimation
+
+## Required Content (deduct if missing)
+
+### Decision Record Structure (Nygard template)
+- [ ] **Status**: Is the decision status marked (Proposed / Accepted / Superseded / Deprecated)?
+- [ ] **Context**: Is the decision's context/background sufficient (problems, constraints, driving factors)?
+- [ ] **Decision**: Is the decision itself clear (what was chosen, what was not)?
+- [ ] **Rationale**: Why was this decision made (comparative analysis, trade-offs)?
+- [ ] **Alternatives**: Are other considered options listed along with the reasons they were rejected?
+- [ ] **Consequences**: Is the impact of the decision stated (positive/negative, costs, migration impact)?
+
+### Decision Quality
+- [ ] **Title**: Is the title descriptive ("Adopt PostgreSQL instead of MySQL" rather than "Database selection")?
+- [ ] **Number**: Is there a unique number (ADR-001)?
+- [ ] **Date**: Is the decision date marked?
+- [ ] **Decision Maker**: Are the decision makers/reviewers recorded (if applicable)?
+- [ ] **Supersession Record**: Are the reasons stated when a decision is superseded/deprecated?
+
+### 5W1H Check (decision context)
+- [ ] **Why**: Why is this decision needed (driving factors)?
+- [ ] **What**: What was decided (solution/technology/architecture choice)?
+- [ ] **When**: When was the decision made (point in time/triggering conditions)?
+- [ ] **Where**: Impact scope (which modules/systems are affected)?
+- [ ] **Who**: Who made the decision / who is affected?
+- [ ] **How**: How is it implemented / how is the migration done?
+
+### Relationships with Other Documents
+- [ ] Are the related architecture documents/code locations referenced?
+- [ ] Do affected systems have corresponding documents?
+- [ ] Does it conflict with existing ADRs (should be cross-checked)?
+
+## Completeness Issue Markers
+- Only conclusions without context (the "why" cannot be understood)
+- Rejected alternatives not listed
+- Consequences not stated (nobody knows the impact after the decision)
+
+## Scoring Guide
+| Finding | Deduction |
+|---|---|
+| Missing context | -20 |
+| Missing decision | -20 |
+| Missing rationale | -15 |
+| Missing alternatives | -15 |
+| Missing consequences | -15 |
+| Status not marked | -10 |
+| Title not descriptive | -5 |
+| No number/date | -5 |
+| Conflict with existing ADRs not stated | -10 |

--- a/agent_skills/md-review/references/scenarios/api.md
+++ b/agent_skills/md-review/references/scenarios/api.md
@@ -1,0 +1,74 @@
+# API Scenario Checklist — API Document
+
+Enabled when the scenario parameter is `api`. Checks whether the API document contains the following content and assesses its completeness.
+
+## Core Questions (editors must address)
+1. Do error codes cover all exception scenarios and troubleshooting suggestions?
+2. Is the authentication method (e.g., Admin/User permissions) clear?
+3. Are the Request/Response examples real and runnable?
+
+## Key Focus
+Endpoint contracts + data models + error dictionary
+- Includes: **Error Code List** (all error codes and their meanings)
+
+## Required Content (deduct if missing)
+
+### Interface Specification
+- [ ] **Interface Overview**: Are the document's purpose/service scope explained?
+- [ ] **Basic Information**: Are Base URL, version, and authentication method clear?
+- [ ] **Interface List**: Are all endpoints numbered (ENDPOINT-1, ENDPOINT-2...)?
+- [ ] **HTTP Methods**: Is each endpoint's method (GET/POST/PUT/DELETE/PATCH) correct?
+
+### Endpoint Definitions (for each endpoint)
+- [ ] **Path**: Is the endpoint path complete and RESTful?
+- [ ] **Request Parameters**: Are parameters (path/query/request body) listed: name/type/required/default/validation rules?
+- [ ] **Response Format**: Is the success response structure defined (fields/type/example)?
+- [ ] **Error Codes**: Are error responses defined (status code/error code/error message/fix suggestion)?
+- [ ] **Examples**: Does each endpoint have request/response examples?
+- [ ] **Boundary Conditions**: Is the behavior for empty parameters/invalid input/over-limit input explained?
+
+### Consistency
+- [ ] **Naming Conventions**: Are endpoint and field names consistent (camelCase/snake_case unified)?
+- [ ] **Pagination**: Do list interfaces define pagination parameters (page/size/cursor)?
+- [ ] **Versioning Strategy**: Is the version management strategy explained (URL versioning vs header versioning)?
+- [ ] **Rate Limiting**: Are rate limits/quotas explained?
+- [ ] **Idempotency**: Is idempotency explained for write operations?
+
+### Security
+- [ ] **Authentication**: Is the authentication method clear (API Key / OAuth2 / JWT)?
+- [ ] **Authorization**: Are permission levels/role-based access control explained?
+- [ ] **Sensitive Data**: Are masking/encryption requirements marked for sensitive fields?
+- [ ] **Transport Security**: Is HTTPS/TLS enforced?
+
+### Testing and Change Management
+- [ ] **Test Cases**: Are there test cases for key interfaces (input → expected output/status code)?
+- [ ] **Change Log**: Are version changes recorded (with breaking changes marked)?
+- [ ] **Deprecation Strategy**: Is the handling strategy for deprecated interfaces explained?
+
+### 5W1H Check (API context)
+- [ ] **What**: What capability does this API provide?
+- [ ] **Who**: Who calls this API (internal/external/third-party)?
+- [ ] **When**: When is it called / what are the trigger conditions?
+- [ ] **Where**: Deployment environment / call entry point?
+- [ ] **Why**: Why does this interface exist (business purpose)?
+- [ ] **How**: How is it called (authentication/request/response chain)?
+
+## Completeness Issue Markers
+- Endpoints without request/response examples
+- Error codes not defined (callers cannot handle failures)
+- Parameters missing type/required markers
+- Authentication method not stated
+
+## Scoring Guide
+| Finding | Deduction |
+|---|---|
+| Missing interface list | -15 |
+| Endpoint missing request parameter definitions | -5 per endpoint |
+| Endpoint missing response format definitions | -5 per endpoint |
+| Missing error code definitions | -12 |
+| Missing examples | -5 per example |
+| Authentication method not stated | -15 |
+| Missing test cases | -10 |
+| Missing change log | -8 |
+| Inconsistent naming | -5 |
+| Boundary conditions not explained | -3 per occurrence |

--- a/agent_skills/md-review/references/scenarios/brd.md
+++ b/agent_skills/md-review/references/scenarios/brd.md
@@ -1,0 +1,64 @@
+# BRD Scenario Checklist — Business Requirements Document
+
+Enabled when the scenario parameter is `brd`. Checks whether the business requirements document contains the following content and assesses its completeness.
+
+## Core Questions (editors must address)
+1. Is the ROI (return on investment) argued with data?
+2. Are external risks such as competitors and policies identified?
+3. Are success metrics (e.g., market share, conversion rate) defined?
+
+## Key Focus
+Business value + cost estimation + return on investment
+
+## Required Content (deduct if missing)
+
+### Business Background
+- [ ] **Business Goals**: Are the business goals the project must achieve clear (revenue/market share/cost/growth)?
+- [ ] **Problem Statement**: Is the business problem/opportunity to be solved clear?
+- [ ] **Business Value**: Is the expected business value/ROI quantified?
+- [ ] **Market Analysis**: Is the market size/trends/opportunity summarized?
+
+### Scope and Constraints
+- [ ] **Scope Definition**: Is the business scope in/out (In-Scope / Out-of-Scope) clear?
+- [ ] **Constraints**: Are budget/time/resources/regulatory constraints explained?
+- [ ] **Assumptions**: Are key business assumptions listed?
+- [ ] **Dependencies**: Are dependent projects/systems/resources identified?
+
+### Requirements and Priorities
+- [ ] **Requirements List**: Are business requirements numbered (BR-1, BR-2...)?
+- [ ] **Priority**: Are requirements tiered (Must/Should/Could or P0/P1/P2)?
+- [ ] **Success Metrics**: Are quantified indicators of business success (KPIs) defined?
+- [ ] **Risk Analysis**: Are business risks identified along with mitigation plans?
+
+### 5W1H Check (business context)
+- [ ] **Who**: Who benefits (customers/users/shareholders)? Who pays?
+- [ ] **What**: What product or service is provided?
+- [ ] **When**: When to enter the market / when to realize revenue?
+- [ ] **Where**: Which market/region/channel?
+- [ ] **Why**: Why do it (business motivation/strategic value)?
+- [ ] **How**: How to achieve it (product plan/operations plan/business model)?
+
+### Financial Aspects
+- [ ] **Cost Estimation**: Are development/operations/marketing costs estimated?
+- [ ] **Revenue Model**: Are revenue sources/pricing strategy described?
+- [ ] **Break-even**: Is the break-even point/payback period analyzed (if applicable)?
+- [ ] **Return on Investment**: Is the ROI/return-on-investment analysis provided?
+
+## Completeness Issue Markers
+- Business goals that cannot be quantified ("improve user experience" without metrics)
+- No value argument (cannot explain why it's worth doing)
+- Risks not identified
+
+## Scoring Guide
+| Finding | Deduction |
+|---|---|
+| Missing business goals | -15 |
+| Missing problem statement | -10 |
+| Missing business value/ROI | -12 |
+| Scope not defined | -10 |
+| Requirements list missing/un-numbered | -15 |
+| Missing success metrics | -10 |
+| Missing cost/revenue model | -12 |
+| Missing risk analysis | -10 |
+| 5W1H missing 2 or more items | -10 |
+| Business goals not quantifiable | -8 |

--- a/agent_skills/md-review/references/scenarios/concept.md
+++ b/agent_skills/md-review/references/scenarios/concept.md
@@ -1,0 +1,62 @@
+# Concept Scenario Checklist — Concept Design Document
+
+Enabled when the scenario parameter is `concept`. Checks whether the concept design document contains the following content and assesses its completeness.
+
+## Core Questions (editors must address)
+1. Is the game's core idea compelling enough?
+2. Is the market potential and competitive analysis sufficient?
+3. Does it provide enough basis for "to build or not to build"?
+
+## Key Focus
+Game idea + market analysis + target audience + core selling points
+
+## Required Content (deduct if missing)
+
+### Game Idea
+- [ ] **Idea Overview**: Is the game's core idea clear and compelling (explainable in one paragraph)?
+- [ ] **Innovation Points**: Are the differences/innovations versus existing games clear?
+- [ ] **Gameplay Prototype**: Is the prototype/preliminary idea of the core gameplay described?
+- [ ] **Emotional Goals**: Is the core emotional experience players are expected to have defined?
+
+### Market Analysis
+- [ ] **Market Potential**: Is the target market's size/growth trend assessed?
+- [ ] **Competitive Analysis**: Are similar/nearby games analyzed (strengths/weaknesses/market performance)?
+- [ ] **Market Gap**: Are needs/gaps not met by existing products identified?
+- [ ] **Timing Assessment**: Is the current moment a good time (trends/window)?
+
+### Target Audience
+- [ ] **Target Users**: Is the target player group (persona/platform preferences/spending habits) clear?
+- [ ] **Audience Size**: Are the target audience's size/willingness to pay assessed?
+- [ ] **Acquisition Channels**: Are channels/marketing ideas to reach the target audience mentioned?
+
+### Decision Basis
+- [ ] **Core Selling Points**: Are the core selling points to players distilled?
+- [ ] **Risks and Assumptions**: Are key assumptions/risks identified (the basis for "to build or not to build")?
+- [ ] **Value Argument**: Why is it worth doing (business/strategic/brand value)?
+- [ ] **Kill Criteria**: Is it stated under what conditions the concept should be abandoned (if applicable)?
+
+### 5W1H Check (concept context)
+- [ ] **What**: What is the game concept?
+- [ ] **Who**: Who is it for (target players)?
+- [ ] **Why**: Why is it worth doing (market/creative basis)?
+- [ ] **Where**: In which market/platform?
+- [ ] **When**: When is the right time to enter?
+- [ ] **How**: How is it achieved (initial path)?
+
+## Completeness Issue Markers
+- Idea without innovation ("yet another X" with no differentiation)
+- Missing competitive analysis (unable to judge market space)
+- No risk identification (insufficient basis for "to build or not to build")
+
+## Scoring Guide
+| Finding | Deduction |
+|---|---|
+| Idea overview unclear/uncompelling | -15 |
+| Missing innovation points | -12 |
+| Missing market potential assessment | -12 |
+| Missing competitive analysis | -12 |
+| Missing target audience | -10 |
+| Missing core selling points | -10 |
+| Missing risks and assumptions | -12 |
+| Missing value argument | -10 |
+| 5W1H missing 2 or more items | -10 |

--- a/agent_skills/md-review/references/scenarios/fsd.md
+++ b/agent_skills/md-review/references/scenarios/fsd.md
@@ -1,0 +1,67 @@
+# FSD Scenario Checklist — Functional Specification Document
+
+Enabled when the scenario parameter is `fsd`. Checks whether the functional specification document contains the following content and assesses its completeness.
+
+## Core Questions (editors must address)
+1. Does it cover boundary conditions such as null values, over-length input, and concurrency?
+2. Is the business logic unambiguous (engineers no longer need to guess)?
+3. Is a state diagram provided when state transitions are involved?
+
+## Key Focus
+Input/output definitions + business rules + exception handling (a direct blueprint for writing test cases)
+- Includes: **Detailed Functional List** (atomic-level functional decomposition)
+
+## Required Content (deduct if missing)
+
+### Functional Definition
+- [ ] **Feature Overview**: Is the overall responsibility of the feature module explained?
+- [ ] **Functional List**: Are features numbered (F-1, F-2...), each with a description?
+- [ ] **Feature Behavior**: Is each feature's specific behavior/rules defined (trigger condition → action → result)?
+- [ ] **Inter-feature Relationships**: Are dependencies/relationships between features explained?
+
+### Functional Details
+- [ ] **Input Definition**: Are the feature's inputs (parameters/data/operations) clear?
+- [ ] **Output Definition**: Are the feature's outputs (results/responses/side effects) clear?
+- [ ] **Processing Logic**: Is the core processing logic/algorithm/rules described?
+- [ ] **Exception Handling**: Are failure/exception paths defined?
+- [ ] **Boundary Conditions**: Is the behavior for null values/extreme values/invalid input explained?
+
+### Scenarios and Use Cases
+- [ ] **Usage Scenarios**: Are typical usage scenarios described?
+- [ ] **Use Cases**: Are key use cases complete (main flow/extension flow/exception flow)?
+- [ ] **Test Cases**: Does each feature have executable test cases (input → expected output)?
+- [ ] **Acceptance Criteria**: Are testable criteria for feature completion defined?
+
+### Priority and Planning
+- [ ] **Priority**: Are features tiered (P0/P1/P2 or Must/Should/Could)?
+- [ ] **Release Planning**: Are the version/milestone each feature belongs to explained?
+- [ ] **Dependencies**: Are dependencies on other modules/systems/data declared?
+- [ ] **Effort Estimation**: Is the implementation effort/complexity estimated (if applicable)?
+
+### 5W1H Check (functional context)
+- [ ] **What**: What does the feature do?
+- [ ] **Who**: Who uses this feature (roles)?
+- [ ] **When**: When is the feature triggered/available?
+- [ ] **Where**: In which module/page/entry point is the feature located?
+- [ ] **Why**: Why is this feature needed (what problem does it solve)?
+- [ ] **How**: How is it operated / how is it implemented?
+
+## Completeness Issue Markers
+- Vague feature descriptions ("the system should support export" without specific behavior)
+- Features without numbers (cannot be traced to implementation)
+- Exception paths not described (only the normal flow written)
+- Features without test cases
+
+## Scoring Guide
+| Finding | Deduction |
+|---|---|
+| Functional list missing/un-numbered | -15 |
+| Incomplete feature behavior definitions | -5 per feature |
+| Missing input/output definitions | -5 per occurrence |
+| Missing exception handling | -8 |
+| Missing boundary conditions | -3 per occurrence |
+| Missing use cases | -10 |
+| Missing test cases | -10 |
+| Missing acceptance criteria | -10 |
+| Features without priority | -5 |
+| Feature dependencies not declared | -5 |

--- a/agent_skills/md-review/references/scenarios/gdd.md
+++ b/agent_skills/md-review/references/scenarios/gdd.md
@@ -1,0 +1,71 @@
+# GDD Scenario Checklist — Game Design Document
+
+Enabled when the scenario parameter is `gdd`. Checks whether the game design document contains the following content and assesses its completeness.
+
+## Core Questions (editors must address)
+1. Is the core experience clearly defined (what the player feels)?
+2. Is the core gameplay loop (Core Loop) visualized?
+3. Are the rules and interactions of each system (economy, combat, etc.) clear?
+
+## Key Focus
+Game overview + core gameplay + system mechanics + narrative and world-building
+- Includes: **Core Mechanics List**, **Game Systems List**
+
+## Required Content (deduct if missing)
+
+### Core Design
+- [ ] **Core Gameplay Loop**: Is the player's core loop from start to finish clear (e.g., collect → craft → combat → upgrade → collect)?
+- [ ] **Player Fantasy**: Is the core experience players should feel described?
+- [ ] **Goals and Win Conditions**: Are the game objectives and win/loss conditions defined?
+- [ ] **Target Audience**: Is the target player group (age/preferences/platform) clear?
+
+### Systems and Mechanics
+- [ ] **Core Mechanics**: Are the main gameplay mechanics defined in detail (operation methods, rules, feedback)?
+- [ ] **Numerical Design**: Do key values (health/damage/speed/probability) have definitions and balancing rationale?
+- [ ] **Formulas**: Are numerical formulas complete (variable definitions, value ranges, example calculations)?
+- [ ] **Edge Cases**: Are the boundary conditions of every mechanism described, at minimum:
+  - **Death / Respawn / Failure determination**: how HP is deducted, when failure is decided, what state the player respawns into, and whether respawning depends on rules defined elsewhere (an undeclared death rule underneath a respawn/continue feature is a bug source)
+  - **Fail / retry / replay behavior** for quests, levels and minigames
+  - **Extreme values**: max/min caps, overflow/underflow, zero-input handling in formulas
+  - **Concurrent state conflicts**: save/load, offline income, shared world state
+- [ ] **Inter-system Dependencies**: Is the dependency of system A on system B declared bidirectionally?
+
+### Content Scope
+- [ ] **Quest List**: Is the list of in-game quests/levels/activities complete (quantities, unlock conditions, rewards)?
+- [ ] **Content List**: Are items/characters/enemies/maps listed?
+- [ ] **Economy System**: Is the design of currencies/resources/exchange relationships complete?
+
+### Experience and Quality
+- [ ] **Test Cases**: Do core mechanics have executable test cases (input → expected output)?
+- [ ] **Acceptance Criteria**: Does each system have testable completion criteria (QA can determine pass/fail)?
+- [ ] **Tuning Knobs**: Are configurable values externalized (not hardcoded)?
+- [ ] **Balance**: Are there obvious numerical imbalances (a certain strategy is always optimal)?
+
+### 5W1H Check (game design context)
+- [ ] **Who**: Who is the player (character/faction)? Who is the enemy?
+- [ ] **What**: What does the player do? What are the core actions?
+- [ ] **When**: When are combat/quests/systems triggered?
+- [ ] **Where**: Where do scenes/maps take place?
+- [ ] **Why**: Why does the player do it (motivations/rewards)?
+- [ ] **How**: How is it operated? How is it implemented?
+
+## Completeness Issue Markers
+- Undefined terms (e.g., "combo system" without a definition)
+- Missing values ("high damage" instead of specific numbers)
+- Incomplete markers (TODO/TBD)
+- Mechanics referenced but their boundary behavior undefined (e.g., a respawn/continue feature with no stated death or failure rules)
+
+## Scoring Guide
+| Finding | Deduction |
+|---|---|
+| Missing core gameplay loop | -15 |
+| Missing player fantasy | -10 |
+| Key values not defined | -5 per occurrence |
+| Missing/incomplete formulas | -10 |
+| Missing test cases | -10 |
+| Missing acceptance criteria | -10 |
+| Incomplete quest/content lists | -5 |
+| Edge cases not handled | -3 per occurrence |
+| Death/respawn/failure rules missing or under-defined | -5 per occurrence |
+| One-way system dependency | -5 |
+| Obvious numerical imbalance | -8 |

--- a/agent_skills/md-review/references/scenarios/gdo.md
+++ b/agent_skills/md-review/references/scenarios/gdo.md
@@ -1,0 +1,56 @@
+# GDO Scenario Checklist — Game Overview Document
+
+Enabled when the scenario parameter is `gdo`. Checks whether the game overview document contains the following content and assesses its completeness.
+
+## Core Questions (editors must address)
+1. Is the core concept clearly explained within 1-2 pages?
+2. Are the design pillars and USP (unique selling point) clear?
+3. Are the target audience and platform defined?
+
+## Key Focus
+Executive summary + core concept + target audience + key features
+
+## Required Content (deduct if missing)
+
+### Core Overview
+- [ ] **Executive Summary**: Is what the game is and why it's worth making clearly explained within one page?
+- [ ] **Core Concept**: Is the game's core idea/gameplay concept clearly stated?
+- [ ] **Design Pillars**: Are the 3-5 core design principles clear (every feature decision should trace back to these pillars)?
+- [ ] **Unique Selling Point (USP)**: Is the core selling point that differentiates from competitors clear?
+
+### Goals and Audience
+- [ ] **Target Audience**: Is the target player group (age/preferences/platform) defined?
+- [ ] **Target Platforms**: Are the release platforms (PC/console/mobile) clear?
+- [ ] **Genre**: Is the genre (RPG/shooter/puzzle, etc.) and perspective clear?
+- [ ] **Business Model**: Is the model (paid/F2P/subscription, etc.) explained?
+
+### Feature Overview
+- [ ] **Key Features**: Are the game's core features/gameplay modules listed?
+- [ ] **Single/Multi-player**: Are single-player/multi-player/social elements explained?
+- [ ] **Length and Scale**: Are the expected game length/content scale described?
+
+### 5W1H Check (game overview context)
+- [ ] **What**: What kind of game is this?
+- [ ] **Who**: Who is it for (target players)?
+- [ ] **Why**: Why will players want to play it (core appeal)?
+- [ ] **Where**: On which platforms/channels is it released?
+- [ ] **When**: When is it expected to be released (development stage)?
+- [ ] **How**: How is it achieved (technology/gameplay key points)?
+
+## Completeness Issue Markers
+- Core concept still unclear after more than 2 pages
+- Design pillars and USP confused (they are different: pillars are design principles, USP is a market selling point)
+- No competitor reference (unable to judge uniqueness)
+
+## Scoring Guide
+| Finding | Deduction |
+|---|---|
+| Missing executive summary | -15 |
+| Core concept unclear | -15 |
+| Missing design pillars | -12 |
+| Missing unique selling point (USP) | -12 |
+| Missing target audience | -10 |
+| Missing target platforms | -8 |
+| Missing key feature list | -10 |
+| 5W1H missing 2 or more items | -10 |
+| Core concept verbose (>2 pages) | -8 |

--- a/agent_skills/md-review/references/scenarios/ldd.md
+++ b/agent_skills/md-review/references/scenarios/ldd.md
@@ -1,0 +1,63 @@
+# LDD Scenario Checklist — Level Design Document
+
+Enabled when the scenario parameter is `ldd`. Checks whether the level design document contains the following content and assesses its completeness.
+
+## Core Questions (editors must address)
+1. Are the level layout and player flow reasonable?
+2. Do the challenges, pacing, and narrative elements within the level match?
+3. Are there level design patterns and metrics?
+
+## Key Focus
+Level layout + player paths + challenge configuration + pacing control
+- Includes: **Level List**, **Scene Interaction Elements List**
+
+## Required Content (deduct if missing)
+
+### Level Design
+- [ ] **Level List**: Are all levels numbered (L-1, L-2...), with objectives/theme/location?
+- [ ] **Level Layout**: Is each level's spatial layout/structure described (or illustrated)?
+- [ ] **Player Path**: Is the player's completion path/route clear (start → objective → end)?
+- [ ] **Scene Interaction Elements List**: Are the interactive elements within the level (mechanisms/items/enemies/NPCs) listed?
+
+### Challenges and Pacing
+- [ ] **Challenge Configuration**: Are the challenge types/difficulty gradients within the level configured?
+- [ ] **Pacing Control**: Is the level's tension-and-release pacing (alternating intense combat and calm exploration) designed?
+- [ ] **Difficulty Curve**: Is the difficulty progression across levels reasonable?
+- [ ] **Reward Distribution**: Is the placement of rewards/incentive points reasonable?
+
+### Narrative and Theme
+- [ ] **Narrative Elements**: Do the in-level narrative elements (dialogue/cutscenes/environmental storytelling) match the level objectives?
+- [ ] **Thematic Consistency**: Is the level's visuals/atmosphere consistent with the game's overall theme?
+
+### Metrics and Patterns
+- [ ] **Design Patterns**: Is there an explanation of level design patterns (e.g., linear/open-world/hub-based)?
+- [ ] **Metrics**: Are metric indicators defined (completion time/death rate/exploration coverage)?
+- [ ] **Acceptance Criteria**: Are testable completion criteria defined (QA can determine pass/fail)?
+- [ ] **Test Cases**: Do the level's key flows have test cases (player behavior → expected result)?
+
+### 5W1H Check (level design context)
+- [ ] **Who**: Who does the player play as / face in the level?
+- [ ] **What**: What does the player do in the level (objectives/tasks)?
+- [ ] **When**: Where in the game flow does the level sit / its unlock conditions?
+- [ ] **Where**: In what scenes/regions does the level take place?
+- [ ] **Why**: What is the purpose of the level (tutorial/climax/turning point)?
+- [ ] **How**: How does the player complete the level (paths/solutions)?
+
+## Completeness Issue Markers
+- Levels without layout descriptions (only textual objectives)
+- Challenges and pacing not designed (monotonous levels)
+- No metrics (unable to assess level quality)
+
+## Scoring Guide
+| Finding | Deduction |
+|---|---|
+| Level list missing | -15 |
+| Level layout not described | -12 |
+| Player path unclear | -12 |
+| Challenge configuration missing | -10 |
+| Pacing control not designed | -10 |
+| Unreasonable difficulty curve | -8 |
+| Narrative and level mismatch | -8 |
+| Missing metrics | -12 |
+| Missing acceptance criteria | -10 |
+| Missing test cases | -10 |

--- a/agent_skills/md-review/references/scenarios/mrd.md
+++ b/agent_skills/md-review/references/scenarios/mrd.md
@@ -1,0 +1,58 @@
+# MRD Scenario Checklist — Market Requirements Document
+
+Enabled when the scenario parameter is `mrd`. Checks whether the market requirements document contains the following content and assesses its completeness.
+
+## Core Questions (editors must address)
+1. Is the user persona based on real research?
+2. Are the core differentiators against the Top 3 competitors fully explained?
+3. Is the current market timing and window clear?
+
+## Key Focus
+Market analysis + user pain points + core feature highlights
+
+## Required Content (deduct if missing)
+
+### Market Analysis
+- [ ] **Market Background**: Are the market status/trends/size described?
+- [ ] **Target Market**: Is the target market/segment clear?
+- [ ] **Competitive Analysis**: Are the main competitors and their strengths/weaknesses analyzed?
+- [ ] **Market Opportunity**: Are market gaps/opportunity points identified?
+
+### Users and Needs
+- [ ] **Target User Persona**: Is the user persona (age/role/scenarios/pain points) specific?
+- [ ] **Requirements List**: Are market requirements numbered (MR-1, MR-2...), each with a priority?
+- [ ] **User Pain Points**: Are the target users' core pain points clear?
+- [ ] **Value Proposition**: Is the product's core value/selling point to users clear?
+
+### 5W1H Check (market context)
+- [ ] **Who**: Who are the target users?
+- [ ] **What**: What does the market need (product/feature/service)?
+- [ ] **When**: When does the need exist / when to enter the market (timing)?
+- [ ] **Where**: In which market/region/channel?
+- [ ] **Why**: Why do users need it (deeper motivations)?
+- [ ] **How**: How to satisfy it (product plan/business model)?
+
+### Business Aspects
+- [ ] **Market Size**: Is there an estimate of market size/capacity?
+- [ ] **Business Model**: Is the revenue model/pricing strategy described?
+- [ ] **Success Metrics**: Are quantified indicators of market success (share/growth/revenue) defined?
+- [ ] **Risks and Assumptions**: Are key assumptions and risks identified?
+
+## Completeness Issue Markers
+- Vague user personas ("young users" without specific description)
+- Missing competitive analysis (cannot judge differentiation)
+- Requirements without priority
+
+## Scoring Guide
+| Finding | Deduction |
+|---|---|
+| Missing market background | -10 |
+| Missing target market | -10 |
+| Missing competitive analysis | -12 |
+| Missing user persona | -12 |
+| Requirements list missing/un-numbered | -15 |
+| Missing value proposition | -10 |
+| Missing business model | -10 |
+| Missing success metrics | -8 |
+| 5W1H missing 2 or more items | -10 |
+| Risks/assumptions not identified | -8 |

--- a/agent_skills/md-review/references/scenarios/prd.md
+++ b/agent_skills/md-review/references/scenarios/prd.md
@@ -1,0 +1,66 @@
+# PRD Scenario Checklist — Product Requirements Document
+
+Enabled when the scenario parameter is `prd`. Checks whether the product requirements document contains the following content and assesses its completeness.
+
+## Core Questions (editors must address)
+1. Is the requirement source traceable to the MRD or user research?
+2. Are acceptance criteria quantified (e.g., response time, success rate)?
+3. Is priority (P0/P1/P2) explicitly assigned?
+
+## Key Focus
+User stories + feature flows + business rules
+- Includes: **Requirements List** (a uniquely numbered list of all functional points)
+
+## Required Content (deduct if missing)
+
+### Requirements Definition
+- [ ] **Background**: Is the reason for building this product/feature stated (problem/opportunity/market driver)?
+- [ ] **Target Users**: Is the target user group clear (persona/scenarios)?
+- [ ] **User Stories**: Are the key user stories complete (As X, I want Y, so that Z)?
+- [ ] **Requirements List**: Are functional requirements numbered (FR-1, FR-2...), each with a description and priority?
+
+### Functional and Non-Functional Requirements
+- [ ] **Feature List**: Does each feature have a clear behavior description?
+- [ ] **Non-Functional Requirements**: Are performance/security/usability/compatibility metrics defined?
+- [ ] **Priority**: Are requirements tiered (P0/P1/P2 or MoSCoW: Must/Should/Could/Won't)?
+- [ ] **Dependencies**: Are dependencies between requirements declared (FR-3 depends on FR-1)?
+
+### Scope and Acceptance
+- [ ] **Scope Definition**: Is In-Scope / Out-of-Scope clearly defined?
+- [ ] **Acceptance Criteria**: Does each requirement have testable acceptance criteria?
+- [ ] **Edge Cases**: Are abnormal inputs/boundary conditions/failure scenarios described?
+- [ ] **Test Cases**: Are there test cases for key flows (input → expected output)?
+
+### 5W1H Check (product context)
+- [ ] **Who**: Who are the target users?
+- [ ] **What**: What features/value does the product provide?
+- [ ] **When**: When do users use it?
+- [ ] **Where**: In what scenarios/channels do users use it?
+- [ ] **Why**: Why do users need it (pain points/motivations)?
+- [ ] **How**: How does the product meet the need (flows/interactions)?
+
+### Supporting Documents
+- [ ] **Flow/Sequence Diagrams**: Are there diagrams for key flows?
+- [ ] **Data Requirements**: Are the involved data fields/storage described?
+- [ ] **Release Plan**: Is version planning/milestones described?
+- [ ] **Tracking/Metrics**: Are success metrics (KPI/conversion rate) defined?
+
+## Completeness Issue Markers
+- Vague requirement descriptions ("better experience" without concrete standards)
+- Requirements without numbers (untraceable)
+- Untestable acceptance criteria ("the system should work well")
+
+## Scoring Guide
+| Finding | Deduction |
+|---|---|
+| Missing requirements background | -10 |
+| Missing target users | -8 |
+| Requirements list missing/un-numbered | -15 |
+| Missing user stories | -8 |
+| Missing non-functional requirements | -8 |
+| Missing acceptance criteria | -10 |
+| Missing test cases | -10 |
+| Scope not defined | -8 |
+| Requirements without priority | -5 |
+| Edge cases not handled | -3 per occurrence |
+| 5W1H missing 2 or more items | -10 |

--- a/agent_skills/md-review/references/scenarios/tcd.md
+++ b/agent_skills/md-review/references/scenarios/tcd.md
@@ -1,0 +1,67 @@
+# TCD Scenario Checklist — Test Case Document
+
+Enabled when the scenario parameter is `tcd`. Checks whether the test case document contains the following content and assesses its completeness.
+
+## Core Questions (editors must address)
+1. Do the cases cover all happy-path flows, boundary values, and exception scenarios?
+2. Are the prerequisites clear (e.g., user state, data preparation)?
+3. Are expected results verifiable (not vague descriptions)?
+4. Is a traceability relationship established with requirement items in the PRD/FSD?
+
+## Key Focus
+Case numbering + test steps + input data + expected output + prerequisites
+- Includes: **Test Case Set** (with linked requirement IDs, priority, execution result)
+- Written by the QA team; the basis for automation scripts and manual testing
+
+## Required Content (deduct if missing)
+
+### Case Structure
+- [ ] **Case Numbering**: Does each case have a unique number (TC-1, TC-2...)?
+- [ ] **Case Title**: Is the title descriptive ("verify successful login" rather than "case 1")?
+- [ ] **Test Steps**: Are test steps numbered and executable (1. 2. 3.)?
+- [ ] **Input Data**: Is the input data explicit (including boundary values/special characters)?
+- [ ] **Expected Output**: Are expected results verifiable (specific values/status codes/behavior, not "normal")?
+
+### Scenario Coverage
+- [ ] **Happy-Path Flows**: Are the normal paths of the main features covered?
+- [ ] **Boundary Values**: Are boundary/extreme value tests covered (minimum/maximum/critical values)?
+- [ ] **Exception Scenarios**: Are abnormal/failure paths covered (invalid input/timeout/insufficient permission/network failure)?
+- [ ] **Null/Over-length/Concurrency**: Are null values, over-length inputs, and concurrency scenarios covered?
+
+### Prerequisites and Traceability
+- [ ] **Prerequisites**: Are each case's prerequisites clear (user state/data preparation/environment)?
+- [ ] **Requirement Traceability**: Are cases linked to requirement IDs in the PRD/FSD (traceability)?
+- [ ] **Priority**: Are cases tiered (P0 critical path/P1 important/P2 general)?
+
+### Execution and Management
+- [ ] **Execution Result**: Is there a field to record execution results (pass/fail/blocked)?
+- [ ] **Automation Flag**: Is it marked whether the case can be automated (as the basis for automation scripts)?
+- [ ] **Linked Defects**: Is there a defect-link field (corresponding bug ID on failure)?
+
+### 5W1H Check (testing context)
+- [ ] **What**: What feature/scenario is tested?
+- [ ] **Who**: Who executes it (QA/automation)?
+- [ ] **When**: When is it executed (smoke/regression/pre-release)?
+- [ ] **Where**: In what environment is it executed (test/staging)?
+- [ ] **Why**: Why test it (which requirement does it verify)?
+- [ ] **How**: How is it tested (steps/data/tools)?
+
+## Completeness Issue Markers
+- Vague expected results ("the system runs normally", "no exceptions")
+- No prerequisites (executors don't know how to prepare)
+- Cases without requirement traceability (coverage cannot be proven)
+- Only happy-path flows covered (no boundary/exception)
+
+## Scoring Guide
+| Finding | Deduction |
+|---|---|
+| Case numbering missing | -15 |
+| Test steps not executable | -12 |
+| Expected results not verifiable | -15 |
+| Boundary values not covered | -10 |
+| Exception scenarios not covered | -12 |
+| Prerequisites missing | -10 |
+| No requirement traceability | -12 |
+| Cases without priority | -5 |
+| No execution result field | -5 |
+| Incomplete coverage (happy path only) | -10 |

--- a/agent_skills/md-review/references/scenarios/tdd.md
+++ b/agent_skills/md-review/references/scenarios/tdd.md
@@ -1,0 +1,66 @@
+# TDD Scenario Checklist — Technical Design Document
+
+Enabled when the scenario parameter is `tdd`. Checks whether the technical design document contains the following content and assesses its completeness.
+
+## Core Questions (editors must address)
+1. Are design concepts translated into clear technical specifications?
+2. Are system architecture, coding standards, and performance goals defined?
+3. Is the technology selection aligned with the design goals?
+
+## Key Focus
+System architecture + technology stack + coding standards + performance requirements
+
+## Required Content (deduct if missing)
+
+### Technical Specification Translation
+- [ ] **Requirements Mapping**: Are the design document's functional requirements mapped to concrete technical implementations?
+- [ ] **Technical Specifications**: Are the implementation specifications of key modules (interfaces, data structures, algorithms) clear?
+- [ ] **Traceability**: Can each technical module be traced back to its corresponding design requirement?
+
+### System Architecture
+- [ ] **Overall Architecture**: Are the system layering/component division/interaction relationships described?
+- [ ] **Module Design**: Are module responsibilities, inputs/outputs, and dependency relationships clear?
+- [ ] **Interface Definitions**: Are inter-module interface/API contracts complete (parameters/returns/error codes)?
+- [ ] **Data Design**: Are the data model/storage scheme/data flows defined?
+
+### Technology Stack
+- [ ] **Technology Selection**: Are the language/framework/middleware choices clear?
+- [ ] **Selection Rationale**: Is the technology selection aligned with design goals (with comparison/trade-off explanation)?
+- [ ] **Compatibility**: Is the chosen technology stack compatible with existing systems?
+- [ ] **Version Locking**: Are dependency versions locked?
+
+### Coding Standards
+- [ ] **Coding Conventions**: Are naming/format/code style defined (or referenced from existing conventions)?
+- [ ] **Project Structure**: Are the module organization and project structure explained?
+- [ ] **Error Handling**: Are unified error handling/logging conventions defined?
+
+### Performance Requirements
+- [ ] **Performance Goals**: Are key performance indicators (latency/throughput/resource usage) quantified?
+- [ ] **Bottleneck Identification**: Are potential performance bottlenecks and optimization plans explained?
+- [ ] **Testing Strategy**: Is the plan for unit/integration/performance testing described?
+
+### 5W1H Check (technical context)
+- [ ] **What**: What technical solution is implemented?
+- [ ] **Why**: Why is it implemented this way (design intent)?
+- [ ] **How**: How is it implemented (architecture/flow)?
+- [ ] **Where**: In which modules/systems is it implemented?
+- [ ] **When**: What is the implementation sequence/dependencies?
+- [ ] **Who**: Who maintains / who depends on this technology?
+
+## Completeness Issue Markers
+- Only high-level descriptions without technical specifications (cannot be developed directly)
+- Technology selection without rationale ("use X" without comparison)
+- Performance goals not quantified
+
+## Scoring Guide
+| Finding | Deduction |
+|---|---|
+| Requirements not mapped to technical implementation | -15 |
+| Missing overall architecture | -15 |
+| Missing interface definitions | -12 |
+| Technology selection without rationale | -12 |
+| Missing coding conventions | -8 |
+| Performance goals not quantified | -12 |
+| Missing testing strategy | -10 |
+| Technology stack compatibility not assessed | -8 |
+| Module dependencies unclear | -8 |

--- a/agent_skills/md-review/references/scenarios/tld.md
+++ b/agent_skills/md-review/references/scenarios/tld.md
@@ -1,0 +1,67 @@
+# TLD Scenario Checklist — Task List Document
+
+Enabled when the scenario parameter is `tld`. Checks whether the task list document contains the following content and assesses its completeness.
+
+## Core Questions (editors must address)
+1. Is the task decomposition granularity reasonable (too large to estimate, too small to manage)?
+2. Are dependencies between tasks marked (blocking/parallel)?
+3. Are effort estimates based on historical data or expert judgment?
+4. Does every task have an explicit owner and acceptance criteria?
+
+## Key Focus
+Task decomposition + dependency relationships + effort estimation + owner assignment
+- Includes: **Task List** (with ID, description, priority, status, estimated person-days)
+- Linked to PRD/ADD, maintained by the engineering manager, dynamically updated
+
+## Required Content (deduct if missing)
+
+### Task Decomposition
+- [ ] **Task List**: Are all tasks numbered (T-1, T-2...), with ID/description/priority/status/estimated person-days?
+- [ ] **Task Granularity**: Is the decomposition granularity reasonable (0.5-5 person-days per task is recommended; too large to estimate, too small to manage)?
+- [ ] **Task Types**: Are tasks categorized (development/testing/documentation/deployment, etc.)?
+- [ ] **Deliverables**: Is each task's output/deliverable clear?
+
+### Dependencies and Ordering
+- [ ] **Dependency Relationships**: Are dependencies between tasks marked (blocking/blocked/parallel)?
+- [ ] **Critical Path**: Is the critical path identified (the chain of tasks that determines total duration)?
+- [ ] **Execution Order**: Is the task ordering reasonable (predecessor tasks first)?
+
+### Estimation and Resources
+- [ ] **Effort Estimation**: Is a person-day estimate given for each task?
+- [ ] **Estimation Basis**: Are estimates based on historical data or expert judgment (rather than gut feeling)?
+- [ ] **Owner**: Does each task have an explicit owner/lead?
+- [ ] **Resource Conflicts**: Could tasks assigned to the same owner conflict (parallel overload)?
+
+### Status and Acceptance
+- [ ] **Priority**: Are tasks tiered (P0/P1/P2)?
+- [ ] **Status Field**: Is the status (todo/in progress/blocked/done) defined?
+- [ ] **Acceptance Criteria**: Does each task have a testable completion standard (DoD)?
+- [ ] **Traceability**: Are tasks linked to PRD/ADD requirement items (traceability)?
+
+### 5W1H Check (task context)
+- [ ] **What**: What does each task do?
+- [ ] **Who**: Who is responsible (owner)?
+- [ ] **When**: When does it start/end (schedule)?
+- [ ] **Where**: In which module/system is it implemented?
+- [ ] **Why**: Why is this task needed (source requirement)?
+- [ ] **How**: How is it completed (dependencies/methods)?
+
+## Completeness Issue Markers
+- Unbalanced task granularity (one task of 30 person-days or 0.1 person-days)
+- Tasks without owners (nobody responsible = nobody executes)
+- Estimates without basis ("about X days" without explanation)
+- Tasks without acceptance criteria (completion cannot be judged)
+
+## Scoring Guide
+| Finding | Deduction |
+|---|---|
+| Task list missing/un-numbered | -20 |
+| Unbalanced task granularity | -10 |
+| Dependency relationships not marked | -12 |
+| Missing effort estimates | -12 |
+| Estimates without basis | -10 |
+| Owner missing | -12 |
+| Acceptance criteria missing | -12 |
+| Priority missing | -8 |
+| Tasks without requirement traceability | -10 |
+| Status field not defined | -5 |

--- a/agent_skills/md-review/scripts/analyze_structure.py
+++ b/agent_skills/md-review/scripts/analyze_structure.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""Structural analysis: lines/words/tokens, heading-level distribution, code-block languages, tables/links/images, incomplete markers, heading skips (Phase 1)."""
+
+import re
+import sys
+from collections import Counter
+from pathlib import Path
+
+def read_text_safe(md_path):
+    """Read a file, trying utf-8 first then common encodings; exit 2 on missing/binary."""
+    p = Path(md_path)
+    if not p.is_file():
+        print(f"Error: file not found: {md_path}", file=sys.stderr)
+        sys.exit(2)
+    raw = p.read_bytes()
+    if b"\x00" in raw:
+        print(f"Error: binary file (contains NUL bytes): {md_path}", file=sys.stderr)
+        sys.exit(2)
+    for enc in ("utf-8", "latin-1"):
+        try:
+            return raw.decode(enc)
+        except UnicodeDecodeError:
+            continue
+    print(f"Error: cannot decode file: {md_path}", file=sys.stderr)
+    sys.exit(2)
+
+def analyze(md_path):
+    text = read_text_safe(md_path)
+    lines = text.splitlines()
+    print(f"=== Structural Analysis: {md_path} ===")
+    print(f"Lines: {len(lines)} | Words: {len(text.split())} | Est. tokens: ~{len(text) // 4}")
+
+    heads = [(i + 1, l) for i, l in enumerate(lines) if l.startswith("#")]
+    levels = Counter(len(re.match(r"^(#+)", h).group(1)) for _, h in heads)
+    print(f"Heading levels: {dict(sorted(levels.items()))} | Total headings: {len(heads)}")
+
+    langs = Counter(re.findall(r"^```(\w*)", text, re.M))
+    print(f"Code-block languages: {dict(langs) if langs else 'none'}")
+
+    tables = sum(1 for l in lines if l.strip().startswith("|"))
+    links = len(re.findall(r"(?<!!)\[[^\]]+\]\([^)]+\)", text))  # (?<!!) excludes image syntax
+    images = len(re.findall(r"!\[[^\]]*\]\([^)]+\)", text))
+    print(f"Table rows: {tables} | Links: {links} | Images: {images}")
+
+    todos = [l for l in lines if re.search(r"TODO|FIXME|HACK|TBD|WIP", l)]
+    print(f"Incomplete markers (TODO/FIXME/HACK/TBD/WIP): {len(todos)}")
+
+    skips = []
+    prev = 0
+    for num, h in heads:
+        level = len(re.match(r"^(#+)", h).group(1))
+        if prev and level > prev + 1:
+            skips.append((num, h))
+        prev = level
+    print(f"Heading skips (affect TOC generation; flag in report): {len(skips)}")
+    for num, h in skips[:5]:
+        print(f"  L{num}: {h}")
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        print("Usage: python3 analyze_structure.py <markdown-file>")
+        sys.exit(1)
+    analyze(sys.argv[1])

--- a/agent_skills/md-review/scripts/extract_refs.py
+++ b/agent_skills/md-review/scripts/extract_refs.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+"""Extract and classify all reference links in a Markdown document (target existence is verified manually by the reviewer)."""
+
+import re
+import sys
+from pathlib import Path
+
+def read_text_safe(md_path):
+    """Read a file, trying utf-8 first then common encodings; exit 2 on missing/binary."""
+    p = Path(md_path)
+    if not p.is_file():
+        print(f"Error: file not found: {md_path}", file=sys.stderr)
+        sys.exit(2)
+    raw = p.read_bytes()
+    if b"\x00" in raw:
+        print(f"Error: binary file (contains NUL bytes): {md_path}", file=sys.stderr)
+        sys.exit(2)
+    for enc in ("utf-8", "latin-1"):
+        try:
+            return raw.decode(enc)
+        except UnicodeDecodeError:
+            continue
+    print(f"Error: cannot decode file: {md_path}", file=sys.stderr)
+    sys.exit(2)
+
+def extract_refs(md_path):
+    content = read_text_safe(md_path)
+
+    # Extract [text](url) links ((?<!!) excludes ![alt](path) image syntax to avoid double counting)
+    links = re.findall(r'(?<!!)\[([^\]]+)\]\(([^)]+)\)', content)
+
+    # Extract ![alt](path) images
+    images = re.findall(r'!\[([^\]]*)\]\(([^)]+)\)', content)
+
+    # Extract <url> bare links
+    bare_urls = re.findall(r'<(https?://[^>]+)>', content)
+
+    print("=== Markdown Reference Extraction ===")
+    print(f"Document: {md_path}")
+    print(f"Text links: {len(links)}")
+    print(f"Image references: {len(images)}")
+    print(f"Bare URLs: {len(bare_urls)}")
+    print()
+
+    all_refs = []
+
+    for text, url in links:
+        all_refs.append({"type": "link", "text": text, "url": url})
+
+    for alt, path in images:
+        all_refs.append({"type": "image", "text": alt, "url": path})
+
+    for url in bare_urls:
+        all_refs.append({"type": "bare_url", "text": url, "url": url})
+
+    # Classify output
+    internal = [r for r in all_refs if not r["url"].startswith(('http://', 'https://'))]
+    external = [r for r in all_refs if r["url"].startswith(('http://', 'https://'))]
+
+    if internal:
+        print("--- Internal References ---")
+        for r in internal:
+            print(f"  [{r['type']}] {r['text'][:30]}... -> {r['url']}")
+
+    if external:
+        print("--- External References ---")
+        for r in external:
+            print(f"  [{r['type']}] {r['text'][:30]}... -> {r['url']}")
+
+    # Check for suspicious references
+    suspicious = []
+    for r in all_refs:
+        url = r["url"]
+        if url.startswith('http://'):
+            suspicious.append((r, "Insecure HTTP protocol"))
+        elif url == '#' or url == '':
+            suspicious.append((r, "Empty link or placeholder"))
+        elif url.startswith('http') and 'localhost' in url:
+            suspicious.append((r, "Link contains localhost"))
+
+    if suspicious:
+        print()
+        print("--- Suspicious References ---")
+        for r, reason in suspicious:
+            print(f"  ⚠️ {reason}: {r['url']}")
+
+if __name__ == '__main__':
+    if len(sys.argv) < 2:
+        print("Usage: python3 extract_refs.py <markdown-file>")
+        sys.exit(1)
+    extract_refs(sys.argv[1])

--- a/agent_skills/md-review/scripts/probe.py
+++ b/agent_skills/md-review/scripts/probe.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+"""Metadata probe: lines/words/est. tokens/heading outline/first-10-line preview/incomplete markers (Phase 0 review plan)."""
+
+import re
+import sys
+from pathlib import Path
+
+def read_text_safe(md_path):
+    """Read a file, trying utf-8 first then common encodings; exit 2 on missing/binary."""
+    p = Path(md_path)
+    if not p.is_file():
+        print(f"Error: file not found: {md_path}", file=sys.stderr)
+        sys.exit(2)
+    raw = p.read_bytes()
+    if b"\x00" in raw:
+        print(f"Error: binary file (contains NUL bytes): {md_path}", file=sys.stderr)
+        sys.exit(2)
+    for enc in ("utf-8", "latin-1"):
+        try:
+            return raw.decode(enc)
+        except UnicodeDecodeError:
+            continue
+    print(f"Error: cannot decode file: {md_path}", file=sys.stderr)
+    sys.exit(2)
+
+def probe(md_path):
+    text = read_text_safe(md_path)
+    lines = text.splitlines()
+    tokens = len(text) // 4  # approx 4 chars = 1 token
+    print("=== Document Metadata Probe ===")
+    print(f"Document: {md_path}")
+    print(f"Lines: {len(lines)} | Words: {len(text.split())} | Est. tokens: ~{tokens}")
+    print()
+    print("--- Heading outline (first 20) ---")
+    heads = [(i + 1, l) for i, l in enumerate(lines) if l.startswith("#")]
+    for num, h in heads[:20]:
+        print(f"  L{num}: {h}")
+    if len(heads) > 20:
+        print(f"  ... {len(heads)} headings total")
+    print()
+    print("--- First 10 lines ---")
+    for l in lines[:10]:
+        print("  " + l if l else "")
+    print()
+    todos = [l for l in lines if re.search(r"TODO|FIXME|TBD|WIP", l)]
+    print(f"Incomplete markers (TODO/FIXME/TBD/WIP): {len(todos)}")
+    for l in todos[:5]:
+        print(f"  {l[:80]}")
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        print("Usage: python3 probe.py <markdown-file>")
+        sys.exit(1)
+    probe(sys.argv[1])

--- a/agent_skills/md-review/scripts/score.py
+++ b/agent_skills/md-review/scripts/score.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+"""Weighted scoring: overall = Σ(dimension×weight), 0-100 validation, grade and risk (Phase 4 report).
+
+Usage: python3 score.py <d1> <d2> <d3> <d4> <d5> <d6> [--p0 N]
+Weights: Logic 30% / Scenario completeness 25% / Sections 15% / References 10% / Redundancy 10% / Format 10%
+--p0 N: P0 (bug-level) issue count, used for the risk level (default 0).
+"""
+
+import sys
+
+WEIGHTS = [0.30, 0.25, 0.15, 0.10, 0.10, 0.10]
+NAMES = ["Logic (bug detection)", "Scenario completeness", "Sections", "References", "Redundancy", "Format"]
+
+def risk_level(total, p0):
+    if total >= 80 and p0 == 0:
+        return "Low"
+    if total >= 60:
+        return "Medium"
+    if total >= 40:
+        return "High"
+    return "Critical"
+
+def score(scores, p0):
+    if len(scores) != 6:
+        print(f"Error: expected 6 dimension scores, got {len(scores)}", file=sys.stderr)
+        sys.exit(2)
+    for s in scores:
+        if not (0 <= s <= 100):
+            print(f"Error: score {s} out of 0-100 range", file=sys.stderr)
+            sys.exit(2)
+    print("=== Weighted Score ===")
+    total = 0.0
+    for n, w, s in zip(NAMES, WEIGHTS, scores):
+        wv = s * w
+        total += wv
+        print(f"  {n}: {s:.0f} x {w:.0%} = {wv:.1f}")
+    print(f"  Overall: {total:.1f}/100")
+    if total >= 90:
+        grade, action = "Excellent", "Ready to publish; minor polish only"
+    elif total >= 75:
+        grade, action = "Good", "Fix P0/P1, then publish"
+    elif total >= 60:
+        grade, action = "Passing", "Must fix P0 (bug-level) before re-review"
+    else:
+        grade, action = "Failing", "Rewrite or restructure recommended"
+    print(f"  Grade: {grade} | Risk: {risk_level(total, p0)}")
+    print(f"  Action: {action}")
+
+if __name__ == "__main__":
+    args = sys.argv[1:]
+    p0 = 0
+    if "--p0" in args:
+        i = args.index("--p0")
+        try:
+            p0 = int(args[i + 1])
+        except (IndexError, ValueError):
+            print("Error: --p0 requires an integer argument", file=sys.stderr)
+            sys.exit(2)
+        del args[i:i + 2]
+    if len(args) < 6:
+        print("Usage: python3 score.py <d1> <d2> <d3> <d4> <d5> <d6> [--p0 N]")
+        sys.exit(1)
+    try:
+        scores = [float(a) for a in args[:6]]
+    except ValueError:
+        print("Error: arguments must be numbers", file=sys.stderr)
+        sys.exit(2)
+    score(scores, p0)

--- a/agent_skills/md-review/scripts/validate_path.py
+++ b/agent_skills/md-review/scripts/validate_path.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+"""Validate that the path argument is a single Markdown (*.md) document.
+
+This is the argument gate for the skill: run it FIRST (SKILL.md Phase 0) before
+any probing or review. It rejects directories, missing files, non-*.md files,
+and binary/undecodable content.
+
+Exit codes (solo protocol): 0 = valid single *.md file; 2 = error
+(missing file, directory target, non-*.md extension, binary/undecodable).
+Usage: python3 validate_path.py <path>
+"""
+
+import sys
+from pathlib import Path
+
+
+def main():
+    if len(sys.argv) < 2:
+        print("Usage: python3 validate_path.py <path>", file=sys.stderr)
+        sys.exit(2)
+    p = Path(sys.argv[1])
+
+    if not p.is_file():
+        kind = "directory" if p.is_dir() else "missing"
+        print(f"Error: {kind} target — expected a single Markdown (*.md) file: {p}", file=sys.stderr)
+        sys.exit(2)
+
+    if p.suffix.lower() != ".md":
+        print(f"Error: not a *.md file (got extension '{p.suffix}'): {p}", file=sys.stderr)
+        sys.exit(2)
+
+    raw = p.read_bytes()
+    if b"\x00" in raw:
+        print(f"Error: binary file (contains NUL bytes): {p}", file=sys.stderr)
+        sys.exit(2)
+
+    for enc in ("utf-8", "latin-1"):
+        try:
+            raw.decode(enc)
+            break
+        except UnicodeDecodeError:
+            continue
+    else:
+        print(f"Error: cannot decode file: {p}", file=sys.stderr)
+        sys.exit(2)
+
+    print(f"OK: single Markdown document: {p}")
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Adds the **md-review** skill to `agent_skills/`.

## What it does

Reviews a single Markdown document across **14 document scenarios** (PRD, API, GDD, TDD, ADR, BRD, MRD, FSD, GDO, LDD, Concept, TLD, TCD) or in generic mode, scoring 6 weighted dimensions — **Logic (bug detection) 30% first**, then scenario completeness 25%, sections 15%, references 10%, redundancy 10%, format 10%. Bugs and logic errors that would break downstream implementation are prioritized over style.

## Meets the bar

- **Real scripts** — 5 deterministic Python helpers (`scripts/`): path gate, metadata probe, structural analysis, reference extraction, weighted scoring. All read-only, no network calls, nothing leaves the machine.
- **Researched references** — `references/` holds 5 review-rules files plus 14 per-scenario required-content checklists, loaded on demand.
- **Evidence over vibes** — every report item must include location + original text; `MD-REVIEW-SUMMARY` block is machine-parseable for CI.
- **Tested before shipped** — self-contained regression suite in the source repo (`bash evals/run_self_test.sh`, 5/5 checks: script verification, clean-doc precision, error-path protocol, registry integrity, step-numbering detection). Development benchmark: 212/213 runs passed (99.5%), 100% of injected defects detected.

## Details

- Source repo: https://github.com/viggo-pod/md-review (MIT, single-commit, also published on ModelScope and skills.sh)
- Folder contains only runtime files (no evals) per the agent_skills convention.