### PR TITLE
Fix renamed/transferred repo URLs across template docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ streamlit run travel_agent.py
 *   [🧬 AI Self-Evolving Agent](advanced_ai_agents/multi_agent_apps/ai_self_evolving_agent/) - Agents that rewrite their own workflows with EvoAgentX
 *   [👨🏻‍💼 AI Sales Intelligence Agent Team](advanced_ai_agents/multi_agent_apps/agent_teams/ai_sales_intelligence_agent_team) - Generates competitive sales battle cards in real time
 *   [🎧 AI Social Media News and Podcast Agent](advanced_ai_agents/multi_agent_apps/ai_news_and_podcast_agents/) - Curates your trusted sources into briefs and generated podcasts
-*   [🌐 Openwork - Open Browser Automation Agent](https://github.com/accomplish-ai/openwork) <sub>↗ external</sub> - Open-source agent that operates a real browser
+*   [🌐 Openwork - Open Browser Automation Agent](https://github.com/accomplish-ai/coworker) <sub>↗ external</sub> - Open-source agent that operates a real browser
 *   [🛡️ Trust-Gated Multi-Agent Research Team](advanced_ai_agents/multi_agent_apps/trust_gated_agent_team/) - Every agent verified, every action in a hash-chained audit trail
 
 ### 🛰️ Always-on Agents

--- a/advanced_ai_agents/multi_agent_apps/ai_self_evolving_agent/README.md
+++ b/advanced_ai_agents/multi_agent_apps/ai_self_evolving_agent/README.md
@@ -1,6 +1,6 @@
 # 🧬 Self-Evolving AI Agent
 
-A multi-agent app built on [EvoAgentX](https://github.com/EvoAgentX/EvoAgentX) that turns a
+A multi-agent app built on [EvoAgentX](https://github.com/ANative-Lab/EvoAgentX) that turns a
 single natural-language goal into a working program. It **automatically generates a
 multi-agent workflow**, executes it to produce code, then **verifies and repairs** that code
 with a second model — no manual agent wiring required.
@@ -26,7 +26,7 @@ in the browser"* and writes a ready-to-play `index.html`.
 2. **Install dependencies**
    ```bash
    pip install -r requirements.txt
-   pip install git+https://github.com/EvoAgentX/EvoAgentX.git
+   pip install git+https://github.com/ANative-Lab/EvoAgentX.git
    ```
 
 3. **Set your API keys**
@@ -54,4 +54,4 @@ in the browser"* and writes a ready-to-play `index.html`.
 
 This example is powered by the open-source **EvoAgentX** framework. For docs, tutorials, and
 additional optimizers (TextGrad, AFlow, MIPRO), see the
-[EvoAgentX repository](https://github.com/EvoAgentX/EvoAgentX).
+[EvoAgentX repository](https://github.com/ANative-Lab/EvoAgentX).

--- a/advanced_ai_agents/multi_agent_apps/multi_agent_trust_layer/README.md
+++ b/advanced_ai_agents/multi_agent_apps/multi_agent_trust_layer/README.md
@@ -226,5 +226,5 @@ policies:
 ## Related Projects
 
 - [LangGraph](https://github.com/langchain-ai/langgraph) - Multi-agent orchestration
-- [CrewAI](https://github.com/joaomdmoura/crewAI) - Multi-agent framework
+- [CrewAI](https://github.com/crewAIInc/crewAI) - Multi-agent framework
 - [AutoGen](https://github.com/microsoft/autogen) - Multi-agent conversations

--- a/advanced_llm_apps/llm_optimization_tools/headroom_context_optimization/README.md
+++ b/advanced_llm_apps/llm_optimization_tools/headroom_context_optimization/README.md
@@ -4,7 +4,7 @@ Reduce LLM API costs by 50-90% through intelligent context compression. Tool out
 
 ## 📋 Overview
 
-This app demonstrates how to use [Headroom](https://github.com/chopratejas/headroom) to dramatically reduce token usage when working with AI agents and tool-heavy LLM applications. Unlike simple truncation, Headroom uses statistical analysis to keep what matters and compress what doesn't.
+This app demonstrates how to use [Headroom](https://github.com/headroomlabs-ai/headroom) to dramatically reduce token usage when working with AI agents and tool-heavy LLM applications. Unlike simple truncation, Headroom uses statistical analysis to keep what matters and compress what doesn't.
 
 ### Key Benefits
 
@@ -142,10 +142,10 @@ python headroom_demo.py
 
 ## 🔗 Resources
 
-- **GitHub**: https://github.com/chopratejas/headroom
+- **GitHub**: https://github.com/headroomlabs-ai/headroom
 - **PyPI**: https://pypi.org/project/headroom-ai/
-- **Documentation**: https://github.com/chopratejas/headroom/tree/main/docs
-- **Demo Video**: https://github.com/chopratejas/headroom/releases
+- **Documentation**: https://github.com/headroomlabs-ai/headroom/tree/main/docs
+- **Demo Video**: https://github.com/headroomlabs-ai/headroom/releases
 
 ## 🔌 Provider Support
 
@@ -167,7 +167,7 @@ Contributions are welcome! Feel free to:
 
 ## 📄 License
 
-Apache License 2.0 - see [LICENSE](https://github.com/chopratejas/headroom/blob/main/LICENSE).
+Apache License 2.0 - see [LICENSE](https://github.com/headroomlabs-ai/headroom/blob/main/LICENSE).
 
 ## 🙏 Credits
 

--- a/ai_agent_framework_crash_course/google_adk_crash_course/4_tool_using_agent/4_4_mcp_tools/firecrawl_agent/README.md
+++ b/ai_agent_framework_crash_course/google_adk_crash_course/4_tool_using_agent/4_4_mcp_tools/firecrawl_agent/README.md
@@ -263,7 +263,7 @@ adk web --debug
 ## 📚 Additional Resources
 
 - **[Firecrawl Documentation](https://docs.firecrawl.dev)** - Complete API reference
-- **[Firecrawl MCP Server](https://github.com/mendableai/firecrawl-mcp-server)** - Source code and examples
+- **[Firecrawl MCP Server](https://github.com/firecrawl/firecrawl-mcp-server)** - Source code and examples
 - **[MCP Specification](https://modelcontextprotocol.io/docs/spec)** - Protocol details
 - **[ADK MCP Documentation](https://google.github.io/adk-docs/tools/mcp-tools/)** - Integration guide
 


### PR DESCRIPTION
## Summary

Updates 5 repositories whose URLs moved (renamed/transferred), referenced across the README and template docs.

| Old | New |
| --- | --- |
| `accomplish-ai/openwork` | `accomplish-ai/coworker` |
| `chopratejas/headroom` | `headroomlabs-ai/headroom` |
| `EvoAgentX/EvoAgentX` | `ANative-Lab/EvoAgentX` |
| `joaomdmoura/crewAI` | `crewAIInc/crewAI` |
| `mendableai/firecrawl-mcp-server` | `firecrawl/firecrawl-mcp-server` |

Each new location confirmed as the canonical `nameWithOwner` via the GitHub API. Pure URL swaps; no prose content changed.