### PR TITLE
Bump ai-deep-research-agent Docker base to node:22-slim (LTS)

### DIFF
--- a/generative_ui_agents/ai-deep-research-agent/Dockerfile
+++ b/generative_ui_agents/ai-deep-research-agent/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20-slim
+FROM node:22-slim
 
 WORKDIR /app
 


### PR DESCRIPTION
## What

Updates the base image in `generative_ui_agents/ai-deep-research-agent/Dockerfile` from `node:20-slim` to `node:22-slim`.

## Why

`node:20-slim` reached end-of-life on 2026-04-30, so that Node.js line no longer receives security releases. The Dockerfile is single-stage, so this base is what actually ships. Because this is a runnable example people clone and copy, the stale base propagates into whatever readers build from it, with no alert (Dependabot's `docker` ecosystem does version updates, not security updates).

`node:22-slim` is a currently supported LTS line, which puts the example back on a maintained runtime. Only the base tag changed; the build and run steps are untouched.

Fixes #1046

Reported by @kobihikri with a detailed writeup on the EOL status and the CVEs patched only into supported lines. Thanks for the flag.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HT3minN5GthswtfERhFme5)_