### PR TITLE
Use Gemini 3.7 Flash for advisor-orchestrator-worker workers

### DIFF
--- a/agent_skills/advisor-orchestrator-worker/README.md
+++ b/agent_skills/advisor-orchestrator-worker/README.md
@@ -11,7 +11,7 @@ This skill turns your coding agent into the orchestrator of a three-tier model t
 | Role | Default model <sub>(July 2026, swap freely)</sub> | What it does | What it never does |
 |---|---|---|---|
 | **Orchestrator** | GPT-5.6 | Frames success criteria, plans waves, dispatches briefs, verifies every result, synthesizes the deliverable | Worker-level grunt work |
-| **Workers** | Gemini 3.5 Flash | One self-contained subtask each, in parallel, stateless; each sees only its brief, with tool access when the subtask needs it | Talk to each other, expand scope, get a second chance on the same call |
+| **Workers** | Gemini 3.7 Flash | One self-contained subtask each, in parallel, stateless; each sees only its brief, with tool access when the subtask needs it | Talk to each other, expand scope, get a second chance on the same call |
 | **Advisor** | Claude Fable 5 | Plan review before any dispatch, taste pass before delivery, called mid-run only at commitment boundaries | Execute anything |
 
 The economics are the point: cheap parallel generation where volume wins, expensive judgment only where it changes a decision. Every run states a budget up front, sized to the plan, and never spends past it silently: running out means an honest report or an explicit ask, not quiet burn. Models are knobs: the tier pattern is the durable part, the defaults were current in July 2026.

--- a/agent_skills/advisor-orchestrator-worker/SKILL.md
+++ b/agent_skills/advisor-orchestrator-worker/SKILL.md
@@ -33,7 +33,7 @@ on another shell, run them with `bash -c`.
 
 ## The team
 
-- **Workers (default: Gemini 3.5 Flash via the Antigravity CLI, `agy`)**: stateless
+- **Workers (default: Gemini 3.7 Flash via the Antigravity CLI, `agy`)**: stateless
   generation units, with tools (web search, file work) when a
   subtask needs them. Never interpolate a brief into a shell string;
   briefs carry quotes and arbitrary text, so that is a shell-injection
@@ -45,7 +45,7 @@ on another shell, run them with `bash -c`.
   # $brief = this worker's brief file; $out = its result file (absolute path)
   d=$(mktemp -d)
   ( cd "$d" && env -i HOME="$HOME" PATH="$PATH" \
-      agy --dangerously-skip-permissions --model "gemini-3.5-flash" \
+      agy --dangerously-skip-permissions --model "gemini-3.7-flash" \
       --print-timeout 5m -p "$(cat "$brief")" \
       > "$out"; s=$?; rm -rf "$d"; exit "$s" ) &
   pids+=($!)

--- a/agent_skills/advisor-orchestrator-worker/references/fallbacks.md
+++ b/agent_skills/advisor-orchestrator-worker/references/fallbacks.md
@@ -18,7 +18,7 @@ api_key="${GEMINI_API_KEY:-$GOOGLE_API_KEY}"
 ( set -o pipefail
   jq -n --rawfile t "$brief" '{contents:[{parts:[{text:$t}]}]}' \
     | curl -sS --fail --max-time 300 \
-      "https://generativelanguage.googleapis.com/v1beta/models/gemini-3.5-flash:generateContent" \
+      "https://generativelanguage.googleapis.com/v1beta/models/gemini-3.7-flash:generateContent" \
       -H "x-goog-api-key: $api_key" -H "Content-Type: application/json" -d @- \
     | jq -r '.candidates[0].content.parts[0].text' > "$out" ) &
 pids+=($!)


### PR DESCRIPTION
## What

Bumps the default worker model in the `advisor-orchestrator-worker` agent skill from Gemini 3.5 Flash to Gemini 3.7 Flash (`gemini-3.7-flash`).

## Changes

- `README.md` — workers row in the team table
- `SKILL.md` — workers default description and the `agy --model` dispatch snippet
- `references/fallbacks.md` — bare Gemini API `generateContent` endpoint

Docs only, no behavior change beyond the model id.

🤖 Generated with [Claude Code](https://claude.com/claude-code)