### PR TITLE
Pin ai_x402_paying_agent dependency versions (follow-up to #1106)

### DIFF
--- a/starter_ai_agents/ai_x402_paying_agent/requirements.txt
+++ b/starter_ai_agents/ai_x402_paying_agent/requirements.txt
@@ -1,6 +1,6 @@
-anthropic
-x402[evm,httpx,fastapi]
-eth-account
-httpx
-fastapi
-uvicorn
+anthropic==1.2.0
+x402[evm,httpx,fastapi]==2.21.0
+eth-account==0.14.0
+httpx==0.28.1
+fastapi==0.141.1
+uvicorn==0.52.4


### PR DESCRIPTION
The non-blocking follow-up from #1106: all six dependencies in `starter_ai_agents/ai_x402_paying_agent/requirements.txt` are now pinned, x402 included, so the tutorial stays reproducible as the SDK evolves.

Versions are today's current releases, and I verified they work together on Python 3.12: `seller.py` constructs its FastAPI app and `x402_paying_agent.py` imports cleanly on x402 2.21.0.

Thanks for the merge!

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019qZn6eQhuFv3EYefuY6Q92