### PR TITLE
docs: add BosAI to Multi-agent Teams

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ streamlit run travel_agent.py
 *   [🎯 博思AI智能体 (Bos AI)](https://github.com/ysy0915/chat-system) - Multi-model debate (3-6 LLMs) + parallel Multi-Agent workflow with RabbitMQ + RAG with Milvus + reusable LLM gateway (Java/Spring Boot)
 *   [🎯 博思AI智能体 (Bos AI)](https://github.com/ysy0915/chat-system) - Multi-model debate (3-6 LLMs) + parallel Multi-Agent workflow with RabbitMQ + RAG with Milvus + reusable LLM gateway (Java/Spring Boot)
 *   [🎯 博思AI智能体 (Bos AI)](https://github.com/ysy0915/chat-system) - Multi-model debate (3-6 LLMs) + parallel Multi-Agent workflow with RabbitMQ + RAG with Milvus + reusable LLM gateway (Java/Spring Boot)
+*   [🎯 博思AI智能体 (Bos AI)](https://github.com/ysy0915/chat-system) - Multi-model debate (3-6 LLMs) + parallel Multi-Agent workflow with RabbitMQ + RAG with Milvus + reusable LLM gateway (Java/Spring Boot)
 
 ### 🗣️ Voice AI Agents
 

--- a/README.md
+++ b/README.md
@@ -160,6 +160,7 @@ streamlit run travel_agent.py
 *   [🌏 AI Travel Planner Agent Team](/advanced_ai_agents/multi_agent_apps/agent_teams/ai_travel_planner_agent_team/) - A complete trip itinerary, crafted by a team
 *   [🎯 博思AI智能体 (Bos AI)](https://github.com/ysy0915/chat-system) - Multi-model debate (3-6 LLMs) + parallel Multi-Agent workflow with RabbitMQ + RAG with Milvus + reusable LLM gateway (Java/Spring Boot)
 *   [🎯 博思AI智能体 (Bos AI)](https://github.com/ysy0915/chat-system) - Multi-model debate (3-6 LLMs) + parallel Multi-Agent workflow with RabbitMQ + RAG with Milvus + reusable LLM gateway (Java/Spring Boot)
+*   [🎯 博思AI智能体 (Bos AI)](https://github.com/ysy0915/chat-system) - Multi-model debate (3-6 LLMs) + parallel Multi-Agent workflow with RabbitMQ + RAG with Milvus + reusable LLM gateway (Java/Spring Boot)
 
 ### 🗣️ Voice AI Agents
 

--- a/README.md
+++ b/README.md
@@ -158,6 +158,7 @@ streamlit run travel_agent.py
 *   [✨ Multimodal Design Agent Team](advanced_ai_agents/multi_agent_apps/agent_teams/multimodal_design_agent_team/) - Design critiques from a Gemini-powered expert panel
 *   [🎨 🍌 Multimodal UI/UX Feedback Agent Team](advanced_ai_agents/multi_agent_apps/agent_teams/multimodal_uiux_feedback_agent_team/) - Landing page feedback plus an auto-generated improved version
 *   [🌏 AI Travel Planner Agent Team](/advanced_ai_agents/multi_agent_apps/agent_teams/ai_travel_planner_agent_team/) - A complete trip itinerary, crafted by a team
+*   [🎯 博思AI智能体 (Bos AI)](https://github.com/ysy0915/chat-system) - Multi-model debate (3-6 LLMs) + parallel Multi-Agent workflow with RabbitMQ + RAG with Milvus + reusable LLM gateway (Java/Spring Boot)
 
 ### 🗣️ Voice AI Agents
 

--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ streamlit run travel_agent.py
 *   [🎨 🍌 Multimodal UI/UX Feedback Agent Team](advanced_ai_agents/multi_agent_apps/agent_teams/multimodal_uiux_feedback_agent_team/) - Landing page feedback plus an auto-generated improved version
 *   [🌏 AI Travel Planner Agent Team](/advanced_ai_agents/multi_agent_apps/agent_teams/ai_travel_planner_agent_team/) - A complete trip itinerary, crafted by a team
 *   [🎯 博思AI智能体 (Bos AI)](https://github.com/ysy0915/chat-system) - Multi-model debate (3-6 LLMs) + parallel Multi-Agent workflow with RabbitMQ + RAG with Milvus + reusable LLM gateway (Java/Spring Boot)
+*   [🎯 博思AI智能体 (Bos AI)](https://github.com/ysy0915/chat-system) - Multi-model debate (3-6 LLMs) + parallel Multi-Agent workflow with RabbitMQ + RAG with Milvus + reusable LLM gateway (Java/Spring Boot)
 
 ### 🗣️ Voice AI Agents
 


### PR DESCRIPTION
## New Project

**博思AI智能体 (Bos AI)** — Multi-model debate + Multi-Agent parallel workflow platform

### Highlights

- **Multi-Model Debate**: 3-6 LLMs (DeepSeek/Qwen/Doubao) randomly teamed for debates with reflection rounds and judgment-style synthesis; tree-mode debate auto-decomposes perspectives, parallel debate, summary
- **Multi-Agent Parallel Workflow**: Long requests split into ≤9 subtasks, RabbitMQ dispatch to dual-instance workers, converge and compress; Redis Lua atomic rate limiting + DLX dead-letter retry + Reconciler reconciliation
- **RAG**: Document upload (PDF/Word/TXT), auto chunking, Milvus vector store, intent-driven auto retrieval; 3-layer memory (Redis short-term + Milvus long-term + user profile)
- **Reusable LLM Gateway**: `chat-llm` module supports zero-dependency standalone deployment (pure in-memory), SPI strategy factory for provider extension

### Tech Stack

Spring Boot 3.1 + gRPC + RabbitMQ + Milvus + Neo4j + React 18 | 722 tests | Prometheus 12 alerts | 24 ADRs

### Links

- Repo: https://github.com/ysy0915/chat-system
- Live demo: http://112.124.106.108/chat/home

### Change

Added one entry to the `Multi-agent Teams` section.
