### PR TITLE
Add MiniMax H3 1K prompt dataset to LLM Applications

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,7 @@ streamlit run travel_agent.py
 *   [🎧 AI Social Media News and Podcast Agent](advanced_ai_agents/multi_agent_apps/ai_news_and_podcast_agents/) - Curates your trusted sources into briefs and generated podcasts
 *   [🌐 Openwork - Open Browser Automation Agent](https://github.com/accomplish-ai/openwork) <sub>↗ external</sub> - Open-source agent that operates a real browser
 *   [🛡️ Trust-Gated Multi-Agent Research Team](advanced_ai_agents/multi_agent_apps/trust_gated_agent_team/) - Every agent verified, every action in a hash-chained audit trail
+*   [🎬 MiniMax H3 1K prompt dataset](https://neta.art/use-cases/en/h3-1000-prompt-list) <sub>↗ external</sub> - Curated 1K text-to-video prompts: 3-field structure anatomy, 10 reusable prompts, H3 vs. peer comparison.
 
 ### 🛰️ Always-on Agents
 


### PR DESCRIPTION
Alongside the prompt tooling already listed here (promptfoo, Langfuse, Promptify, ...), this curated 1K text-to-video prompt dataset is a prompt-resource companion: 3-field prompt-structure anatomy, 10 hand-picked reusable prompts, and an H3 vs. peer model comparison.\n\nLinks:\n- Interactive atlas of all 1,000 H3 clips: https://neta.art/use-cases/en/h3-1000-prompt-list\n- Curated index repo: https://github.com/yangzhou-chaofan/minimax-h3-1000-prompts\n- Original dataset (ostris/minimax_h3_1k): https://huggingface.co/datasets/ostris/minimax_h3_1k