### PR TITLE
chore(advisor-orchestrator-worker): Fable 5.1, GPT-6 Astra, Gemini 3.8 Flash

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ streamlit run travel_agent.py
 *   [🔭 Scope Creep Detector](agent_skills/scope-creep-detector/) - Checks whether a diff grew beyond its stated intent and recommends what to keep, split, or justify
 *   [🏺 Commit Archaeologist](agent_skills/commit-archaeologist/) - Reconstructs why a file or code region exists from its introducing commit, later edits, co-changes, and intent clues
 *   [🩺 Dependency Doctor](agent_skills/dependency-doctor/) - Checks a dependency manifest for standard-library pins, obsolete backports, unpinned entries, duplicate constraints, and yanked releases
-*   [🧠 Advisor Orchestrator Worker](agent_skills/advisor-orchestrator-worker/) - Meta Loop with Claude Fable 5 as advisor, GPT-5.6 as orchestrator, and Gemini 3.7 Flash as worker
+*   [🧠 Advisor Orchestrator Worker](agent_skills/advisor-orchestrator-worker/) - Meta Loop with Claude Fable 5.1 as advisor, GPT-6 Astra as orchestrator, and Gemini 3.8 Flash as worker
 *   [♾️ Self-Improving Agent Skills](agent_skills/self-improving-agent-skills/) - Automatically optimize agent skills using Gemini and ADK
 
 ### 🌱 Starter AI Agents

--- a/agent_skills/advisor-orchestrator-worker/README.md
+++ b/agent_skills/advisor-orchestrator-worker/README.md
@@ -10,9 +10,9 @@ This skill turns your coding agent into the orchestrator of a three-tier model t
 
 | Role | Default model <sub>(Aug 2026, swap freely)</sub> | What it does | What it never does |
 |---|---|---|---|
-| **Orchestrator** | GPT-5.6 | Frames success criteria, plans waves, dispatches briefs, verifies every result, synthesizes the deliverable | Worker-level grunt work |
-| **Workers** | Gemini 3.7 Flash | One self-contained subtask each, in parallel, stateless; each sees only its brief, with tool access when the subtask needs it | Talk to each other, expand scope, get a second chance on the same call |
-| **Advisor** | Claude Fable 5 | Plan review before any dispatch, taste pass before delivery, called mid-run only at commitment boundaries | Execute anything |
+| **Orchestrator** | GPT-6 Astra | Frames success criteria, plans waves, dispatches briefs, verifies every result, synthesizes the deliverable | Worker-level grunt work |
+| **Workers** | Gemini 3.8 Flash | One self-contained subtask each, in parallel, stateless; each sees only its brief, with tool access when the subtask needs it | Talk to each other, expand scope, get a second chance on the same call |
+| **Advisor** | Claude Fable 5.1 | Plan review before any dispatch, taste pass before delivery, called mid-run only at commitment boundaries | Execute anything |
 
 The economics are the point: cheap parallel generation where volume wins, expensive judgment only where it changes a decision. Every run states a budget up front, sized to the plan, and never spends past it silently: running out means an honest report or an explicit ask, not quiet burn. Models are knobs: the tier pattern is the durable part, the defaults were current in July 2026.
 
@@ -55,4 +55,4 @@ advisor-orchestrator-worker/
 
 Evals live repo-side in `agent_skills/evals/advisor-orchestrator-worker/`; you install only what runs.
 
