### PR TITLE
feat: add runnable UIZZE anti-ui-slop skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ streamlit run travel_agent.py
 *Give your coding agent new abilities. One command to install, plain English to use. Every skill ships real code and passes a security + eval CI gate. Works with Claude Code, Codex, Cursor, and other coding agents. [Browse all skills →](agent_skills/)*
 
 *   [⚰️ Project Graveyard](agent_skills/project-graveyard/) - Finds every side project you abandoned, tells you why each one died, and helps you finish the one worth going back to
+*   [🛡️ UIZZE Anti-UI-Slop Gate](agent_skills/anti-ui-slop/) - Deterministic local checks for generic copy, inert controls, missing states, inaccessible images, and token drift before UI ships
 *   [🔭 Scope Creep Detector](agent_skills/scope-creep-detector/) - Checks whether a diff grew beyond its stated intent and recommends what to keep, split, or justify
 *   [🏺 Commit Archaeologist](agent_skills/commit-archaeologist/) - Reconstructs why a file or code region exists from its introducing commit, later edits, co-changes, and intent clues
 *   [🩺 Dependency Doctor](agent_skills/dependency-doctor/) - Checks a dependency manifest for standard-library pins, obsolete backports, unpinned entries, duplicate constraints, and yanked releases

--- a/agent_skills/anti-ui-slop/README.md
+++ b/agent_skills/anti-ui-slop/README.md
@@ -1,0 +1,46 @@
+# 🛡️ Anti-UI-Slop Gate
+
+A small, local-first Agent Skill for catching concrete UI quality risks before
+they ship. It is a runnable example from [UIZZE](https://uizze.com)'s broader
+anti-UI-slop workflow, packaged for the [Awesome LLM Apps](https://github.com/Shubhamsaboo/awesome-llm-apps)
+collection.
+
+## Install
+
+```bash
+npx skills add https://github.com/Shubhamsaboo/awesome-llm-apps/tree/main/agent_skills/anti-ui-slop
+```
+
+Then ask an agent to audit a frontend project for UI slop, or run the core
+checker directly:
+
+```bash
+python3 scripts/check_ui_slop.py --path /path/to/project
+```
+
+## What it checks
+
+- generic placeholder copy;
+- buttons that have no visible source-level action hook;
+- images without an `alt` attribute;
+- forms with no visible state vocabulary;
+- repeated raw color values in CSS.
+
+The checker is deterministic, uses only the Python standard library, and never
+edits the project or accesses the network. Source heuristics are triage, not a
+design verdict: delegated event handlers, generated markup, and intentional
+one-off values need human review.
+
+## Example output
+
+```text
+WARN generic-copy src/Checkout.tsx:18 — placeholder copy: "Click here"
+WARN inert-control src/Checkout.tsx:32 — button has no visible action hook
+ERROR image-alt src/Checkout.tsx:41 — image is missing alt text
+
+3 finding(s): 1 error, 2 warning(s)
+```
+
+For live UI evidence, the full [UIZZE MCP](https://uizze.com) can search
+800,000+ real web and iOS screens. The free local Skill and no-account preview
+remain available from the [canonical UIZZE repository](https://github.com/uizze/uizze).

--- a/agent_skills/anti-ui-slop/README.md
+++ b/agent_skills/anti-ui-slop/README.md
@@ -8,7 +8,7 @@ collection.
 ## Install
 
 ```bash
-npx skills add https://github.com/Shubhamsaboo/awesome-llm-apps/tree/main/agent_skills/anti-ui-slop
+npx skills add https://github.com/uizze/uizze --skill anti-ui-slop
 ```
 
 Then ask an agent to audit a frontend project for UI slop, or run the core

--- a/agent_skills/anti-ui-slop/SKILL.md
+++ b/agent_skills/anti-ui-slop/SKILL.md
@@ -1,0 +1,86 @@
+---
+name: anti-ui-slop
+description: >-
+  Checks web UI source for generic copy, inert controls, missing interaction
+  states, inaccessible images, and raw token drift, then produces a focused
+  finish-gate report. Use when the user asks to audit UI quality, stop UI slop,
+  review a frontend diff, or check whether an interface feels generic before
+  shipping.
+license: Apache-2.0
+compatibility: Runs locally with Python 3.8+; no network access or external services required.
+metadata:
+  author: "UIZZE"
+  version: "1.0.0"
+  source: "https://github.com/uizze/uizze"
+---
+
+# Anti-UI-Slop Gate
+
+Generic UI is usually a quality problem before it is a style problem. This
+skill gives the agent a small, deterministic first pass over frontend source,
+then turns the findings into a product-specific finish gate.
+
+The local checker is intentionally limited. It does not pretend to understand
+the product, replace a rendered review, or judge taste from source text alone.
+It catches concrete signals so the agent can spend its judgment on the user's
+job, the existing design system, and the states the interface must survive.
+
+## Run the local check
+
+From this skill directory, scan one file or a project directory:
+
+```bash
+python3 scripts/check_ui_slop.py --path /path/to/project
+```
+
+Use JSON when the result will be consumed by another tool:
+
+```bash
+python3 scripts/check_ui_slop.py \
+  --path src/components/Checkout.tsx \
+  --format json \
+  --fail-on warning
+```
+
+The checker reads supported source files only (`.html`, `.jsx`, `.tsx`, `.vue`,
+`.css`, and `.scss`). It never edits files, installs dependencies, accesses
+the network, or reads credentials. A non-zero exit code means the selected
+failure threshold was met; it is not proof that the UI is bad.
+
+## Work the findings
+
+1. Read the product brief, existing tokens, components, and the user's actual
+   job before changing a finding.
+2. Treat generic copy as a prompt to name the real user, task, object, and
+   consequence. Do not replace it with another slogan-shaped placeholder.
+3. For every interactive surface, account for the states that matter:
+   loading, empty, error, success, disabled, permission, and responsive
+   states. Do not invent states that the product does not have.
+4. Make controls visibly and programmatically connected to their action. A
+   warning about a button can be legitimate when behavior is delegated or
+   added elsewhere; inspect the surrounding code before changing it.
+5. Use the product's existing design tokens. Raw colors can be intentional,
+   but repeated one-off values are a reason to check for token drift.
+6. Render the result once on the relevant desktop and mobile surfaces, then
+   fix objective breakage and run the checker again.
+
+## Finish gate
+
+Before handoff, report:
+
+- what the user is trying to accomplish;
+- which findings were fixed, accepted, or false positives, with reasons;
+- which required interaction states were verified;
+- whether the rendered result was inspected at the relevant breakpoints;
+- any remaining risk that needs product or user input.
+
+The full [UIZZE project](https://github.com/uizze/uizze) adds the portable
+anti-ui-slop workflow, a GitHub Action, a deterministic MCP preview, and
+optional live research across 800,000+ real web and iOS screens. Use the
+canonical project when live evidence or deeper rendered review materially
+helps; this example remains useful offline on its own.
+
+## Files
+
+- `scripts/check_ui_slop.py` — deterministic local source checker
+- `README.md` — installation, examples, and limitations

--- a/agent_skills/anti-ui-slop/scripts/check_ui_slop.py
+++ b/agent_skills/anti-ui-slop/scripts/check_ui_slop.py
@@ -1,0 +1,173 @@
+#!/usr/bin/env python3
+"""Deterministic, local-first source checks for common UI quality risks.
+
+This is a triage tool, not a design judge. It reads supported frontend source
+files and emits stable findings that an agent or developer can review.
+"""
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+
+SUPPORTED = {".css", ".html", ".jsx", ".scss", ".tsx", ".vue"}
+GENERIC_COPY = re.compile(
+    r"\b(?:click here|lorem ipsum|welcome to our platform|learn more|"
+    r"your journey starts here|unlock your potential|seamless experience)\b",
+    re.IGNORECASE,
+)
+BUTTON = re.compile(r"<button\b[^>]*>(.*?)</button\s*>", re.IGNORECASE | re.DOTALL)
+IMAGE = re.compile(r"<img\b([^>]*)>", re.IGNORECASE | re.DOTALL)
+FORM = re.compile(r"<form\b[^>]*>|\b(?:input|textarea|select)\b", re.IGNORECASE)
+STATE_WORDS = re.compile(
+    r"\b(?:error|invalid|success|successful|loading|disabled|empty|permission|"
+    r"unauthorized|retry|try again)\b",
+    re.IGNORECASE,
+)
+RAW_COLOR = re.compile(r"(?<![\w-])#[0-9a-fA-F]{3,8}\b")
+ACTION_HOOK = re.compile(
+    r"\b(?:onClick|onSubmit|onChange|data-action|aria-controls|form=|"
+    r"type\s*=\s*['\"]submit['\"]|href\s*=)\b",
+    re.IGNORECASE,
+)
+
+
+def line_number(text, offset):
+    return text.count("\n", 0, offset) + 1
+
+
+def finding(rule, severity, path, line, message):
+    return {
+        "rule": rule,
+        "severity": severity,
+        "file": str(path),
+        "line": line,
+        "message": message,
+    }
+
+
+def source_files(paths):
+    for raw in paths:
+        path = Path(raw)
+        if path.is_file() and path.suffix.lower() in SUPPORTED:
+            yield path
+        elif path.is_dir():
+            for child in sorted(path.rglob("*")):
+                if child.is_file() and child.suffix.lower() in SUPPORTED:
+                    yield child
+
+
+def scan(path):
+    try:
+        text = path.read_text(encoding="utf-8", errors="replace")
+    except OSError as exc:
+        return [finding("read-error", "error", path, 1, str(exc))]
+
+    findings = []
+    for match in GENERIC_COPY.finditer(text):
+        value = match.group(0)
+        findings.append(
+            finding(
+                "generic-copy",
+                "warning",
+                path,
+                line_number(text, match.start()),
+                "placeholder copy: %r" % value,
+            )
+        )
+
+    for match in BUTTON.finditer(text):
+        opening_end = text.find(">", match.start())
+        opening = text[match.start() : opening_end + 1] if opening_end >= 0 else ""
+        content = match.group(1).strip()
+        if not ACTION_HOOK.search(opening) and not ACTION_HOOK.search(content):
+            findings.append(
+                finding(
+                    "inert-control",
+                    "warning",
+                    path,
+                    line_number(text, match.start()),
+                    "button has no visible source-level action hook",
+                )
+            )
+
+    for match in IMAGE.finditer(text):
+        attrs = match.group(1)
+        if not re.search(r"\balt\s*=", attrs, re.IGNORECASE):
+            findings.append(
+                finding(
+                    "image-alt",
+                    "error",
+                    path,
+                    line_number(text, match.start()),
+                    "image is missing alt text",
+                )
+            )
+
+    if FORM.search(text) and not STATE_WORDS.search(text):
+        findings.append(
+            finding(
+                "missing-state",
+                "warning",
+                path,
+                1,
+                "form or field has no visible loading, empty, error, success, or disabled state",
+            )
+        )
+
+    if path.suffix.lower() in {".css", ".scss"}:
+        colors = {}
+        for match in RAW_COLOR.finditer(text):
+            colors[match.group(0).lower()] = colors.get(match.group(0).lower(), 0) + 1
+        for color, count in sorted(colors.items()):
+            if count >= 2:
+                findings.append(
+                    finding(
+                        "token-drift",
+                        "warning",
+                        path,
+                        line_number(text, text.lower().find(color)),
+                        "raw color %s appears %d times; check for a shared design token" % (color, count),
+                    )
+                )
+
+    return findings
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--path", action="append", required=True, help="File or directory to scan; repeatable")
+    parser.add_argument("--format", choices=("text", "json"), default="text")
+    parser.add_argument("--fail-on", choices=("error", "warning", "never"), default="error")
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
+    files = list(source_files(args.path))
+    findings = []
+    for path in files:
+        findings.extend(scan(path))
+
+    if args.format == "json":
+        print(json.dumps({"files": len(files), "findings": findings}, indent=2, sort_keys=True))
+    else:
+        for item in findings:
+            print(
+                "%s %s %s:%d — %s"
+                % (item["severity"].upper(), item["rule"], item["file"], item["line"], item["message"])
+            )
+        errors = sum(item["severity"] == "error" for item in findings)
+        warnings = sum(item["severity"] == "warning" for item in findings)
+        print("\n%d finding(s): %d error(s), %d warning(s)" % (len(findings), errors, warnings))
+
+    if args.fail_on == "never":
+        return 0
+    threshold = {"error": {"error"}, "warning": {"error", "warning"}}[args.fail_on]
+    return 1 if any(item["severity"] in threshold for item in findings) else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/agent_skills/evals/anti-ui-slop/test_anti_ui_slop.py
+++ b/agent_skills/evals/anti-ui-slop/test_anti_ui_slop.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+"""Executable eval for the local anti-ui-slop source checker."""
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = ROOT / "anti-ui-slop" / "scripts" / "check_ui_slop.py"
+checks = []
+
+
+def check(name, ok, detail=""):
+    checks.append(ok)
+    suffix = " — %s" % detail if detail and not ok else ""
+    print("  %s %s%s" % ("PASS" if ok else "FAIL", name, suffix))
+
+
+def run(*args):
+    return subprocess.run(
+        [sys.executable, str(SCRIPT), *args],
+        capture_output=True,
+        text=True,
+    )
+
+
+def main():
+    with tempfile.TemporaryDirectory(prefix="anti-ui-slop-eval-") as root:
+        root = Path(root)
+        bad = root / "Bad.tsx"
+        bad.write_text(
+            '<h1>Welcome to our platform</h1>\n'
+            '<button>Click here</button>\n'
+            '<img src="hero.png">\n'
+            '<form><input /></form>\n',
+            encoding="utf-8",
+        )
+        css = root / "styles.css"
+        css.write_text(".a { color: #123456; }\n.b { color: #123456; }\n", encoding="utf-8")
+
+        result = run("--path", str(root), "--format", "json", "--fail-on", "warning")
+        payload = json.loads(result.stdout)
+        rules = {item["rule"] for item in payload["findings"]}
+        check("bad fixture fails warning threshold", result.returncode == 1)
+        check(
+            "all deterministic rules fire",
+            {"generic-copy", "inert-control", "image-alt", "missing-state", "token-drift"}.issubset(rules),
+            sorted(rules),
+        )
+
+        good = root / "Good.tsx"
+        good.write_text(
+            '<button onClick={save}>Save</button>\n'
+            '<img src="hero.png" alt="Product preview">\n'
+            '<p>Loading…</p>\n',
+            encoding="utf-8",
+        )
+        clean = run("--path", str(good), "--format", "json")
+        check("good fixture passes", clean.returncode == 0)
+        check("good fixture has no findings", json.loads(clean.stdout)["findings"] == [])
+
+    print()
+    passed = sum(checks)
+    print("PASS — %d/%d checks" % (passed, len(checks)) if passed == len(checks) else "FAIL — %d/%d checks passed" % (passed, len(checks)))
+    return 0 if passed == len(checks) else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/agent_skills/evals/anti-ui-slop/trigger-cases.json
+++ b/agent_skills/evals/anti-ui-slop/trigger-cases.json
@@ -1,0 +1,42 @@
+{
+  "skill": "anti-ui-slop",
+  "purpose": "Trigger-behavior spec for deterministic UI quality routing.",
+  "cases": [
+    {
+      "id": "audit-ui-quality",
+      "prompt": "audit my frontend for UI quality problems",
+      "should_trigger": true,
+      "assert": "Runs the local checker and produces a finish-gate report."
+    },
+    {
+      "id": "stop-ui-slop",
+      "prompt": "stop the generic UI slop before we ship",
+      "should_trigger": true,
+      "assert": "Checks concrete source signals and required interaction states."
+    },
+    {
+      "id": "review-frontend-diff",
+      "prompt": "review this frontend diff for inert controls and missing states",
+      "should_trigger": true,
+      "assert": "Scans the selected frontend files and explains each finding."
+    },
+    {
+      "id": "near-miss-format",
+      "prompt": "format my code",
+      "should_trigger": false,
+      "assert": "Does not trigger for routine formatting alone."
+    },
+    {
+      "id": "near-miss-deploy",
+      "prompt": "deploy the application",
+      "should_trigger": false,
+      "assert": "Does not trigger for deployment alone."
+    },
+    {
+      "id": "near-miss-api",
+      "prompt": "add an API endpoint",
+      "should_trigger": false,
+      "assert": "Does not trigger for backend work without a UI quality request."
+    }
+  ]
+}


### PR DESCRIPTION
## What this adds

Adds a self-contained, runnable UIZZE anti-ui-slop Skill under `agent_skills/anti-ui-slop/`, following the invitation in #1104 to contribute code that lives in its own folder.

- stdlib-only `scripts/check_ui_slop.py` for deterministic local checks
- generic placeholder copy, inert controls, missing image alt text, missing state vocabulary, and repeated raw CSS colors
- text and JSON output with configurable failure thresholds
- README with install/run examples and clear heuristic limitations
- fixture-based deterministic eval plus trigger cases
- one root README entry

The local example works offline and does not edit projects, access credentials, or call a network. It keeps full UIZZE research and the canonical source separate: https://github.com/uizze/uizze

## Verification

- `python3 agent_skills/evals/anti-ui-slop/test_anti_ui_slop.py` — 4/4
- strict skill lint — 0 errors, 0 warnings
- security scan — 0 findings
- trigger and routing eval — all clear
- `git diff --check` and `py_compile` pass