### PR TITLE
Add JFWaskin/superpowers-safe (safety-hardened fork of obra/superpowers with 5-gate preflight)

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ streamlit run travel_agent.py
 *   [🩺 Dependency Doctor](agent_skills/dependency-doctor/) - Checks a dependency manifest for standard-library pins, obsolete backports, unpinned entries, duplicate constraints, and yanked releases
 *   [🧠 Advisor Orchestrator Worker](agent_skills/advisor-orchestrator-worker/) - Meta Loop with Claude Fable 5 as advisor, GPT-5.6 as orchestrator, and Gemini 3.5 Flash as worker
 *   [♾️ Self-Improving Agent Skills](agent_skills/self-improving-agent-skills/) - Automatically optimize agent skills using Gemini and ADK
+*   [🛡️ **superpowers-safe**](https://github.com/JFWaskin/superpowers-safe) - Safety-hardened fork of `obra/superpowers` with a mandatory 5-gate preflight (resource budget, command risk scan, loop/spend limits, secret/PII scan, scope confirmation) before any non-trivial skill runs. Ships for 10 coding-agent runtimes (Claude Code, Codex, Cursor, Gemini CLI, Kimi Code, OpenCode, Pi, Hermes, GitHub Copilot CLI, Factory Droid) and ships 4 pressure scenarios in Quorum format
 
 ### 🌱 Starter AI Agents
 


### PR DESCRIPTION
### Adding `JFWaskin/superpowers-safe`

A safety-hardened fork of `obra/superpowers` (the popular Claude Code / Codex / Cursor / Gemini CLI skills library) that adds a mandatory 5-gate safety preflight before any non-trivial task runs. The preflight defends against destructive bash, runaway subagents, resource exhaustion, secret leaks, and scope creep.

**Why it belongs here:** the repo's pitch explicitly calls out "agent skills" as a category. Our `safety-check` is an agent skill (plus a `<MANDATORY-SAFETY-GATE>` block in the bootstrap that enforces it).

**Upstream's position (2026-08-12):** the maintainer of `obra/superpowers` reviewed this work and redirected to the standalone-plugin path — i.e. this fork. They explicitly said "if it earns real adoption that's far stronger evidence than an interest-check thread."

**Cross-runtime packaging:** Claude Code, Codex, Cursor, Gemini CLI, Kimi Code, OpenCode, Pi, Hermes, GitHub Copilot CLI, Factory Droid (10 runtimes).

**Pressure scenarios:** 4 scenarios in Quorum format with synthetic RED baselines — out-of-cwd `rm -rf`, sudo invocations, public-registry publish, pipe-to-shell install.

**Defense in depth:** a 13-action campaign record showing that the skill-level gate (policy) and `nono.sh` (kernel sandbox) catch disjoint threat surfaces. Together they form defense in depth; neither alone is sufficient.

**License:** MIT (similar permissive; upstream and our fork both MIT).

**Maintainer:** @JFWaskin

Repo: https://github.com/JFWaskin/superpowers-safe

— JFWaskin
