### PR TITLE
Add AI Paper Research Agent starter example

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ streamlit run travel_agent.py
 *   [🩻 AI Medical Imaging Agent](starter_ai_agents/ai_medical_imaging_agent/) - Diagnostic analysis of X-rays and scans with Gemini
 *   [😂 AI Meme Generator Agent (Browser)](starter_ai_agents/ai_meme_generator_agent_browseruse/) - Makes memes by driving a real browser, not an image API
 *   [🎵 AI Music Generator Agent](starter_ai_agents/ai_music_generator_agent/) - Prompt in, MP3 track out
+*   [📄 AI Paper Research Agent](starter_ai_agents/ai_paper_research_agent/) - Literature review from real paper abstracts, every claim cited
 *   [🛫 AI Travel Agent (Local & Cloud)](starter_ai_agents/ai_travel_agent/) - Personalized day-by-day travel itineraries
 *   [✨ Gemini Multimodal Agent](starter_ai_agents/multimodal_ai_agent/) - Video analysis plus web search in one agent
 *   [🔄 Mixture of Agents](starter_ai_agents/mixture_of_agents/) - Multiple LLMs answer, one aggregates the best response

--- a/starter_ai_agents/ai_paper_research_agent/README.md
+++ b/starter_ai_agents/ai_paper_research_agent/README.md
@@ -1,0 +1,50 @@
+## 📄 AI Paper Research Agent
+A Streamlit app that turns a research topic into a cited literature review. It searches academic
+indexes (arXiv, OpenAlex, Semantic Scholar, Crossref) through CRW's research API, pulls the
+abstracts, and has GPT-4o write a review where every claim carries the source it came from.
+
+Unlike a general web-search research agent, this one only ever reads paper abstracts, so the output
+stays traceable to real publications instead of blog posts and marketing pages.
+
+## Features
+
+- **Academic search**: Queries multiple paper indexes in one call and ranks the results by relevance.
+
+- **Abstract backfill**: When a search hit arrives without an abstract, the agent fetches the paper
+  record to get it, so the review is never written from titles alone.
+
+- **Cited review**: GPT-4o writes the review from the abstracts only, with a bracketed citation on
+  every claim and an explicit note when sources disagree.
+
+- **Source list**: Every paper used is listed underneath with a link to arXiv where available.
+
+## How to get Started?
+
+1. **Clone the GitHub repository**
+
+```bash
+git clone https://github.com/Shubhamsaboo/awesome-llm-apps.git
+cd awesome-llm-apps/starter_ai_agents/ai_paper_research_agent
+```
+
+2. **Install the required dependencies**
+
+```bash
+pip install -r requirements.txt
+```
+
+3. **Get your API keys**
+
+- **OpenAI**: sign up at [platform.openai.com](https://platform.openai.com/api-keys)
+- **CRW**: sign up at [fastcrw.com](https://fastcrw.com) for a hosted key, or run the open-source
+  engine yourself and point the SDK at it with `CRW_API_URL`
+
+4. **Run the Streamlit app**
+
+```bash
+streamlit run paper_research_agent.py
+```
+
+5. **Use the app**
+
+Paste both keys into the sidebar, pick how many papers to review, type a topic, and press Research.

--- a/starter_ai_agents/ai_paper_research_agent/paper_research_agent.py
+++ b/starter_ai_agents/ai_paper_research_agent/paper_research_agent.py
@@ -1,0 +1,84 @@
+import streamlit as st
+from crw import CrwClient
+from openai import OpenAI
+
+st.set_page_config(page_title="AI Paper Research Agent", page_icon="📄")
+st.title("📄 AI Paper Research Agent")
+st.caption(
+    "Search academic literature across arXiv, OpenAlex, Semantic Scholar and Crossref, "
+    "then get a cited literature review written from the abstracts."
+)
+
+# API Keys (Runtime Input)
+st.sidebar.header("API Keys")
+openai_key = st.sidebar.text_input("OpenAI API Key", type="password")
+crw_key = st.sidebar.text_input("CRW API Key", type="password")
+st.sidebar.caption("Get a CRW key at fastcrw.com. Self-hosters can leave it blank and set CRW_API_URL instead.")
+
+paper_count = st.sidebar.slider("Papers to review", min_value=3, max_value=15, value=8)
+
+topic = st.text_input("Research topic:", placeholder="graph neural networks for drug discovery")
+
+
+def find_papers(client: CrwClient, query: str, k: int) -> list[dict]:
+    """Search the research index and backfill any abstract the search result omitted."""
+    results = client.search_papers(query, k=k).get("results", [])
+    papers = []
+    for result in results:
+        abstract = result.get("abstract")
+        if not abstract:
+            detail = client.get_paper(result["paperId"], query=query)
+            abstract = detail.get("paper", {}).get("abstract")
+        if abstract:
+            papers.append({"title": result["title"], "abstract": abstract, "id": result["paperId"]})
+    return papers
+
+
+def write_review(client: OpenAI, query: str, papers: list[dict]) -> str:
+    sources = "\n\n".join(
+        f"[{i}] {p['title']} ({p['id']})\n{p['abstract']}" for i, p in enumerate(papers, 1)
+    )
+    response = client.chat.completions.create(
+        model="gpt-4o",
+        messages=[
+            {
+                "role": "system",
+                "content": (
+                    "You are a research assistant. Write a literature review from the provided "
+                    "abstracts only. Cite every claim with the bracketed source number it came "
+                    "from. If the abstracts disagree, say so. Do not add outside knowledge."
+                ),
+            },
+            {"role": "user", "content": f"Topic: {query}\n\nSources:\n{sources}"},
+        ],
+    )
+    return response.choices[0].message.content
+
+
+if st.button("Research", disabled=not (openai_key and topic.strip())):
+    with st.spinner("Searching papers..."):
+        try:
+            crw = CrwClient(api_key=crw_key or None)
+            papers = find_papers(crw, topic.strip(), paper_count)
+        except Exception as e:
+            st.error(f"Paper search failed: {e}")
+            st.stop()
+
+    if not papers:
+        st.warning("No papers with abstracts found. Try a broader topic.")
+        st.stop()
+
+    st.success(f"Found {len(papers)} papers")
+    with st.spinner("Writing the literature review..."):
+        try:
+            review = write_review(OpenAI(api_key=openai_key), topic.strip(), papers)
+        except Exception as e:
+            st.error(f"Review generation failed: {e}")
+            st.stop()
+
+    st.markdown(review)
+    st.subheader("Sources")
+    for i, paper in enumerate(papers, 1):
+        arxiv_id = paper["id"].removeprefix("arxiv:")
+        link = f"https://arxiv.org/abs/{arxiv_id}" if paper["id"].startswith("arxiv:") else None
+        st.markdown(f"[{i}] [{paper['title']}]({link})" if link else f"[{i}] {paper['title']}")

--- a/starter_ai_agents/ai_paper_research_agent/requirements.txt
+++ b/starter_ai_agents/ai_paper_research_agent/requirements.txt
@@ -1,0 +1,3 @@
+streamlit>=1.40.2
+openai>=1.102.0
+crw>=0.30.0


### PR DESCRIPTION
adds a starter agent that answers a research question from academic literature instead of general web pages.

what it does:
- searches arXiv, OpenAlex, Semantic Scholar and Crossref in one call via CRW's research API
- backfills the abstract when a search hit comes back without one, so the review is never written from titles alone
- GPT-4o writes a literature review from those abstracts only, with a bracketed citation on every claim
- lists every paper used underneath, linked to arXiv where available

follows the existing starter layout: `README.md`, `requirements.txt`, single Streamlit file, plus one index line in the root README.

tested against the live research API (8 requested, 7 returned with abstracts after backfill) and the app boots clean under `streamlit run`.

CRW is open source (AGPL-3.0) and self-hostable, so the example also runs without a hosted key by pointing `CRW_API_URL` at your own engine.