### PR TITLE
fix(financial-coach): use raw regex strings and normalize gallery link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Works with Claude, Gemini, GPT, DeepSeek, Llama, Qwen and other open-source mode
       <sub><b>Self-Improving Agent Skills</b></sub>
     </td>
     <td align="center">
-      <a href="advanced_ai_agents/multi_agent_apps/ai_home_renovation_agent"><img src="docs/gallery/ai-home-renovation.png" alt="AI Home Renovation Agent: photo in, photoreal redesign out"></a>
+      <a href="advanced_ai_agents/multi_agent_apps/ai_home_renovation_agent/"><img src="docs/gallery/ai-home-renovation.png" alt="AI Home Renovation Agent: photo in, photoreal redesign out"></a>
       <sub><b>AI Home Renovation Agent</b></sub>
     </td>
     <td align="center">

--- a/advanced_ai_agents/multi_agent_apps/ai_financial_coach_agent/ai_financial_coach_agent.py
+++ b/advanced_ai_agents/multi_agent_apps/ai_financial_coach_agent/ai_financial_coach_agent.py
@@ -530,7 +530,7 @@ def parse_csv_transactions(file_content) -> List[Dict[str, Any]]:
         df['Date'] = pd.to_datetime(df['Date']).dt.strftime('%Y-%m-%d')
         
         # Convert amount strings to float, handling currency symbols and commas
-        df['Amount'] = df['Amount'].replace('[\$,]', '', regex=True).astype(float)
+        df['Amount'] = df['Amount'].replace(r'[\$,]', '', regex=True).astype(float)
         
         # Group by category and calculate totals
         category_totals = df.groupby('Category')['Amount'].sum().reset_index()
@@ -571,7 +571,7 @@ def validate_csv_format(file) -> bool:
             
         # Validate amount format (should be numeric after removing currency symbols)
         try:
-            df['Amount'].replace('[\$,]', '', regex=True).astype(float)
+            df['Amount'].replace(r'[\$,]', '', regex=True).astype(float)
         except:
             return False, "Invalid amount format in Amount column"
             


### PR DESCRIPTION
## Summary

- Fixed Python 3.12+ `SyntaxWarning: "\$" is an invalid escape sequence` in `ai_financial_coach_agent.py` by converting currency matching regex literals into raw strings (`r"[\$,]"`).
- Normalized the gallery link for `ai_home_renovation_agent` in `README.md` with a trailing slash to match sibling gallery items.