### PR TITLE
fix(advisor-orchestrator-worker): specify high effort for Gemini workers

### DIFF
--- a/agent_skills/advisor-orchestrator-worker/SKILL.md
+++ b/agent_skills/advisor-orchestrator-worker/SKILL.md
@@ -45,7 +45,7 @@ on another shell, run them with `bash -c`.
   # $brief = this worker's brief file; $out = its result file (absolute path)
   d=$(mktemp -d)
   ( cd "$d" && env -i HOME="$HOME" PATH="$PATH" \
-      agy --dangerously-skip-permissions --model "gemini-3.7-flash" \
+      agy --dangerously-skip-permissions --model "gemini-3.7-flash" --effort high \
       --print-timeout 5m -p "$(cat "$brief")" \
       > "$out"; s=$?; rm -rf "$d"; exit "$s" ) &
   pids+=($!)
@@ -53,7 +53,8 @@ on another shell, run them with `bash -c`.
 
   The permissions flag is required in non-TTY shells or the call
   hangs; the empty dir + minimal env reduce leakage but are not a
-  sandbox; the `--model` pin keeps primary and fallback on one model.
+  sandbox; the `--model` pin keeps primary and fallback on one model,
+  and `--effort high` satisfies the CLI's required effort selection.
   Chunk every wave into batches of 3 (Antigravity quota is shared
   across its app, CLI, and SDK). Start each batch with `pids=()`, reap
   each worker with its own `wait "$pid"` (a collective wait reports


### PR DESCRIPTION
## Summary

  - Add `--effort high` to the `agy` worker invocation.
  - Document why the explicit effort setting is required.

  ## Problem

  With `agy` 1.1.13, selecting `gemini-3.7-flash` without an effort level causes every worker dispatch to fail before
  reaching the model:

  ```text
  Error: invalid model selection (--model "gemini-3.7-flash" --effort ""):
  --model gemini-3.7-flash requires --effort
  (available: low, medium, high)

  ## Fix

  Update the worker command to include:

  agy --dangerously-skip-permissions \
    --model "gemini-3.7-flash" \
    --effort high

  ## Validation

  Tested with agy 1.1.13 by dispatching three isolated Gemini 3.7 Flash workers concurrently. All workers completed
  successfully, returned valid JSON, and passed exact jq assertions.

  Without the flag: 3/3 dispatches failed locally.
  With --effort high: 3/3 dispatches passed.