### PR TITLE
fix: remove deprecated pathlib backport and migrate PyPDF2 to pypdf

### DIFF
--- a/advanced_ai_agents/autonomous_game_playing_agent_apps/ai_tic_tac_toe_agent/requirements.txt
+++ b/advanced_ai_agents/autonomous_game_playing_agent_apps/ai_tic_tac_toe_agent/requirements.txt
@@ -112,8 +112,6 @@ packaging==24.2
     #   streamlit
 pandas==2.2.3
     # via streamlit
-pathlib==1.0.1
-    # via -r cookbook/examples/apps/tic_tac_toe/requirements.in
 pillow==11.1.0
     # via
     #   -r cookbook/examples/apps/tic_tac_toe/requirements.in

--- a/advanced_ai_agents/multi_agent_apps/agent_teams/ai_recruitment_agent_team/README.md
+++ b/advanced_ai_agents/multi_agent_apps/agent_teams/ai_recruitment_agent_team/README.md
@@ -83,7 +83,7 @@ A Streamlit application that simulates a full-service recruitment team using mul
 - **Framework**: Phidata
 - **Model**: OpenAI GPT-4o
 - **Integration**: Zoom API, EmailTools Tool from Phidata
-- **PDF Processing**: PyPDF2
+- **PDF Processing**: pypdf
 - **Time Management**: pytz
 - **State Management**: Streamlit Session State
 

--- a/advanced_ai_agents/multi_agent_apps/agent_teams/ai_recruitment_agent_team/ai_recruitment_agent_team.py
+++ b/advanced_ai_agents/multi_agent_apps/agent_teams/ai_recruitment_agent_team/ai_recruitment_agent_team.py
@@ -3,7 +3,7 @@ import os
 import time
 import json
 import requests
-import PyPDF2
+import pypdf
 from datetime import datetime, timedelta
 import pytz
 
@@ -177,7 +177,7 @@ def create_scheduler_agent() -> Agent:
 
 def extract_text_from_pdf(pdf_file) -> str:
     try:
-        pdf_reader = PyPDF2.PdfReader(pdf_file)
+        pdf_reader = pypdf.PdfReader(pdf_file)
         text = ""
         for page in pdf_reader.pages:
             text += page.extract_text()

--- a/advanced_ai_agents/multi_agent_apps/agent_teams/ai_recruitment_agent_team/requirements.txt
+++ b/advanced_ai_agents/multi_agent_apps/agent_teams/ai_recruitment_agent_team/requirements.txt
@@ -1,7 +1,7 @@
 # Core dependencies
 agno>=2.2.10
 streamlit==1.40.2
-PyPDF2==3.0.1
+pypdf>=4.0.0
 streamlit-pdf-viewer==0.0.19
 requests==2.32.3
 pytz==2023.4

--- a/rag_tutorials/rag_chain/requirements.txt
+++ b/rag_tutorials/rag_chain/requirements.txt
@@ -5,5 +5,5 @@ langchain-community
 langchain-core
 chromadb
 sentence-transformers
-PyPDF2
+pypdf>=4.0.0
 python-dotenv


### PR DESCRIPTION
## Summary

- Remove abandoned `pathlib==1.0.1` backport from `ai_tic_tac_toe_agent` requirements
- Migrate `PyPDF2` to maintained `pypdf` in `ai_recruitment_agent_team` and `rag_chain`
- Update README and Python imports to match

## Problem

Fixes #1029

The issue flagged two hygiene problems found across the repo:

1. **`pathlib==1.0.1`** pinned in `ai_tic_tac_toe_agent/requirements.txt` is the abandoned 2012 backport of the stdlib module. Installing it can shadow and break Python's built-in `pathlib` on modern Python. The code already uses `from pathlib import Path` (stdlib), so the package is unnecessary.

2. **`PyPDF2`** is deprecated and had a ReDoS vulnerability (CVE-2023-36810). The maintained successor is `pypdf`, which the rest of the repo already uses in 10+ other projects (e.g., `ai_legal_agent_team`, `chat_with_research_papers`, `hybrid_search_rag`, `local_rag_agent`, etc.).

## Fix

### pathlib removal
Removed `pathlib==1.0.1` and its `# via` comment from `ai_tic_tac_toe_agent/requirements.txt`. The stdlib `pathlib` module has been available since Python 3.4, so no replacement is needed.

### PyPDF2 to pypdf migration
Replaced `PyPDF2` with `pypdf>=4.0.0` in two projects:

**ai_recruitment_agent_team** (direct usage):
- `requirements.txt`: `PyPDF2==3.0.1` -> `pypdf>=4.0.0`
- `ai_recruitment_agent_team.py`: `import PyPDF2` -> `import pypdf`, `PyPDF2.PdfReader` -> `pypdf.PdfReader`
- `README.md`: updated tech stack mention

**rag_chain** (unused dependency):
- `requirements.txt`: `PyPDF2` -> `pypdf>=4.0.0`
- `app.py` uses `PyPDFLoader` from `langchain_community` (not `PyPDF2` directly), but `langchain_community` requires `pypdf` internally, so the dependency is now correct.

The `pypdf.PdfReader` API is identical to `PyPDF2.PdfReader` (same `.pages` property, same `.extract_text()` method). Verified locally with pypdf 6.10.2.

## Files changed

| File | Change |
|------|--------|
| `ai_tic_tac_toe_agent/requirements.txt` | Removed `pathlib==1.0.1` (2 lines) |
| `ai_recruitment_agent_team/requirements.txt` | `PyPDF2==3.0.1` -> `pypdf>=4.0.0` |
| `ai_recruitment_agent_team/ai_recruitment_agent_team.py` | `import PyPDF2` -> `import pypdf`, `PyPDF2.PdfReader` -> `pypdf.PdfReader` |
| `ai_recruitment_agent_team/README.md` | `PyPDF2` -> `pypdf` in tech stack |
| `rag_chain/requirements.txt` | `PyPDF2` -> `pypdf>=4.0.0` |

#### Test plan

- [x] Python syntax check passes on `ai_recruitment_agent_team.py`
- [x] `pypdf.PdfReader` API verified compatible (same `.pages` and `.extract_text()`)
- [x] No remaining `PyPDF2` references in requirements, Python files, or READMEs
- [x] No remaining `pathlib==1.0.1` in any requirements file
- [x] `cloudpathlib` (legitimate package in `beifong/requirements.txt`) not touched
