### PR TITLE
Add Quill: open-source macOS system-wide voice typing

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,7 @@ streamlit run travel_agent.py
 *   [🛡️ Insurance Claim Live Agent Team](voice_ai_agents/insurance_claim_live_agent_team/) - Real-time voice claim intake with Gemini Live
 *   [🔊 Voice RAG Agent (OpenAI SDK)](voice_ai_agents/voice_rag_openaisdk/) - Ask your PDFs questions, hear the answers
 *   [🎙️ OpenSource Voice Dictation Agent (Wispr Flow clone)](https://github.com/akshayaggarwal99/jarvis-ai-assistant) <sub>↗ external</sub> - Open-source dictation that types where you talk
+*   [🪶 Quill (macOS system-wide voice typing)](https://github.com/skundu42/quill) <sub>↗ external</sub> - Native macOS dictation that inserts cleaned-up text at your cursor, using your own Gemini API key
 
 ### 🖼️ Generative UI and Agentic Frontends
 


### PR DESCRIPTION
Adding Quill to the Voice AI Agents list as an external entry, alongside the existing dictation/Wispr-Flow-clone entry.

Quill is a native macOS voice-typing app (macOS 14+, Apache 2.0). Hold a shortcut in any text field, speak, and cleaned-up text appears at your cursor. It uses your own Gemini API key, stores no recordings or transcript history, and has no backend.

Self-submission. Happy to adjust wording or placement if preferred.

- Repo: https://github.com/skundu42/quill
- Site: https://quillvoice.xyz