### PR TITLE
docs: add SandBase CLI MCP agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,6 +224,7 @@ streamlit run travel_agent.py
 *   [🌍 AI Travel Planner MCP Agent](mcp_ai_agents/ai_travel_planner_mcp_agent_team) - Itineraries built on live Airbnb and Google Maps data
 *   [🔀 Multi-MCP Agent Router](mcp_ai_agents/multi_mcp_agent_router/) - Specialist agents, each wired to its own MCP server
 *   [🔌 OpenAI Remote MCP Tool Bridge](mcp_ai_agents/openai_remote_mcp_bridge/) - Connect OpenAI function calling directly to a remote MCP server
+*   [🧰 SandBase CLI](https://github.com/sandbaseai/cli) <sub>↗ external</sub> - Agent-first CLI and local MCP bridge that connects 25 AI clients to 2,000+ models and APIs through one onboarding command
 
 ### 📀 RAG (Retrieval Augmented Generation)
 


### PR DESCRIPTION
Adds SandBase CLI to the MCP AI Agents section as an external project.

- Single README-only entry
- Canonical repository link
- Describes the CLI/MCP bridge and published client/model coverage
- No code or dependency changes