### PR TITLE
fix(docs): fix relative directory link for AI Travel Planner Agent Team

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ streamlit run travel_agent.py
 *   [💻 Multimodal Coding Agent Team](advanced_ai_agents/multi_agent_apps/agent_teams/multimodal_coding_agent_team/) - Snap a photo of a coding problem, get a sandboxed solution
 *   [✨ Multimodal Design Agent Team](advanced_ai_agents/multi_agent_apps/agent_teams/multimodal_design_agent_team/) - Design critiques from a Gemini-powered expert panel
 *   [🎨 🍌 Multimodal UI/UX Feedback Agent Team](advanced_ai_agents/multi_agent_apps/agent_teams/multimodal_uiux_feedback_agent_team/) - Landing page feedback plus an auto-generated improved version
-*   [🌏 AI Travel Planner Agent Team](/advanced_ai_agents/multi_agent_apps/agent_teams/ai_travel_planner_agent_team/) - A complete trip itinerary, crafted by a team
+*   [🌏 AI Travel Planner Agent Team](advanced_ai_agents/multi_agent_apps/agent_teams/ai_travel_planner_agent_team/) - A complete trip itinerary, crafted by a team
 
 ### 🗣️ Voice AI Agents
 


### PR DESCRIPTION
### Summary
- Fixes leading slash in `[AI Travel Planner Agent Team]` link in `README.md` (`/advanced_ai_agents/...` -> `advanced_ai_agents/...`) so that relative navigation works consistently across GitHub markdown views and clone directories.