### PR TITLE
Add UIZZE anti-UI-slop external skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ streamlit run travel_agent.py
 *   [🩺 Dependency Doctor](agent_skills/dependency-doctor/) - Checks a dependency manifest for standard-library pins, obsolete backports, unpinned entries, duplicate constraints, and yanked releases
 *   [🧠 Advisor Orchestrator Worker](agent_skills/advisor-orchestrator-worker/) - Meta Loop with Claude Fable 5 as advisor, GPT-5.6 as orchestrator, and Gemini 3.7 Flash as worker
 *   [♾️ Self-Improving Agent Skills](agent_skills/self-improving-agent-skills/) - Automatically optimize agent skills using Gemini and ADK
+*   [🛡️ UIZZE anti-UI-slop](https://github.com/uizze/uizze) <sub>↗ external</sub> - Portable skill and GitHub Action for Codex, Claude Code, Cursor, and Copilot that uses a product-specific design contract, complete interaction states, audits, and a hard finish gate to prevent generic UI, grounded in 800,000+ real web and iOS screens
 
 ### 🌱 Starter AI Agents
 


### PR DESCRIPTION
Adds UIZZE to the Agent Skills section as an external resource, following the repository's existing external-entry format.

UIZZE provides a portable anti-UI-slop skill and GitHub Action for Codex, Claude Code, Cursor, and Copilot. It uses product-specific design contracts, complete interaction states, audits, and a hard finish gate grounded in 800,000+ real web and iOS screens.

Validation:
- `git diff --check`
- canonical repository link verified: https://github.com/uizze/uizze
- public skill install source verified: https://uizze.com