### PR TITLE
Add ViBo-memory (persistent agent memory)

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ streamlit run travel_agent.py
 *   [🧠 Advisor Orchestrator Worker](agent_skills/advisor-orchestrator-worker/) - Meta Loop with Claude Fable 5 as advisor, GPT-5.6 as orchestrator, and Gemini 3.5 Flash as worker
 *   [♾️ Self-Improving Agent Skills](agent_skills/self-improving-agent-skills/) - Automatically optimize agent skills using Gemini and ADK
 
+- [ViBo-memory](https://github.com/vnbochkarev-netizen/ViBo-memory) - Persistent memory for AI agents: semantic search, L1/L2/L3 encryption, 50-150x token savings on context
 ### 🌱 Starter AI Agents
 
 *Single-file agents that run with just an API key - a great place to start.*

--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ Works with Claude, Gemini, GPT, DeepSeek, Llama, Qwen and other open-source mode
   </tr>
 </table>
 
+- [ViBo — encrypted memory for AI agents (97.5% fewer tokens)](https://github.com/vnbochkarev-netizen/ViBo-memory) — persistent memory L1/L2/L3, web search savings 99.6%, thread memory. $5/mo, free trial.
+
 ## 🚀 Run one now
 
 Give your coding agent a new skill in 10 seconds:


### PR DESCRIPTION
Adds [ViBo-memory](https://github.com/vnbochkarev-netizen/ViBo-memory) - persistent memory for AI agents (semantic search, L1/L2/L3 encryption, 50-150x token savings). CI: SkillQA grade A on every PR.