-Part of [awesome-llm-apps](https://github.com/Shubhamsaboo/awesome-llm-apps) · Apache-2.0 · Last verified: July 2026
+Part of [awesome-llm-apps](https://github.com/Shubhamsaboo/awesome-llm-apps) · Apache-2.0 · Last verified: September 2026

--- a/agent_skills/advisor-orchestrator-worker/SKILL.md
+++ b/agent_skills/advisor-orchestrator-worker/SKILL.md
@@ -33,7 +33,7 @@ on another shell, run them with `bash -c`.
 
 ## The team
 
-- **Workers (default: Gemini 3.7 Flash via the Antigravity CLI, `agy`)**: stateless
+- **Workers (default: Gemini 3.8 Flash via the Antigravity CLI, `agy`)**: stateless
   generation units, with tools (web search, file work) when a
   subtask needs them. Never interpolate a brief into a shell string;
   briefs carry quotes and arbitrary text, so that is a shell-injection
@@ -45,7 +45,7 @@ on another shell, run them with `bash -c`.
   # $brief = this worker's brief file; $out = its result file (absolute path)
   d=$(mktemp -d)
   ( cd "$d" && env -i HOME="$HOME" PATH="$PATH" \
-      agy --dangerously-skip-permissions --model "gemini-3.7-flash" --effort high \
+      agy --dangerously-skip-permissions --model "gemini-3.8-flash" --effort high \
       --print-timeout 5m -p "$(cat "$brief")" \
       > "$out"; s=$?; rm -rf "$d"; exit "$s" ) &
   pids+=($!)
@@ -69,11 +69,11 @@ on another shell, run them with `bash -c`.
   subtask that needs tools goes through agy or gets ESCALATE. Clean up
   all temp files at run end.
 
-- **Advisor (default: Claude Fable 5 via the claude CLI)**: consult
+- **Advisor (default: Claude Fable 5.1 via the claude CLI)**: consult
   written to a temp file, passed on stdin (never inline in the
   command), behind a timeout so a hung consult can't stall the loop
   (perl's alarm; timeout(1) is missing on stock macOS):
-  `perl -e 'alarm shift; exec @ARGV' 300 claude --model claude-fable-5 -p < "$consult"`.
+  `perl -e 'alarm shift; exec @ARGV' 300 claude --model claude-fable-5-1 -p < "$consult"`.
   Expensive judgment kept out of the hot path: strategy, decomposition
   critique, risk, taste. Never execution. If the CLI is missing or a
   consult fails, use the Anthropic API fallback in

--- a/agent_skills/advisor-orchestrator-worker/references/fallbacks.md
+++ b/agent_skills/advisor-orchestrator-worker/references/fallbacks.md
@@ -18,7 +18,7 @@ api_key="${GEMINI_API_KEY:-$GOOGLE_API_KEY}"
 ( set -o pipefail
   jq -n --rawfile t "$brief" '{contents:[{parts:[{text:$t}]}]}' \
     | curl -sS --fail --max-time 300 \
-      "https://generativelanguage.googleapis.com/v1beta/models/gemini-3.7-flash:generateContent" \
+      "https://generativelanguage.googleapis.com/v1beta/models/gemini-3.8-flash:generateContent" \
       -H "x-goog-api-key: $api_key" -H "Content-Type: application/json" -d @- \
     | jq -r '.candidates[0].content.parts[0].text' > "$out" ) &
 pids+=($!)
@@ -27,14 +27,14 @@ pids+=($!)
 ## Advisor: bare Anthropic API call
 
 Same model as the CLI path. The `fallbacks` parameter re-serves a
-safety-classifier refusal on Opus 4.8 inside the same call, so one
+safety-classifier refusal on Opus 5 inside the same call, so one
 declined consult cannot stall the loop.
 
 ```bash
 [ -n "$ANTHROPIC_API_KEY" ] || { echo "no ANTHROPIC_API_KEY" >&2; exit 1; }
 ( set -o pipefail
-  jq -n --rawfile c "$consult" '{model: "claude-fable-5", max_tokens: 16000,
-      fallbacks: [{model: "claude-opus-4-8"}],
+  jq -n --rawfile c "$consult" '{model: "claude-fable-5-1", max_tokens: 16000,
+      fallbacks: [{model: "claude-opus-5"}],
       messages: [{role: "user", content: $c}]}' \
     | curl -sS --fail --max-time 300 "https://api.anthropic.com/v1/messages" \
       -H "x-api-key: $ANTHROPIC_API_KEY" -H "anthropic-version: 2023-06-01" \

--- a/agent_skills/evals/advisor-orchestrator-worker/evals.json
+++ b/agent_skills/evals/advisor-orchestrator-worker/evals.json
@@ -12,7 +12,7 @@
         "Every worker result gets a PASS/FIX/ESCALATE verdict against its own criteria",
         "The final report includes a verification ledger and advisor notes applied or rebutted",
         "Parallel worker outputs are collected from per-worker scratch files (mktemp + redirect, wait, read in dispatch order), never from a shared interleaved stdout",
-        "Workers dispatch via the agy CLI by default with --model pinned to gemini-3.5-flash (same model as the API fallback), waves chunked into batches of at most 3 with a wait between batches",
+        "Workers dispatch via the agy CLI by default with --model pinned to gemini-3.8-flash (same model as the API fallback), waves chunked into batches of at most 3 with a wait between batches",
         "Briefs and consults are written to temp files (handed to agy as a quoted expansion, jq-built payloads on the API fallback, consults passed on stdin); never interpolated inline into shell strings",
         "The Gemini API fallback fails fast if neither GEMINI_API_KEY nor GOOGLE_API_KEY is set (no silent empty-key call)",
         "Each backgrounded worker runs in its own subshell so parallel cd/cleanup and traps never collide",


### PR DESCRIPTION
## Summary

Refreshes the three model tiers in the advisor-orchestrator-worker skill and the catalog line that indexes it.

| Tier | Before | After |
|---|---|---|
| Advisor | Claude Fable 5 (`claude-fable-5`), refusal fallback Opus 4.8 | Claude Fable 5.1 (`claude-fable-5-1`), refusal fallback Opus 5 (`claude-opus-5`) |
| Orchestrator | GPT-5.6 | GPT-6 Astra |
| Workers | Gemini 3.7 Flash (`gemini-3.7-flash`) | Gemini 3.8 Flash (`gemini-3.8-flash`) |

## Files

- `agent_skills/advisor-orchestrator-worker/SKILL.md`: worker and advisor defaults and ids
- `agent_skills/advisor-orchestrator-worker/references/fallbacks.md`: Gemini API URL, Anthropic API model and fallback
- `agent_skills/advisor-orchestrator-worker/README.md`: role table, verified date, and a new cover diagram (`advisor_skill.jpeg`) showing the three current models
- `agent_skills/evals/advisor-orchestrator-worker/evals.json`: expectation corrected from the stale `gemini-3.5-flash` pin
- `README.md`: the Agent Skills catalog line

## Verification

Every id in the change was exercised live from the CLI on a Mac before commit:

- `agy --model gemini-3.8-flash --effort high --print …` returns OK; Antigravity rejects a made-up id, so the pin is enforced
- `claude --model claude-fable-5-1 -p …` returns OK, in both the inline and the stdin consult form the skill uses; `claude --model claude-opus-5` returns OK
- `codex exec -m gpt-6-astra …` returns OK on Codex 0.154.0 (0.144.3 rejects the model as too old, so the CLI needs to be current)

Skill lint (strict), the security scanner, and trigger and routing evals all pass.

## Not in this PR

- Other projects in the repo that pin older ids in their own code are unrelated to this skill and untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

