### PR TITLE
Add credential-free temporal memory inspector

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,6 +236,7 @@ streamlit run travel_agent.py
 *   [📝 LLM App with Personalized Memory](advanced_llm_apps/llm_apps_with_memory_tutorials/llm_app_personalized_memory/) - A chatbot that keeps context across conversations
 *   [🗄️ Local ChatGPT Clone with Memory](advanced_llm_apps/llm_apps_with_memory_tutorials/local_chatgpt_with_memory/) - Fully local, with a personal memory per user
 *   [🧠 Multi-LLM Application with Shared Memory](advanced_llm_apps/llm_apps_with_memory_tutorials/multi_llm_memory/) - Different models, one shared conversation memory
+*   [🕰️ Temporal Memory Inspector](advanced_llm_apps/llm_apps_with_memory_tutorials/temporal_memory_inspector/) - Compare what an agent knows now with what it knew at an earlier time
 
 ### 💬 Chat with X
 

--- a/advanced_llm_apps/llm_apps_with_memory_tutorials/temporal_memory_inspector/README.md
+++ b/advanced_llm_apps/llm_apps_with_memory_tutorials/temporal_memory_inspector/README.md
@@ -1,0 +1,46 @@
+## 🕰️ Temporal Memory Inspector
+
+This credential-free Streamlit app demonstrates a failure mode that ordinary chat history cannot solve: a fact changes, but an agent must still answer both "what is true now?" and "what was true then?" without leaking the later update into the historical answer.
+
+The example stores two shipping-estimate revisions in local [Lians](https://github.com/Lians-ai/Lians) memory, then lets you switch between current and point-in-time recall. It runs entirely on your machine with SQLite and a local embedding model; no LLM API key or external database is required.
+
+### Features
+
+- Current recall returns the latest valid shipping estimate
+- Point-in-time recall reconstructs the estimate before a later correction
+- Revisions are seeded newest-first to prove recall does not depend on insertion order
+- Every result includes a SHA-256-verifiable receipt
+- Local SQLite storage with no API key
+
+### How to get started
+
+1. Clone the repository and open this example:
+
+```bash
+git clone https://github.com/Shubhamsaboo/awesome-llm-apps.git
+cd awesome-llm-apps/advanced_llm_apps/llm_apps_with_memory_tutorials/temporal_memory_inspector
+```
+
+2. Install the dependencies:
+
+```bash
+pip install -r requirements.txt
+```
+
+3. Verify the current and historical results from the command line:
+
+```bash
+python verify.py
+```
+
+4. Launch the interactive app:
+
+```bash
+streamlit run app.py
+```
+
+### What to try
+
+Choose **Current state** to see the corrected Monday estimate. Choose **August 2 at noon** to move the memory boundary three hours before the correction and recover the earlier Friday estimate.
+
+The same pattern applies to support agents, policy assistants, research agents, and any workflow where facts change over time.

--- a/advanced_llm_apps/llm_apps_with_memory_tutorials/temporal_memory_inspector/app.py
+++ b/advanced_llm_apps/llm_apps_with_memory_tutorials/temporal_memory_inspector/app.py
@@ -1,0 +1,61 @@
+"""Interactive current-versus-historical memory inspector."""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+
+import streamlit as st
+from lians import LocalLiansClient
+
+from temporal_memory import (
+    HISTORICAL_CUTOFF,
+    contents,
+    recall,
+    seed_timeline,
+)
+
+st.set_page_config(page_title="Temporal Memory Inspector", page_icon="🕰️")
+st.title("🕰️ Temporal Memory Inspector")
+st.caption("Ask an agent what is true now—or what was true before a correction.")
+
+if "lians_db" not in st.session_state:
+    session_dir = Path(tempfile.mkdtemp(prefix="lians-memory-"))
+    st.session_state.lians_db = str(session_dir / "memory.db")
+    with LocalLiansClient(
+        db_path=st.session_state.lians_db,
+        embedding_provider="sentence-transformers",
+    ) as memory:
+        seed_timeline(memory)
+
+st.subheader("Order 1842 timeline")
+left, right = st.columns(2)
+left.info("August 1, 9:00 UTC\n\nEstimate: **Friday**")
+right.warning("August 2, 15:00 UTC\n\nCorrected estimate: **Monday**")
+
+perspective = st.radio(
+    "Memory boundary",
+    ("Current state", "August 2 at noon"),
+    horizontal=True,
+)
+
+if st.button("Recall shipping estimate", type="primary", use_container_width=True):
+    as_of = None if perspective == "Current state" else HISTORICAL_CUTOFF
+    with LocalLiansClient(
+        db_path=st.session_state.lians_db,
+        embedding_provider="sentence-transformers",
+    ) as memory:
+        result = recall(memory, as_of=as_of)
+
+    recalled = contents(result)
+    st.success(recalled[0] if recalled else "No memory matched the query.")
+
+    with st.expander("Inspect verifiable receipt"):
+        st.code(result.get("receipt_sha256", "No receipt hash returned"))
+        st.json(result.get("receipt", {}))
+
+st.divider()
+st.markdown(
+    "Powered by [Lians](https://github.com/Lians-ai/Lians), "
+    "local temporal memory for AI agents."
+)

--- a/advanced_llm_apps/llm_apps_with_memory_tutorials/temporal_memory_inspector/requirements.txt
+++ b/advanced_llm_apps/llm_apps_with_memory_tutorials/temporal_memory_inspector/requirements.txt
@@ -1,0 +1,2 @@
+lians-sdk[local]==0.5.0
+streamlit>=1.40,<2

--- a/advanced_llm_apps/llm_apps_with_memory_tutorials/temporal_memory_inspector/temporal_memory.py
+++ b/advanced_llm_apps/llm_apps_with_memory_tutorials/temporal_memory_inspector/temporal_memory.py
@@ -1,0 +1,61 @@
+"""Shared temporal-memory scenario for the Streamlit app and verifier."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from lians import LocalLiansClient
+
+AGENT_ID = "shipping-support-agent"
+FACT_FILTER = {"entity": "order-1842", "field": "shipping_estimate"}
+QUERY = "When will order 1842 ship?"
+HISTORICAL_CUTOFF = datetime(2026, 8, 2, 12, tzinfo=UTC)
+
+
+def seed_timeline(memory: LocalLiansClient) -> None:
+    """Store a correction newest-first to avoid relying on insertion order."""
+    memory.add(
+        agent_id=AGENT_ID,
+        content="Order 1842 shipping estimate changed to Monday",
+        event_time=datetime(2026, 8, 2, 15, tzinfo=UTC),
+        metadata=FACT_FILTER,
+        source="synthetic-order-event",
+    )
+    memory.add(
+        agent_id=AGENT_ID,
+        content="Order 1842 shipping estimate is Friday",
+        event_time=datetime(2026, 8, 1, 9, tzinfo=UTC),
+        metadata=FACT_FILTER,
+        source="synthetic-order-event",
+    )
+
+
+def recall(memory: LocalLiansClient, as_of: datetime | None = None) -> dict[str, Any]:
+    """Recall the fact at the requested temporal boundary."""
+    return memory.recall(
+        agent_id=AGENT_ID,
+        query=QUERY,
+        filters=FACT_FILTER,
+        as_of=as_of,
+        k=3,
+    )
+
+
+def run_scenario(db_path: str | Path) -> dict[str, dict[str, Any]]:
+    """Seed an isolated database and return current and historical recall."""
+    with LocalLiansClient(
+        db_path=db_path,
+        embedding_provider="sentence-transformers",
+    ) as memory:
+        seed_timeline(memory)
+        return {
+            "current": recall(memory),
+            "historical": recall(memory, as_of=HISTORICAL_CUTOFF),
+        }
+
+
+def contents(result: dict[str, Any]) -> list[str]:
+    """Extract human-readable memory contents from a recall result."""
+    return [item["content"] for item in result["memories"]]

--- a/advanced_llm_apps/llm_apps_with_memory_tutorials/temporal_memory_inspector/verify.py
+++ b/advanced_llm_apps/llm_apps_with_memory_tutorials/temporal_memory_inspector/verify.py
@@ -1,0 +1,48 @@
+"""Executable verification for current and point-in-time recall."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import tempfile
+from pathlib import Path
+from typing import Any
+
+from temporal_memory import contents, run_scenario
+
+
+def verify_receipt(result: dict[str, Any], label: str) -> None:
+    receipt = result.get("receipt")
+    expected = result.get("receipt_sha256")
+    if not isinstance(receipt, dict) or not isinstance(expected, str):
+        raise RuntimeError(f"{label} recall did not return a complete receipt")
+
+    encoded = json.dumps(receipt, sort_keys=True, separators=(",", ":"), default=str)
+    actual = hashlib.sha256(encoded.encode()).hexdigest()
+    if actual != expected:
+        raise RuntimeError(f"{label} receipt hash does not match its payload")
+
+
+def main() -> None:
+    with tempfile.TemporaryDirectory() as temp_dir:
+        results = run_scenario(Path(temp_dir) / "memory.db")
+
+    current = contents(results["current"])
+    historical = contents(results["historical"])
+
+    if not any("Monday" in item for item in current):
+        raise RuntimeError("current recall did not return the Monday estimate")
+    if any("Friday" in item for item in current):
+        raise RuntimeError("current recall leaked the superseded Friday estimate")
+    if not any("Friday" in item for item in historical):
+        raise RuntimeError("historical recall did not return the Friday estimate")
+    if any("Monday" in item for item in historical):
+        raise RuntimeError("historical recall leaked the later Monday estimate")
+
+    verify_receipt(results["current"], "current")
+    verify_receipt(results["historical"], "historical")
+    print("PASS: current and point-in-time memory stayed separated")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What changed

Adds a credential-free Streamlit app to the existing **LLM Apps with Memory** section. The app stores a shipping-estimate correction in local Lians memory and lets users compare current recall with point-in-time recall before the correction.

The example includes:

- an interactive current-versus-historical memory inspector
- local SQLite persistence and on-device embeddings
- newest-first seeding to show recall is independent of insertion order
- receipt inspection and executable SHA-256 verification
- setup and usage documentation

## Why

Most memory examples demonstrate persistence. This one demonstrates a different practical failure mode: facts change, but an agent still needs to answer what was true at an earlier time without leaking a later update.

## Validation

- `python verify.py`
- Streamlit `AppTest` load and recall-button interaction
- `python -m py_compile` on all Python files
- `git diff --check`