### PR TITLE
Add PM Skills to Agent Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ streamlit run travel_agent.py
 *   [🩺 Dependency Doctor](agent_skills/dependency-doctor/) - Checks a dependency manifest for standard-library pins, obsolete backports, unpinned entries, duplicate constraints, and yanked releases
 *   [🧠 Advisor Orchestrator Worker](agent_skills/advisor-orchestrator-worker/) - Meta Loop with Claude Fable 5 as advisor, GPT-5.6 as orchestrator, and Gemini 3.7 Flash as worker
 *   [♾️ Self-Improving Agent Skills](agent_skills/self-improving-agent-skills/) - Automatically optimize agent skills using Gemini and ADK
+*   [📋 PM Skills](https://github.com/mohitagw15856/pm-claude-skills) <sub>↗ external</sub> - Library of 1,153 plain-markdown agent skills across 35 professions, from PRDs and postmortems to RICE prioritisation and negotiation prep
 
 ### 🌱 Starter AI Agents
 


### PR DESCRIPTION
Adds **PM Skills** to the 🧩 Agent Skills section as an external entry, matching the `<sub>↗ external</sub>` convention already used in Advanced AI Agents and Voice AI Agents.

**What it is:** an MIT-licensed library of 1,153 agent skills as plain-markdown `SKILL.md` files, spanning 35 professions — PRDs, incident postmortems, RICE prioritisation, code review checklists, RFCs, QBR decks, and a large life-admin set.

It fits the section's stated bar:
- **One command to install** — `npx pm-claude-skills add`, with generated exports for Claude Code, Cursor, Windsurf, Zed, Codex and 8 more
- **Plain English to use** — each skill declares its trigger phrases and required inputs
- **Real code** — 53 stdlib-only Python helpers do the computation for the calculator skills (RICE, runway Monte Carlo, cohort curves), each with contract tests on Python 3.9/3.11/3.13
- **Security + CI gate** — every skill passes a structural spec check at L3 and a security scan on each PR

Also runs free in a browser playground and ships an MCP server.

Happy to shorten the line if it runs long for the section's style.
